### PR TITLE
feat: password protected pdfs

### DIFF
--- a/packages/vue/playground/App.vue
+++ b/packages/vue/playground/App.vue
@@ -8,18 +8,20 @@ import Invitation from "./samples/Invitation.vue";
 import Showcase from "./samples/Showcase.vue";
 import Report from "./samples/Report.vue";
 import Transparency from "./samples/Transparency.vue";
+import Encrypted from "./samples/Encrypted.vue";
 import fontUrl from "./assets/GreatVibes-Regular.ttf?url";
 import imgUrl from "./assets/photo.jpg?url";
 import logoUrl from "./assets/logo.png?url";
 
 type AssetKey = "font" | "image" | "logo";
-const samples: { label: string; comp: any; assets?: AssetKey[] }[] = [
+const samples: { label: string; comp: any; assets?: AssetKey[]; encrypt?: boolean }[] = [
   { label: "Hello world", comp: Hello },
   { label: "Invoice", comp: Invoice },
   { label: "Report", comp: Report },
   { label: "Invitation", comp: Invitation },
   { label: "Showcase", comp: Showcase, assets: ["font", "image"] },
   { label: "Transparency", comp: Transparency, assets: ["logo"] },
+  { label: "Encrypted", comp: Encrypted, encrypt: true },
 ];
 
 // Each sample gets ONLY the keys it declares (above), never the whole cache - a stray asset would fall
@@ -43,6 +45,9 @@ const currentIndex = ref(Number(sessionStorage.getItem(STORAGE)) || 0);
 const pdfUrl = ref<string>();
 const error = ref<string>();
 const building = ref(false);
+// The password for the "Encrypted" sample - editable, so you can watch it gate the PDF.
+const password = ref("secret");
+const isEncrypted = computed(() => !!samples[currentIndex.value].encrypt);
 const downloadName = computed(
   () => samples[currentIndex.value].label.toLowerCase().replace(/\s+/g, "-") + ".pdf",
 );
@@ -58,8 +63,11 @@ async function render() {
       const cache = await loadAssets();
       props = Object.fromEntries(sample.assets.map((k) => [k, cache[k]]));
     }
-    const bytes = await renderToPdf(sample.comp, props);
-    // vue-pdf-embed paints the PDF onto a <canvas>, so it always shows inline and never downloads.
+    // The third arg is plain RenderOptions - `encrypt` flows straight through to the engine.
+    const options = sample.encrypt ? { encrypt: { userPassword: password.value || "secret" } } : undefined;
+    const bytes = await renderToPdf(sample.comp, props, options);
+    // vue-pdf-embed paints the PDF onto a <canvas>; an encrypted PDF can't show without the password,
+    // so for those we skip the preview and offer the download + the password instead (see the template).
     pdfUrl.value = URL.createObjectURL(new Blob([bytes], { type: "application/pdf" }));
   } catch (e: any) {
     error.value = String(e?.message ?? e);
@@ -91,11 +99,22 @@ onMounted(render);
           {{ s.label }}
         </button>
       </nav>
+      <label v-if="isEncrypted" class="pw">
+        password
+        <input v-model="password" @change="render" spellcheck="false" />
+      </label>
       <a v-if="pdfUrl" class="download" :href="pdfUrl" :download="downloadName">↓ Download</a>
       <span class="hint">{{ building ? "rendering…" : "100% in your browser · no server" }}</span>
     </header>
     <main>
       <pre v-if="error" class="error">{{ error }}</pre>
+      <div v-else-if="isEncrypted && pdfUrl" class="locked">
+        <div class="lock">🔒</div>
+        <h2>This PDF is encrypted (AES-256)</h2>
+        <p>The inline viewer can't open it without the password - that's the point.</p>
+        <p>Hit <strong>↓ Download</strong> (top right); your PDF viewer will ask for:</p>
+        <code>{{ password || "secret" }}</code>
+      </div>
       <div v-else class="viewer">
         <VuePdfEmbed v-if="pdfUrl" :key="pdfUrl" :source="pdfUrl" class="page" />
       </div>
@@ -170,6 +189,55 @@ nav button.active {
 .hint {
   opacity: 0.6;
   font-size: 12px;
+}
+.pw {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  font-size: 12px;
+  opacity: 0.85;
+}
+.pw input {
+  width: 120px;
+  padding: 4px 8px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  font-size: 13px;
+}
+.pw + .download {
+  margin-left: 14px;
+}
+.locked {
+  margin: 60px auto;
+  max-width: 460px;
+  text-align: center;
+  color: #e2e8f0;
+  font-family: system-ui, sans-serif;
+}
+.locked .lock {
+  font-size: 64px;
+}
+.locked h2 {
+  margin: 12px 0 6px;
+  color: #fff;
+}
+.locked p {
+  margin: 6px 0;
+  opacity: 0.8;
+  font-size: 14px;
+}
+.locked code {
+  display: inline-block;
+  margin-top: 10px;
+  padding: 8px 16px;
+  background: #f3dc29;
+  color: #0a2348;
+  border-radius: 6px;
+  font-size: 16px;
+  font-weight: 700;
 }
 main {
   flex: 1;

--- a/packages/vue/playground/App.vue
+++ b/packages/vue/playground/App.vue
@@ -64,7 +64,9 @@ async function render() {
       props = Object.fromEntries(sample.assets.map((k) => [k, cache[k]]));
     }
     // The third arg is plain RenderOptions - `encrypt` flows straight through to the engine.
-    const options = sample.encrypt ? { encrypt: { userPassword: password.value || "secret" } } : undefined;
+    const options = sample.encrypt
+      ? { encrypt: { userPassword: password.value || "secret" } }
+      : undefined;
     const bytes = await renderToPdf(sample.comp, props, options);
     // vue-pdf-embed paints the PDF onto a <canvas>; an encrypted PDF can't show without the password,
     // so for those we skip the preview and offer the download + the password instead (see the template).

--- a/packages/vue/playground/samples/Encrypted.vue
+++ b/packages/vue/playground/samples/Encrypted.vue
@@ -13,7 +13,8 @@ import * as Pdf from "@jasy/vue";
       >
       <Pdf.Box :bg="'#fef3c7'" :padding="16">
         <Pdf.Text :size="12" :color="'#92400e'"
-          >Salary review, Q3 projections, and other things you would not send in plain text.</Pdf.Text
+          >Salary review, Q3 projections, and other things you would not send in plain
+          text.</Pdf.Text
         >
       </Pdf.Box>
       <Pdf.Text :size="11" :color="'#94a3b8'">JasyPDF - no Java, no headless browser.</Pdf.Text>

--- a/packages/vue/playground/samples/Encrypted.vue
+++ b/packages/vue/playground/samples/Encrypted.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+// Namespace import - sidesteps a UI lib's own Row/Text/Box without per-name aliasing.
+import * as Pdf from "@jasy/vue";
+</script>
+
+<template>
+  <Pdf.Document>
+    <Pdf.Page :size="'A4'" :gap="16">
+      <Pdf.Text :size="28" bold :color="'#0a2348'">Confidential</Pdf.Text>
+      <Pdf.Text :size="13" :color="'#475569'"
+        >This document is encrypted with AES-256. A PDF viewer asks for the password before it shows
+        anything - and it was rendered 100% in your browser by @jasy/vue.</Pdf.Text
+      >
+      <Pdf.Box :bg="'#fef3c7'" :padding="16">
+        <Pdf.Text :size="12" :color="'#92400e'"
+          >Salary review, Q3 projections, and other things you would not send in plain text.</Pdf.Text
+        >
+      </Pdf.Box>
+      <Pdf.Text :size="11" :color="'#94a3b8'">JasyPDF - no Java, no headless browser.</Pdf.Text>
+    </Pdf.Page>
+  </Pdf.Document>
+</template>

--- a/packages/vue/playground/tsconfig.json
+++ b/packages/vue/playground/tsconfig.json
@@ -8,7 +8,13 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    // Mirror the vite alias so the editor's TS server resolves @jasy/vue from source too (vite aliases are
+    // invisible to tsserver). Paths are relative to this tsconfig (no deprecated baseUrl needed in TS 5+).
+    // @jasy/pdf needs nothing here - it resolves via node_modules + its dist .d.ts.
+    "paths": {
+      "@jasy/vue": ["../src/index.ts"]
+    }
   },
   "include": ["**/*.ts", "**/*.vue", "env.d.ts"]
 }

--- a/packages/vue/playground/vite.config.ts
+++ b/packages/vue/playground/vite.config.ts
@@ -11,7 +11,10 @@ export default defineConfig({
     // keeps resolving via its package so its `browser` field still swaps the platform ports for the browser.
     // Dev-only: this file is not part of the published package, so it can never affect the build/release.
     alias: [
-      { find: /^@jasy\/vue$/, replacement: fileURLToPath(new URL("../src/index.ts", import.meta.url)) },
+      {
+        find: /^@jasy\/vue$/,
+        replacement: fileURLToPath(new URL("../src/index.ts", import.meta.url)),
+      },
     ],
   },
   // vue-pdf-embed bundles pdf.js + its worker; excluding it from pre-bundling keeps that worker happy.

--- a/packages/vue/playground/vite.config.ts
+++ b/packages/vue/playground/vite.config.ts
@@ -1,9 +1,19 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
+import { fileURLToPath } from "node:url";
 
 // 100% browser: the @jasy/pdf engine renders the PDF client-side (no server, no dev middleware).
 export default defineConfig({
   plugins: [vue()],
+  resolve: {
+    // Resolve @jasy/vue straight from its source, so the playground runs with no build step and survives
+    // node_modules drift (the self-ref symlink going missing). @jasy/pdf is deliberately NOT aliased - it
+    // keeps resolving via its package so its `browser` field still swaps the platform ports for the browser.
+    // Dev-only: this file is not part of the published package, so it can never affect the build/release.
+    alias: [
+      { find: /^@jasy\/vue$/, replacement: fileURLToPath(new URL("../src/index.ts", import.meta.url)) },
+    ],
+  },
   // vue-pdf-embed bundles pdf.js + its worker; excluding it from pre-bundling keeps that worker happy.
   optimizeDeps: { exclude: ["vue-pdf-embed"] },
 });

--- a/src/lib/api/structure.ts
+++ b/src/lib/api/structure.ts
@@ -9,6 +9,9 @@ import { Orientation } from "../renderer/pdf-config.ts";
 import { PDFDocument, PDFConfig } from "../renderer/pdf-document-class.ts";
 import { FontStyle } from "../utils/pdf-object-manager.ts";
 import { getArrayBuffer } from "../utils/utf8-to-windows1252-encoder.ts";
+import { createSecurityHandler, type EncryptOptions } from "../crypto/security-handler.ts";
+// Public types so users can name the encryption options.
+export type { EncryptOptions, Permissions } from "../crypto/security-handler.ts";
 import { Column, StackOptions } from "./layout.ts";
 import { Insets, toEdges } from "./insets.ts";
 import { TextDefaults, toTextStyleOverride } from "./text.ts";
@@ -233,6 +236,9 @@ export interface RenderOptions {
   /** What to do when content is taller than a page and cannot break: `"error"` throws (default),
    *  `"warn"` logs and clips, `"ignore"` clips silently. It is always clipped either way. */
   onOverflow?: OverflowPolicy;
+  /** Encrypt the PDF with a password (AES-256, the newest standard). NOT compatible with PDF/A
+   *  (ZUGFeRD invoices) - encrypting one throws, since PDF/A forbids encryption. */
+  encrypt?: EncryptOptions;
 }
 
 function isFontBytes(v: FontBytes | FontFamily): v is FontBytes {
@@ -253,6 +259,11 @@ export async function renderPdf(doc: PDFDocumentElement, options?: RenderOptions
     ...options?.fonts,
   };
   const attachments = options?.attachments ?? [];
+  // The security handler's key derivation is async (WebCrypto), so build it here, before the sync
+  // PDFDocument constructor wires it into the object manager.
+  const securityHandler = options?.encrypt
+    ? await createSecurityHandler(options.encrypt)
+    : undefined;
 
   // A throwaway PDFDocument whose build() yields this tree, reusing the engine's standard
   // font registration + config handling (the constructor does both). Custom fonts are
@@ -284,6 +295,7 @@ export async function renderPdf(doc: PDFDocumentElement, options?: RenderOptions
       if (options?.outputIntent) om.setOutputIntent(options.outputIntent);
       if (options?.pdfVersion) om.setPdfVersion(options.pdfVersion);
       if (options?.documentId) om.enableDocumentId();
+      if (securityHandler) om.setSecurityHandler(securityHandler);
     }
     build(): PDFDocumentElement {
       return doc;

--- a/src/lib/crypto/security-handler.ts
+++ b/src/lib/crypto/security-handler.ts
@@ -49,6 +49,13 @@ const concat = (...parts: Uint8Array[]): Uint8Array => {
   return out;
 };
 const toHex = (a: Uint8Array) => [...a].map((b) => b.toString(16).padStart(2, "0")).join("");
+// Constant-time-ish equality for password validation (no early-out on the first differing byte).
+const bytesEqual = (a: Uint8Array, b: Uint8Array): boolean => {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+};
 
 // ISO 32000-2 Algorithm 2.B: the hardened password hash. Loops AES-128-CBC + SHA-256/384/512 until the
 // stopping rule. `udata` is the 48-byte /U for the owner computations, empty for the user ones.
@@ -146,14 +153,21 @@ class StandardAes256 implements SecurityHandler {
     return aesCbcDecrypt(this.fileKey, data.subarray(0, 16), data.subarray(16));
   }
 
-  /** Test/edit groundwork: recover the file key from a password as a reader would (decrypt /UE). */
+  /** Recover the file key from a password as a reader does: validate it against /U FIRST (so a wrong
+   *  password is rejected, not silently turned into a garbage key), then decrypt /UE. The groundwork the
+   *  future "open/edit existing PDF" path reuses. Throws on a wrong password. */
   static async recoverFileKey(
     userPassword: string,
     u: Uint8Array,
     ue: Uint8Array,
   ): Promise<Uint8Array> {
-    const uKS = u.subarray(40, 48);
-    const intermediate = await hash2B(utf8(userPassword), uKS, new Uint8Array(0));
+    const pw = utf8(userPassword);
+    // Algorithm 11: hash(password + validation salt) must equal the first 32 bytes of /U.
+    const check = await hash2B(pw, u.subarray(32, 40), new Uint8Array(0));
+    if (!bytesEqual(check, u.subarray(0, 32))) {
+      throw new Error("@jasy/pdf: wrong password.");
+    }
+    const intermediate = await hash2B(pw, u.subarray(40, 48), new Uint8Array(0));
     return aesCbcDecryptNoPad(intermediate, new Uint8Array(16), ue);
   }
 }

--- a/src/lib/crypto/security-handler.ts
+++ b/src/lib/crypto/security-handler.ts
@@ -1,0 +1,171 @@
+// PDF Standard security handler. The PDFObjectManager talks to the `SecurityHandler` interface, never to a
+// concrete algorithm - so adding another scheme later (a new revision, or per-object RC4/AES-128) is just a
+// second implementation + a factory branch, with the writer untouched. Today we ship exactly one:
+// `StandardAes256` = AES-256, V5/R6 (ISO 32000-2 / PDF 2.0), the newest standard PDF encryption.
+import {
+  aesCbcDecrypt,
+  aesCbcDecryptNoPad,
+  aesCbcEncrypt,
+  aesCbcEncryptNoPad,
+  randomBytes,
+  sha,
+} from "./webcrypto.ts";
+
+/** A handler encrypts/decrypts the strings + streams of a document and describes itself as an `/Encrypt` dict. */
+export interface SecurityHandler {
+  /** The `/Encrypt` dictionary body (between `<<` and `>>`). Its own strings are never encrypted. */
+  encryptDict(): string;
+  /** Encrypt one string/stream. `ref` is unused for V5/R6 (one file key) but kept for future per-object schemes. */
+  encrypt(data: Uint8Array, ref?: { num: number; gen: number }): Promise<Uint8Array>;
+  /** Decrypt one string/stream (the groundwork the future "open/edit existing PDF" path reuses). */
+  decrypt(data: Uint8Array, ref?: { num: number; gen: number }): Promise<Uint8Array>;
+}
+
+/** What the user grants; everything defaults to allowed. Maps to the `/P` bitfield (ISO 32000-2 Table 22). */
+export interface Permissions {
+  printing?: boolean;
+  copying?: boolean;
+  modifying?: boolean;
+  annotating?: boolean;
+}
+
+export interface EncryptOptions {
+  /** Only "aes-256" today - the seam for future algorithms. */
+  algorithm?: "aes-256";
+  userPassword: string;
+  /** Full-rights password; defaults to the user password if omitted. */
+  ownerPassword?: string;
+  permissions?: Permissions;
+}
+
+const utf8 = (s: string) => new TextEncoder().encode(s).subarray(0, 127); // R6 truncates passwords to 127 bytes
+const concat = (...parts: Uint8Array[]): Uint8Array => {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let o = 0;
+  for (const p of parts) {
+    out.set(p, o);
+    o += p.length;
+  }
+  return out;
+};
+const toHex = (a: Uint8Array) => [...a].map((b) => b.toString(16).padStart(2, "0")).join("");
+
+// ISO 32000-2 Algorithm 2.B: the hardened password hash. Loops AES-128-CBC + SHA-256/384/512 until the
+// stopping rule. `udata` is the 48-byte /U for the owner computations, empty for the user ones.
+async function hash2B(
+  password: Uint8Array,
+  salt: Uint8Array,
+  udata: Uint8Array,
+): Promise<Uint8Array> {
+  let k = await sha(256, concat(password, salt, udata));
+  let e: Uint8Array = new Uint8Array(0);
+  // At least 64 rounds; then stop once the last byte of E <= round - 32 (ISO 32000-2 Algorithm 2.B).
+  for (let round = 0; round < 64 || e[e.length - 1] > round - 32; round++) {
+    const block = concat(password, k, udata);
+    const k1 = new Uint8Array(block.length * 64);
+    for (let i = 0; i < 64; i++) k1.set(block, i * block.length);
+    e = await aesCbcEncryptNoPad(k.subarray(0, 16), k.subarray(16, 32), k1);
+    let sum = 0;
+    for (let i = 0; i < 16; i++) sum += e[i]; // big-endian 128-bit mod 3 == byte-sum mod 3 (256 ≡ 1 mod 3)
+    k = await sha(([256, 384, 512] as const)[sum % 3], e);
+  }
+  return k.subarray(0, 32);
+}
+
+function permissionBits(p: Permissions = {}): number {
+  const { printing = true, copying = true, modifying = true, annotating = true } = p;
+  let bits = 0xfffff000 | 0b11000000; // reserved-1 bits (positions 7-8 and 13-32)
+  if (printing) bits |= 4 | 2048;
+  if (modifying) bits |= 8 | 1024;
+  if (copying) bits |= 16 | 512;
+  if (annotating) bits |= 32 | 256;
+  return bits | 0; // int32
+}
+
+class StandardAes256 implements SecurityHandler {
+  private constructor(
+    private readonly fileKey: Uint8Array,
+    private readonly dict: string,
+  ) {}
+
+  static async create(opts: EncryptOptions): Promise<StandardAes256> {
+    const user = utf8(opts.userPassword);
+    const owner = utf8(opts.ownerPassword ?? opts.userPassword);
+    const fileKey = randomBytes(32);
+    const p = permissionBits(opts.permissions);
+
+    // Algorithm 8: /U and /UE.
+    const uVS = randomBytes(8);
+    const uKS = randomBytes(8);
+    const empty = new Uint8Array(0);
+    const u = concat(await hash2B(user, uVS, empty), uVS, uKS); // 48 bytes
+    const ue = await aesCbcEncryptNoPad(
+      await hash2B(user, uKS, empty),
+      new Uint8Array(16),
+      fileKey,
+    );
+
+    // Algorithm 9: /O and /OE (these also fold in /U).
+    const oVS = randomBytes(8);
+    const oKS = randomBytes(8);
+    const o = concat(await hash2B(owner, oVS, u), oVS, oKS); // 48 bytes
+    const oe = await aesCbcEncryptNoPad(await hash2B(owner, oKS, u), new Uint8Array(16), fileKey);
+
+    // Algorithm 10: /Perms (a 16-byte block, ECB == single-block CBC with a zero IV).
+    const perms = new Uint8Array(16);
+    perms[0] = p & 0xff;
+    perms[1] = (p >> 8) & 0xff;
+    perms[2] = (p >> 16) & 0xff;
+    perms[3] = (p >> 24) & 0xff;
+    perms[4] = perms[5] = perms[6] = perms[7] = 0xff;
+    perms[8] = 0x46; // 'F' - metadata (XMP) stays unencrypted (standard; keeps it indexer-readable)
+    perms[9] = 0x61; // 'a'
+    perms[10] = 0x64; // 'd'
+    perms[11] = 0x62; // 'b'
+    perms.set(randomBytes(4), 12);
+    const permsEnc = await aesCbcEncryptNoPad(fileKey, new Uint8Array(16), perms);
+
+    const dict =
+      `/Filter /Standard /V 5 /R 6 /Length 256 /P ${p} /EncryptMetadata false ` +
+      `/CF << /StdCF << /CFM /AESV3 /AuthEvent /DocOpen /Length 32 >> >> /StmF /StdCF /StrF /StdCF ` +
+      `/U <${toHex(u)}> /UE <${toHex(ue)}> /O <${toHex(o)}> /OE <${toHex(oe)}> /Perms <${toHex(permsEnc)}>`;
+    return new StandardAes256(fileKey, dict);
+  }
+
+  encryptDict(): string {
+    return this.dict;
+  }
+
+  async encrypt(data: Uint8Array): Promise<Uint8Array> {
+    const iv = randomBytes(16);
+    const ct = await aesCbcEncrypt(this.fileKey, iv, data);
+    return concat(iv, ct);
+  }
+
+  async decrypt(data: Uint8Array): Promise<Uint8Array> {
+    return aesCbcDecrypt(this.fileKey, data.subarray(0, 16), data.subarray(16));
+  }
+
+  /** Test/edit groundwork: recover the file key from a password as a reader would (decrypt /UE). */
+  static async recoverFileKey(
+    userPassword: string,
+    u: Uint8Array,
+    ue: Uint8Array,
+  ): Promise<Uint8Array> {
+    const uKS = u.subarray(40, 48);
+    const intermediate = await hash2B(utf8(userPassword), uKS, new Uint8Array(0));
+    return aesCbcDecryptNoPad(intermediate, new Uint8Array(16), ue);
+  }
+}
+
+/** The factory = the seam. Today it always returns the AES-256 handler. */
+export async function createSecurityHandler(opts: EncryptOptions): Promise<SecurityHandler> {
+  if (opts.algorithm && opts.algorithm !== "aes-256") {
+    throw new Error(
+      `@jasy/pdf: unsupported encryption algorithm "${opts.algorithm}" (only "aes-256").`,
+    );
+  }
+  return StandardAes256.create(opts);
+}
+
+export { StandardAes256 };

--- a/src/lib/crypto/webcrypto.ts
+++ b/src/lib/crypto/webcrypto.ts
@@ -70,6 +70,8 @@ export async function aesCbcEncryptNoPad(
   iv: Uint8Array,
   data: Uint8Array,
 ): Promise<Uint8Array> {
+  if (data.length % 16 !== 0)
+    throw new Error("aesCbcEncryptNoPad: data must be a multiple of 16 bytes.");
   return (await aesCbcEncrypt(key, iv, data)).subarray(0, data.length);
 }
 
@@ -86,6 +88,8 @@ export async function aesCbcDecryptNoPad(
   iv: Uint8Array,
   data: Uint8Array,
 ): Promise<Uint8Array> {
+  if (data.length === 0 || data.length % 16 !== 0)
+    throw new Error("aesCbcDecryptNoPad: data must be a non-zero multiple of 16 bytes.");
   const prev = data.length >= 16 ? data.subarray(data.length - 16) : iv;
   // ECB(x) == first block of CBC(iv=0, x); we want the appended block to decrypt to 0x10*16 after the CBC xor.
   const appended = await aesCbcEncryptNoPad(

--- a/src/lib/crypto/webcrypto.ts
+++ b/src/lib/crypto/webcrypto.ts
@@ -1,0 +1,100 @@
+// Isomorphic crypto via the platform WebCrypto (`globalThis.crypto.subtle`) - native in the browser AND in
+// Node 20+, with zero dependencies. This is the primitive layer the PDF Standard security handler (AES-256,
+// R6) builds on. Everything is async (so is `render()`), so that is no constraint.
+//
+// One wrinkle: WebCrypto's AES-CBC ALWAYS applies PKCS#7 padding and offers no raw/no-pad mode. The PDF R6
+// key derivation (Algorithm 2.B, /UE, /OE, /Perms) needs UNPADDED AES, so we synthesize it from the padded
+// primitive (encrypt: drop the trailing pad block; decrypt: append a block that decrypts to a full pad, then
+// let WebCrypto strip it). Document strings/streams use the padded primitive directly - that IS AESV3.
+
+const subtle = (): SubtleCrypto => {
+  const c = (globalThis as { crypto?: Crypto }).crypto;
+  if (!c?.subtle) {
+    throw new Error(
+      "@jasy/pdf: PDF encryption needs WebCrypto (globalThis.crypto.subtle), unavailable here.",
+    );
+  }
+  return c.subtle;
+};
+
+export function randomBytes(n: number): Uint8Array {
+  const b = new Uint8Array(n);
+  (globalThis as { crypto: Crypto }).crypto.getRandomValues(b);
+  return b;
+}
+
+// WebCrypto's types want a BufferSource backed by ArrayBuffer; our Uint8Arrays are ArrayBuffer-backed, so
+// this cast at the platform boundary is safe (TS 5.7+ just can't prove it isn't a SharedArrayBuffer).
+const buf = (a: Uint8Array): BufferSource => a as unknown as BufferSource;
+
+export async function sha(bits: 256 | 384 | 512, data: Uint8Array): Promise<Uint8Array> {
+  return new Uint8Array(await subtle().digest(`SHA-${bits}`, buf(data)));
+}
+
+async function aesKey(key: Uint8Array, usage: KeyUsage): Promise<CryptoKey> {
+  return subtle().importKey("raw", buf(key), { name: "AES-CBC" }, false, [usage]);
+}
+
+/** AES-CBC with PKCS#7 padding (the AESV3 mode for PDF strings/streams). */
+export async function aesCbcEncrypt(
+  key: Uint8Array,
+  iv: Uint8Array,
+  data: Uint8Array,
+): Promise<Uint8Array> {
+  return new Uint8Array(
+    await subtle().encrypt(
+      { name: "AES-CBC", iv: buf(iv) },
+      await aesKey(key, "encrypt"),
+      buf(data),
+    ),
+  );
+}
+export async function aesCbcDecrypt(
+  key: Uint8Array,
+  iv: Uint8Array,
+  data: Uint8Array,
+): Promise<Uint8Array> {
+  return new Uint8Array(
+    await subtle().decrypt(
+      { name: "AES-CBC", iv: buf(iv) },
+      await aesKey(key, "decrypt"),
+      buf(data),
+    ),
+  );
+}
+
+/** AES-CBC WITHOUT padding (`data.length` must be a multiple of 16). WebCrypto pads unconditionally, so we
+ *  encrypt and drop the extra full pad block - the leading blocks are the true unpadded CBC. */
+export async function aesCbcEncryptNoPad(
+  key: Uint8Array,
+  iv: Uint8Array,
+  data: Uint8Array,
+): Promise<Uint8Array> {
+  return (await aesCbcEncrypt(key, iv, data)).subarray(0, data.length);
+}
+
+const xor16 = (a: Uint8Array, b: Uint8Array): Uint8Array => {
+  const o = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) o[i] = a[i] ^ b[i];
+  return o;
+};
+
+/** AES-CBC no-padding DECRYPT (`data` a multiple of 16). We append one cipher block crafted to decrypt to a
+ *  full 0x10 PKCS#7 pad (so WebCrypto accepts and strips it), leaving the original. */
+export async function aesCbcDecryptNoPad(
+  key: Uint8Array,
+  iv: Uint8Array,
+  data: Uint8Array,
+): Promise<Uint8Array> {
+  const prev = data.length >= 16 ? data.subarray(data.length - 16) : iv;
+  // ECB(x) == first block of CBC(iv=0, x); we want the appended block to decrypt to 0x10*16 after the CBC xor.
+  const appended = await aesCbcEncryptNoPad(
+    key,
+    new Uint8Array(16),
+    xor16(new Uint8Array(16).fill(16), prev),
+  );
+  const withPad = new Uint8Array(data.length + 16);
+  withPad.set(data);
+  withPad.set(appended, data.length);
+  return aesCbcDecrypt(key, iv, withPad);
+}

--- a/src/lib/renderer/pdf-renderer.ts
+++ b/src/lib/renderer/pdf-renderer.ts
@@ -101,6 +101,9 @@ export class PDFRenderer {
     // font objects with the subset font program (must happen before the objects are serialized).
     objectManager.finalizeCustomFonts();
 
+    // Encrypt every registered stream + add the /Encrypt object (no-op unless a security handler was set).
+    await objectManager.finalizeEncryption();
+
     // Add rendered objects
     pdfContent += objectManager.getRenderedObjects();
 

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -8,6 +8,7 @@ import { AFMParser } from "./afm-parser.ts";
 import { TTFParser } from "./ttf-parser.ts";
 import { subsetTTF } from "./ttf-subsetter.ts";
 import { getArrayBuffer } from "./utf8-to-windows1252-encoder.ts";
+import type { SecurityHandler } from "../crypto/security-handler.ts";
 // Enums come from the leaf config module (never in a cycle); the config type is
 // erased at runtime so it can come from the cyclic module safely.
 import { ColorMode, Orientation } from "../renderer/pdf-config.ts";
@@ -210,6 +211,12 @@ export class PDFObjectManager implements FontMetrics {
   private compress = false;
   private overflowPolicy: OverflowPolicy = "error";
 
+  // Optional encryption (setSecurityHandler). Stream emitters register their raw bytes here during the
+  // render; finalizeEncryption() encrypts them all in one async pass and adds the /Encrypt object.
+  private security?: SecurityHandler;
+  private encJobs: Uint8Array[] = [];
+  private encryptObjNum?: number;
+
   constructor();
   constructor(pageSize?: PageSize) {
     if (pageSize) this.pageFormat = pageFormats[pageSize];
@@ -246,20 +253,36 @@ export class PDFObjectManager implements FontMetrics {
     return this.overflowPolicy;
   }
 
+  // A unique, binary-safe placeholder for a stream's bytes, swapped for ciphertext in finalizeEncryption().
+  private encToken(id: number): string {
+    return ` JENC:${id} `;
+  }
+
+  // The single encryption choke-point every stream emitter routes through (stream(), registerImage). Without
+  // a security handler: the bytes as a latin1 string + their length. With one: register the raw bytes for the
+  // finalize pass and return a placeholder + the pre-computable encrypted length (16-byte IV + PKCS#7 padding).
+  private streamPayload(bytes: Uint8Array): { body: string; length: number } {
+    if (!this.security) return { body: latin1FromBytes(bytes), length: bytes.length };
+    const id = this.encJobs.push(bytes) - 1;
+    return { body: this.encToken(id), length: 16 + (Math.floor(bytes.length / 16) + 1) * 16 };
+  }
+
   // Builds a stream object body: `<< extraDict /Length n >> stream … endstream`, FlateDecode-compressed
-  // when enabled AND it actually helps (tiny streams aren't inflated). Binary bytes ride as a latin1
-  // string - the final encoder passes 0x00-0xFF through unchanged.
+  // when enabled AND it actually helps (tiny streams aren't inflated). The payload rides through
+  // streamPayload, so it is encrypted uniformly when a security handler is set.
   private stream(extraDict: string, data: Uint8Array): string {
     const head = extraDict ? extraDict + " " : "";
+    let body = data;
+    let filter = "";
     if (this.compress) {
       const z = zlibSync(data);
       if (z.length < data.length) {
-        return `<< ${head}/Filter /FlateDecode /Length ${z.length} >>\nstream\n${latin1FromBytes(
-          z,
-        )}\nendstream`;
+        body = z;
+        filter = "/Filter /FlateDecode ";
       }
     }
-    return `<< ${head}/Length ${data.length} >>\nstream\n${latin1FromBytes(data)}\nendstream`;
+    const p = this.streamPayload(body);
+    return `<< ${head}${filter}/Length ${p.length} >>\nstream\n${p.body}\nendstream`;
   }
 
   // Adds a page content stream (compressed when enabled). The caller passes the raw operator string.
@@ -327,6 +350,7 @@ export class PDFObjectManager implements FontMetrics {
     // A transparent PNG carries its alpha as a separate DeviceGray /SMask image the viewer composites with.
     let smaskEntry = "";
     if (smaskData) {
+      const s = this.streamPayload(bytesFromLatin1(smaskData));
       const smaskObject = `<< /Type /XObject
     /Subtype /Image
     /Width ${width}
@@ -334,13 +358,14 @@ export class PDFObjectManager implements FontMetrics {
     /ColorSpace /DeviceGray
     /BitsPerComponent 8
     /Filter /FlateDecode
-    /Length ${smaskData.length} >>
+    /Length ${s.length} >>
 stream
-${smaskData}
+${s.body}
 endstream`;
       smaskEntry = `    /SMask ${this.addObject(smaskObject)} 0 R\n`;
     }
 
+    const img = this.streamPayload(bytesFromLatin1(imageData));
     const imageObject = `<< /Type /XObject
     /Subtype /Image
     /Width ${width}
@@ -348,9 +373,9 @@ endstream`;
     /ColorSpace /DeviceRGB
     /BitsPerComponent 8
     /Filter /${imageType}
-${smaskEntry}    /Length ${imageData.length} >>
+${smaskEntry}    /Length ${img.length} >>
 stream
-${imageData}
+${img.body}
 endstream`;
 
     // Add the image and its object number to the image manager - return the object number
@@ -438,6 +463,31 @@ endstream`;
   // Enables a trailer /ID (required by PDF/A). The id is a content hash, so it is deterministic.
   enableDocumentId(): void {
     this.documentId = true;
+  }
+
+  // Turn on encryption: the handler encrypts every stream and supplies the /Encrypt dict. Forces a trailer
+  // /ID (encrypted PDFs require one) and PDF 2.0 (AES-256 R6). PDF/A forbids encryption - guarded at finalize.
+  setSecurityHandler(handler: SecurityHandler): void {
+    this.security = handler;
+    this.documentId = true;
+    this.setPdfVersion("2.0");
+  }
+
+  // One async pass at the very end: refuse to encrypt a PDF/A document, then encrypt every registered stream
+  // (swap each placeholder for its ciphertext) and add the /Encrypt object the trailer references.
+  async finalizeEncryption(): Promise<void> {
+    if (!this.security) return;
+    if (this.outputIntent !== undefined || this.attachments.length > 0) {
+      throw new Error("@jasy/pdf: cannot encrypt a PDF/A document - PDF/A forbids encryption.");
+    }
+    for (let id = 0; id < this.encJobs.length; id++) {
+      const ciphertext = latin1FromBytes(await this.security.encrypt(this.encJobs[id]));
+      const token = this.encToken(id);
+      const idx = this.objects.findIndex((o) => o.includes(token));
+      // Function replacement: a string replacement would interpret `$&`/`$\``/... in the random ciphertext.
+      if (idx >= 0) this.objects[idx] = this.objects[idx].replace(token, () => ciphertext);
+    }
+    this.encryptObjNum = this.addObject(`<< ${this.security.encryptDict()} >>`);
   }
 
   // Registers (or reuses) a transparency graphics state and returns its resource name
@@ -829,7 +879,8 @@ endstream`;
     const root = this.objects.findIndex((f) => f.toLowerCase().includes("catalog")) + 1;
     // A fresh document uses the same hash for both /ID strings; they only diverge on an update.
     const id = this.documentId ? ` /ID [${this.contentId()} ${this.contentId()}]` : "";
-    return `trailer\n<< /Size ${objectCount + 1} /Root ${root} 0 R${id} >>\nstartxref\n${startxref}\n%%EOF`;
+    const enc = this.encryptObjNum ? ` /Encrypt ${this.encryptObjNum} 0 R` : "";
+    return `trailer\n<< /Size ${objectCount + 1} /Root ${root} 0 R${id}${enc} >>\nstartxref\n${startxref}\n%%EOF`;
   }
 
   private contentId(): string {

--- a/tests/unit/crypto/encrypt-pdf.test.ts
+++ b/tests/unit/crypto/encrypt-pdf.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { Document, Page, Text, renderToBytes } from "../../../src/lib/index";
+import { StandardAes256 } from "../../../src/lib/crypto/security-handler";
+import { aesCbcDecrypt } from "../../../src/lib/crypto/webcrypto";
+
+const lat = (b: Uint8Array) => new TextDecoder("latin1").decode(b);
+const hex = (s: string) => Uint8Array.from(s.match(/../g)!.map((b) => parseInt(b, 16)));
+
+describe("PDF encryption (AES-256 R6) end-to-end", () => {
+  it("produces an encrypted PDF 2.0 that decrypts with the password", async () => {
+    const doc = Document([
+      Page({ size: "A4", margin: 40 }, [Text("TopSecretContent", { size: 20 })]),
+    ]);
+    // compress:false so the decrypted stream is the raw operators (no inflate step needed to assert).
+    const bytes = await renderToBytes(doc, {
+      compress: false,
+      encrypt: { userPassword: "letmein" },
+    });
+    const pdf = lat(bytes);
+
+    expect(pdf.startsWith("%PDF-2.0")).toBe(true);
+    expect(pdf).toMatch(/\/Encrypt \d+ 0 R/);
+    expect(pdf).toContain("/Filter /Standard");
+    expect(pdf).toContain("/V 5");
+    expect(pdf).toContain("/AESV3");
+    expect(pdf).not.toContain("TopSecretContent"); // the page text is encrypted, not plaintext
+
+    // Recover the file key from the password (exactly what a reader does), then decrypt the streams.
+    const u = hex(pdf.match(/\/U <([0-9a-f]+)>/)![1]);
+    const ue = hex(pdf.match(/\/UE <([0-9a-f]+)>/)![1]);
+    const key = await StandardAes256.recoverFileKey("letmein", u, ue);
+
+    // `pdf` is a single-byte decode, so a string index equals the byte index; slice the RAW bytes here -
+    // re-encoding the ciphertext through a string would corrupt the 0x80-0x9F bytes (the web's "latin1" is
+    // windows-1252). Match "\nstream\n" so "endstream" is never mistaken for the opening keyword.
+    let recovered = false;
+    for (let s = pdf.indexOf("\nstream\n"); s >= 0; s = pdf.indexOf("\nstream\n", s + 1)) {
+      const e = pdf.indexOf("\nendstream", s + 8);
+      if (e < 0) continue;
+      const blob = bytes.subarray(s + 8, e);
+      if (blob.length < 32) continue;
+      try {
+        const dec = lat(await aesCbcDecrypt(key, blob.subarray(0, 16), blob.subarray(16)));
+        if (dec.includes("TopSecretContent")) recovered = true;
+      } catch {
+        /* not a stream that decrypts cleanly with this key */
+      }
+    }
+    expect(recovered).toBe(true);
+  });
+
+  it("refuses to encrypt a PDF/A document", async () => {
+    const doc = Document([Page({ size: "A4" }, [Text("x")])]);
+    await expect(
+      renderToBytes(doc, {
+        outputIntent: new Uint8Array(8), // marks it PDF/A-ish (an OutputIntent is set)
+        encrypt: { userPassword: "p" },
+      }),
+    ).rejects.toThrow(/PDF\/A/);
+  });
+});

--- a/tests/unit/crypto/security-handler.test.ts
+++ b/tests/unit/crypto/security-handler.test.ts
@@ -33,21 +33,11 @@ describe("StandardAes256 (V5/R6) security handler", () => {
     expect(toHex(manual)).toBe(toHex(data));
   });
 
-  it("a wrong password does NOT recover the key", async () => {
+  it("rejects a wrong password (validates against /U before deriving a key)", async () => {
     const h = await createSecurityHandler({ userPassword: "right" });
     const d = h.encryptDict();
-    const enc = await h.encrypt(new TextEncoder().encode("0123456789abcdef"));
-    const wrong = await StandardAes256.recoverFileKey(
-      "WRONG",
-      dictBytes(d, "U"),
-      dictBytes(d, "UE"),
-    );
-    let manual: Uint8Array | null = null;
-    try {
-      manual = await aesCbcDecrypt(wrong, enc.subarray(0, 16), enc.subarray(16));
-    } catch {
-      /* bad PKCS#7 padding from the wrong key */
-    }
-    expect(manual === null || toHex(manual) !== toHex(enc.subarray(16))).toBe(true);
+    await expect(
+      StandardAes256.recoverFileKey("WRONG", dictBytes(d, "U"), dictBytes(d, "UE")),
+    ).rejects.toThrow(/wrong password/);
   });
 });

--- a/tests/unit/crypto/security-handler.test.ts
+++ b/tests/unit/crypto/security-handler.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { createSecurityHandler, StandardAes256 } from "../../../src/lib/crypto/security-handler";
+import { aesCbcDecrypt } from "../../../src/lib/crypto/webcrypto";
+
+const hex = (s: string) => Uint8Array.from(s.match(/../g)!.map((b) => parseInt(b, 16)));
+const toHex = (a: Uint8Array) => [...a].map((b) => b.toString(16).padStart(2, "0")).join("");
+const dictBytes = (dict: string, key: string) =>
+  hex(dict.match(new RegExp(`/${key} <([0-9a-f]+)>`))![1]);
+
+describe("StandardAes256 (V5/R6) security handler", () => {
+  it("encrypt/decrypt round-trips a string/stream", async () => {
+    const h = await createSecurityHandler({ userPassword: "hunter2" });
+    const data = new TextEncoder().encode("the page content stream bytes 🟦🟨");
+    expect(toHex(await h.decrypt(await h.encrypt(data)))).toBe(toHex(data));
+  });
+
+  it("emits a V5/R6 AESV3 /Encrypt dict", async () => {
+    const d = (await createSecurityHandler({ userPassword: "x" })).encryptDict();
+    expect(d).toContain("/Filter /Standard");
+    expect(d).toContain("/V 5");
+    expect(d).toContain("/R 6");
+    expect(d).toContain("/CFM /AESV3");
+  });
+
+  it("recovers the file key from the password via /U + /UE (the decrypt/edit groundwork)", async () => {
+    const pw = "öpen-sésame";
+    const h = await createSecurityHandler({ userPassword: pw });
+    const d = h.encryptDict();
+    const data = new TextEncoder().encode("secret payload");
+    const enc = await h.encrypt(data);
+    const key = await StandardAes256.recoverFileKey(pw, dictBytes(d, "U"), dictBytes(d, "UE"));
+    const manual = await aesCbcDecrypt(key, enc.subarray(0, 16), enc.subarray(16));
+    expect(toHex(manual)).toBe(toHex(data));
+  });
+
+  it("a wrong password does NOT recover the key", async () => {
+    const h = await createSecurityHandler({ userPassword: "right" });
+    const d = h.encryptDict();
+    const enc = await h.encrypt(new TextEncoder().encode("0123456789abcdef"));
+    const wrong = await StandardAes256.recoverFileKey(
+      "WRONG",
+      dictBytes(d, "U"),
+      dictBytes(d, "UE"),
+    );
+    let manual: Uint8Array | null = null;
+    try {
+      manual = await aesCbcDecrypt(wrong, enc.subarray(0, 16), enc.subarray(16));
+    } catch {
+      /* bad PKCS#7 padding from the wrong key */
+    }
+    expect(manual === null || toHex(manual) !== toHex(enc.subarray(16))).toBe(true);
+  });
+});

--- a/tests/unit/crypto/webcrypto.test.ts
+++ b/tests/unit/crypto/webcrypto.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import {
+  sha,
+  aesCbcEncrypt,
+  aesCbcDecrypt,
+  aesCbcEncryptNoPad,
+  aesCbcDecryptNoPad,
+  randomBytes,
+} from "../../../src/lib/crypto/webcrypto";
+
+const hex = (s: string) => Uint8Array.from(s.match(/../g)!.map((b) => parseInt(b, 16)));
+const toHex = (a: Uint8Array) => [...a].map((b) => b.toString(16).padStart(2, "0")).join("");
+
+describe("webcrypto primitives", () => {
+  it("SHA-256 matches the known 'abc' vector", async () => {
+    const out = await sha(256, new TextEncoder().encode("abc"));
+    expect(toHex(out)).toBe("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+  });
+
+  it("AES-256-CBC no-pad matches the NIST SP 800-38A vector (proves the no-pad trick)", async () => {
+    const key = hex("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4");
+    const iv = hex("000102030405060708090a0b0c0d0e0f");
+    const pt = hex("6bc1bee22e409f96e93d7e117393172a");
+    expect(toHex(await aesCbcEncryptNoPad(key, iv, pt))).toBe("f58c4c04d6e5f1ba779eabfb5f7bfbd6");
+  });
+
+  it("AES-CBC padded round-trips (the AESV3 string/stream mode)", async () => {
+    const key = randomBytes(32);
+    const iv = randomBytes(16);
+    const data = new TextEncoder().encode("jasy encrypts this — arbitrary length 🟦🟨");
+    const back = await aesCbcDecrypt(key, iv, await aesCbcEncrypt(key, iv, data));
+    expect(toHex(back)).toBe(toHex(data));
+  });
+
+  it("AES-CBC no-pad round-trips (synthesized-pad decrypt)", async () => {
+    const key = randomBytes(32);
+    const iv = randomBytes(16);
+    const data = randomBytes(48); // 3 blocks, no padding
+    const enc = await aesCbcEncryptNoPad(key, iv, data);
+    expect(enc.length).toBe(48);
+    expect(toHex(await aesCbcDecryptNoPad(key, iv, enc))).toBe(toHex(data));
+  });
+});

--- a/tests/unit/renderer/pdf-renderer.test.ts
+++ b/tests/unit/renderer/pdf-renderer.test.ts
@@ -31,6 +31,7 @@ describe("PDFRenderer", () => {
       getPdfVersion: vi.fn().mockReturnValue("1.4"),
       getHeader: vi.fn().mockReturnValue("%PDF-1.4\n"),
       finalizeCustomFonts: vi.fn(),
+      finalizeEncryption: vi.fn().mockResolvedValue(undefined),
     } as unknown as PDFObjectManager;
 
     vi.spyOn(PDFDocumentRenderer, "render").mockResolvedValue(1);


### PR DESCRIPTION
## Summary

Implement password encryption to jasy!

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for password-protected, AES-256 encrypted PDF exports with configurable permissions.
  * Updated the Vue playground with a new “Encrypted” sample that prompts for a password and shows locked-download guidance.
* **Bug Fixes**
  * Ensured encrypted PDFs properly finalize encryption during the render flow.
* **Tests**
  * Added/expanded unit and end-to-end coverage for encryption, the security handler, and WebCrypto primitives; updated renderer encryption mocks.
* **Chores**
  * Aligned `@jasy/vue` aliasing in the playground and excluded `vue-pdf-embed` from dependency pre-bundling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->