### PR TITLE
feat: pdf/ua support as default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,18 @@ lineHeight, align, bold, italic }, …)` sets doc-wide text defaults; `DefaultTe
   choke-point (`streamPayload`) + a finalize pass (`finalizeEncryption`) writes `/Encrypt` + forces `/ID`;
   `EncryptMetadata false` keeps XMP plaintext. Mutually exclusive with PDF/A (ZUGFeRD throws). `recoverFileKey`
   (validates the password vs `/U`) is the groundwork for a future decrypt/edit path. Proven against poppler.
+- ✅ **Accessibility / tagged PDF (PDF/UA-1)** (2026-07-01) — `renderToBytes(doc, { accessible, lang, title })`
+  emits a full structure tree, **verified `isCompliant` by veraPDF** (local at `~/.jasy/verapdf/verapdf -f ua1`).
+  Engine owns it; components only declare a role: `Text({ role: "h1".."h6"|"p" })`, `Image({ alt })` → Figure,
+  `Table` → Table/TR/TH/TD (auto), decoration → Artifact. The **`StructTree`** (`utils/struct-tree.ts`) builds
+  StructTreeRoot → nested StructElem + ParentTree; a leaf/container both `openElement(structId, role)`, containers
+  `push`/`pop`. **Keyed by a stable `structId`** (base `PDFElement`, carried through fragmentation clones) so a
+  paragraph or table split across pages stays ONE logical element (Acrobat-level). A layout-**transparent**
+  **`StructGroup`** (`elements/layout/struct-group.ts`) wraps table rows/cells; it fragments only if its child
+  does (`canFragment` veto → rows move whole, never clipped). Backend wraps each node `/Role <</MCID>> BDC…EMC`
+  (untagged → `/Artifact **BMC**`); catalog gets `/MarkInfo`, `/StructTreeRoot`, `/Lang`, `/ViewerPreferences
+/DisplayDocTitle`, pages `/Tabs /S`, TH `/Scope /Column`, XMP `pdfuaid:part 1` (`utils/ua-xmp.ts`). Off =
+  byte-identical. Full conformance needs embedded fonts + a title (same as PDF/A). **~377 tests.**
 
 Genuine remaining gaps / deferred:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,13 @@ lineHeight, align, bold, italic }, …)` sets doc-wide text defaults; `DefaultTe
 - ✅ **`onOverflow` safety** (2026-06-24) — over-tall unbreakable content is force-placed (clipped) so
   pagination always terminates (no infinite loop); render option `onOverflow: "error" (default) | "warn"
 | "ignore"` (`fragmentation.ts packChildren`).
+- ✅ **Encryption** (2026-06-28, `@jasy/pdf@alpha.4`) — AES-256, V5/R6 (ISO 32000-2, the newest standard).
+  `renderToBytes(doc, { encrypt: { userPassword, ownerPassword?, permissions? } })`. Built on **WebCrypto**
+  (`crypto/webcrypto.ts`, isomorphic, zero-dep) behind a pluggable **`SecurityHandler` seam**
+  (`crypto/security-handler.ts`) — a future algorithm/revision is just a second impl. Streams encrypt at one
+  choke-point (`streamPayload`) + a finalize pass (`finalizeEncryption`) writes `/Encrypt` + forces `/ID`;
+  `EncryptMetadata false` keeps XMP plaintext. Mutually exclusive with PDF/A (ZUGFeRD throws). `recoverFileKey`
+  (validates the password vs `/U`) is the groundwork for a future decrypt/edit path. Proven against poppler.
 
 Genuine remaining gaps / deferred:
 

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ const pdf = await renderToBytes(
 ```
 
 Real text layout (Adobe AFM metrics, kerning, word-wrap), flexbox-style `gap` / `justify` / `align`,
-boxes with radius and alpha, images, custom TrueType fonts, and **real pagination** - content that
-overflows flows onto the next page, headers and footers repeat.
+boxes with radius and alpha, images, custom TrueType fonts, **AES-256 password encryption**, and **real
+pagination** - content that overflows flows onto the next page, headers and footers repeat.
 
 ---
 
@@ -132,6 +132,9 @@ verify all of it:
   740 KB font ships as a ~76 KB subset, and the text stays copy- and searchable.
 - **Compression.** Content streams and images are FlateDecode-compressed; the spreadsheets `jasy export`
   writes are real `.xlsx` ZIPs we deflate with our own writer and CRC32, zero dependencies.
+- **AES-256 encryption, pure JS.** Lock a PDF with `renderToBytes(doc, { encrypt: { userPassword } })` - the
+  newest standard handler (AES-256, R6 / ISO 32000-2) via the platform WebCrypto: no native crypto, no deps,
+  the same code in Node **and** the browser. Owner password + permissions optional.
 - **Real font metrics.** Text is laid out with the Adobe AFM metrics of the standard-14 fonts - kerning
   and word-wrap are _computed_, not guessed.
 - **PDF/A-3, matched not approximated.** The conformance graph is hand-built and **passes veraPDF**, the

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -92,6 +92,21 @@ export default definePdfHandler(build, { cache: { maxAge: 3600 } });
 
 Expired entries re-render fresh (`swr` is off by default) - a stale invoice is never served.
 
+### Password protection
+
+`usePdf` and `definePdfHandler` / `sendPdf` forward `@jasy/pdf` render options via `renderOptions` - so
+AES-256 password protection is one option away, client or server:
+
+```ts
+// client
+const { download } = usePdf(Invoice, { renderOptions: { encrypt: { userPassword: "secret" } } });
+
+// server
+export default definePdfHandler(build, { renderOptions: { encrypt: { userPassword: "secret" } } });
+```
+
+`ownerPassword` + `permissions` are optional. (AES-256 ≠ PDF/A, so this is not for ZUGFeRD invoices.)
+
 ## What the module sets up
 
 - **Components** for templates: `Document` · `Page` · `Column` · `Row` · `Box` · `Padding` · `Text` ·

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -115,6 +115,9 @@ const props = defineProps<{ font: Uint8Array; logo: Uint8Array }>();
 
 - `renderToPdf(root, props?, options?) => Promise<Uint8Array>` - the PDF bytes. Browser or Node.
 - `renderToPdfString(root, props?, options?) => Promise<string>` - the raw PDF string.
+- `options` are the `@jasy/pdf` `RenderOptions` and flow straight through - e.g.
+  `renderToPdf(Doc, props, { encrypt: { userPassword: "secret" } })` for AES-256 password protection (also
+  `fonts`, `compress`, `onOverflow`, …).
 - `toDocumentDescriptor(root, props?)` - the framework-agnostic descriptor (the seam a Node service can
   receive from the browser).
 - `jasyVue` - the global-registration plugin (`{ prefix }`).

--- a/scripts/gh-release.mjs
+++ b/scripts/gh-release.mjs
@@ -82,7 +82,9 @@ const PATHSPEC = {
 };
 const pathspec = PATHSPEC[prefix] ? ["--", ...PATHSPEC[prefix]] : [];
 const inScope = new Set(
-  sh("git", ["log", `${from}..${tag}`, "--format=%H", ...pathspec]).split("\n").filter(Boolean),
+  sh("git", ["log", `${from}..${tag}`, "--format=%H", ...pathspec])
+    .split("\n")
+    .filter(Boolean),
 );
 const shaInScope = (short) => [...inScope].some((full) => full.startsWith(short));
 

--- a/scripts/gh-release.mjs
+++ b/scripts/gh-release.mjs
@@ -12,6 +12,35 @@ import { existsSync, rmSync, writeFileSync } from "node:fs";
 const sh = (cmd, args) => execFileSync(cmd, args, { encoding: "utf8" }).trim();
 const gh = (args) => sh("gh", args);
 
+// Filter changelogen's grouped markdown down to commits in scope, dropping any group heading left without
+// entries. Entry lines look like "- Subject ([abc1234](…/commit/abc1234))"; the compare-changes link and
+// blank lines before the first heading are kept as-is.
+function scopeNotes(md, inScopeSha) {
+  const out = [];
+  let header = null;
+  let items = [];
+  const flush = () => {
+    if (header && items.length) out.push(header, "", ...items, "");
+    header = null;
+    items = [];
+  };
+  for (const line of md.split("\n")) {
+    if (/^#{2,6}\s/.test(line)) {
+      flush();
+      header = line;
+      continue;
+    }
+    const m = line.match(/\(\[([0-9a-f]{7,40})\]\(/);
+    if (m && /^\s*-\s/.test(line)) {
+      if (inScopeSha(m[1])) items.push(line);
+      continue;
+    }
+    if (!header && line.trim()) out.push(line); // compare-changes link etc., before any heading
+  }
+  flush();
+  return out.join("\n").trim();
+}
+
 const { TAG: tag, NAME: name, VERSION: version, DIST: dist, GITHUB_REPOSITORY: repo } = process.env;
 if (!tag || !name || !version || !repo) {
   throw new Error("missing env: TAG, NAME, VERSION, GITHUB_REPOSITORY required");
@@ -41,6 +70,22 @@ const from =
   (i >= 0 && i + 1 < tags.length && tags[i + 1]) ||
   sh("git", ["rev-list", "--max-parents=0", "HEAD"]);
 
+// Path-scope per package: a changelog only lists commits that touched THIS package's files. The root `pdf`
+// package = everything EXCEPT the sub-packages. A commit touching several packages shows up in each of them,
+// which is correct. inScope = the set of full shas in the range that touched the package's path.
+const PATHSPEC = {
+  pdf: [".", ":(exclude)packages"],
+  zugferd: ["packages/zugferd"],
+  cli: ["packages/cli"],
+  vue: ["packages/vue"],
+  nuxt: ["packages/nuxt"],
+};
+const pathspec = PATHSPEC[prefix] ? ["--", ...PATHSPEC[prefix]] : [];
+const inScope = new Set(
+  sh("git", ["log", `${from}..${tag}`, "--format=%H", ...pathspec]).split("\n").filter(Boolean),
+);
+const shaInScope = (short) => [...inScope].some((full) => full.startsWith(short));
+
 // 1) Grouped notes for the delta (changelogen print mode), minus its own header line + contributor block.
 // changelogen still writes a CHANGELOG.md even in print mode; we only want stdout, so remove that
 // artifact afterwards (option B = no committed changelog file).
@@ -60,11 +105,13 @@ notes = notes
   .replace(/### ❤️ Contributors[\s\S]*$/m, "")
   .replace(/^##\s.*$/m, "")
   .trim();
+// Drop entries for commits that did not touch this package, plus any group heading left empty.
+notes = scopeNotes(notes, shaInScope);
 
 // 2) Contributors via per-commit attribution (correct GitHub user, not an email-search org hit).
 const seen = new Set();
 const contributors = [];
-for (const sha of sh("git", ["log", `${from}..${tag}`, "--pretty=format:%H"])
+for (const sha of sh("git", ["log", `${from}..${tag}`, "--pretty=format:%H", ...pathspec])
   .split("\n")
   .filter(Boolean)) {
   let data;

--- a/src/lib/api/content.ts
+++ b/src/lib/api/content.ts
@@ -64,6 +64,9 @@ export interface ImageOptions {
   fit?: ImageFit;
   /** Corner radius in points (rounds the image box). */
   radius?: number;
+  /** Alternate text for accessibility (tagged PDF): describes the image for screen readers. With `alt`
+   *  the image is a `Figure`; without it (and when rendered `accessible`) it counts as decoration. */
+  alt?: string;
 }
 
 /**
@@ -82,5 +85,6 @@ export function Image(src: ImageSource, opts: ImageOptions = {}): ImageElement {
     height: opts.height,
     fit: opts.fit ? FIT[opts.fit] : undefined,
     radius: opts.radius,
+    alt: opts.alt,
   });
 }

--- a/src/lib/api/structure.ts
+++ b/src/lib/api/structure.ts
@@ -239,6 +239,12 @@ export interface RenderOptions {
   /** Encrypt the PDF with a password (AES-256, the newest standard). NOT compatible with PDF/A
    *  (ZUGFeRD invoices) - encrypting one throws, since PDF/A forbids encryption. */
   encrypt?: EncryptOptions;
+  /** Emit an accessible, tagged PDF (structure tree for screen readers). */
+  accessible?: boolean;
+  /** Document language for accessibility, e.g. `"en-US"` / `"de-DE"` (default `"en-US"`). */
+  lang?: string;
+  /** Document title (used by accessible readers; also good metadata). */
+  title?: string;
 }
 
 function isFontBytes(v: FontBytes | FontFamily): v is FontBytes {
@@ -296,6 +302,11 @@ export async function renderPdf(doc: PDFDocumentElement, options?: RenderOptions
       if (options?.pdfVersion) om.setPdfVersion(options.pdfVersion);
       if (options?.documentId) om.enableDocumentId();
       if (securityHandler) om.setSecurityHandler(securityHandler);
+      if (options?.accessible) {
+        om.struct.enabled = true;
+        if (options.lang) om.struct.lang = options.lang;
+        if (options.title) om.struct.title = options.title;
+      }
     }
     build(): PDFDocumentElement {
       return doc;

--- a/src/lib/api/structure.ts
+++ b/src/lib/api/structure.ts
@@ -306,9 +306,11 @@ export async function renderPdf(doc: PDFDocumentElement, options?: RenderOptions
       if (options?.accessible) {
         om.struct.enabled = true;
         if (options.lang) om.struct.lang = options.lang;
-        if (options.title) om.struct.title = options.title;
+        // Fall back to the document's own title (Document({ meta })) when no explicit title is given.
+        const title = options.title ?? meta?.title;
+        if (title) om.struct.title = title;
         // Declare PDF/UA-1 in the XMP metadata, unless the caller supplied their own packet.
-        if (!options.xmp) om.setXmpMetadata(uaXmp({ title: options.title, lang: options.lang }));
+        if (!options.xmp) om.setXmpMetadata(uaXmp({ title }));
       }
     }
     build(): PDFDocumentElement {

--- a/src/lib/api/structure.ts
+++ b/src/lib/api/structure.ts
@@ -12,6 +12,7 @@ import { getArrayBuffer } from "../utils/utf8-to-windows1252-encoder.ts";
 import { createSecurityHandler, type EncryptOptions } from "../crypto/security-handler.ts";
 // Public types so users can name the encryption options.
 export type { EncryptOptions, Permissions } from "../crypto/security-handler.ts";
+import { uaXmp } from "../utils/ua-xmp.ts";
 import { Column, StackOptions } from "./layout.ts";
 import { Insets, toEdges } from "./insets.ts";
 import { TextDefaults, toTextStyleOverride } from "./text.ts";
@@ -306,6 +307,8 @@ export async function renderPdf(doc: PDFDocumentElement, options?: RenderOptions
         om.struct.enabled = true;
         if (options.lang) om.struct.lang = options.lang;
         if (options.title) om.struct.title = options.title;
+        // Declare PDF/UA-1 in the XMP metadata, unless the caller supplied their own packet.
+        if (!options.xmp) om.setXmpMetadata(uaXmp({ title: options.title, lang: options.lang }));
       }
     }
     build(): PDFDocumentElement {

--- a/src/lib/api/table.ts
+++ b/src/lib/api/table.ts
@@ -103,7 +103,7 @@ function composeTable(opts: TableOptions, rows: Cell[][], columns: ColumnWidth[]
       cellPadding !== undefined ? Padding(cellPadding, asElement(cell)) : asElement(cell);
     // Tag the cell (TH for a header cell, else TD). StructGroup is layout-transparent - visually nothing
     // changes; it only nests the cell's content under a table-cell element in the accessible structure tree.
-    const inner = new StructGroup(isHeader ? "TH" : "TD", content);
+    const inner = new StructGroup({ role: isHeader ? "TH" : "TD", child: content });
     // The border lives on the wrapper, which stretches to the row height (crisp lines).
     const border = {
       ...borderFor(firstRow, firstCol),
@@ -118,13 +118,13 @@ function composeTable(opts: TableOptions, rows: Cell[][], columns: ColumnWidth[]
 
   // align:stretch → equal-height cells, so a wrapping cell keeps the row's bottom rule straight.
   const buildRow = (cells: Cell[], firstRow: boolean, ruled = false, isHeader = false) =>
-    new StructGroup(
-      "TR",
-      Row(
+    new StructGroup({
+      role: "TR",
+      child: Row(
         { gap: colGap, align: "stretch" },
         cells.map((cell, i) => wrap(cell, columns[i] ?? "1fr", firstRow, i === 0, ruled, isHeader)),
       ),
-    );
+    });
 
   // The first row (which gets the top border) is the header if present, else body row 0.
   // `rule` underlines the header and the last body row (the table foot).
@@ -143,7 +143,7 @@ function composeTable(opts: TableOptions, rows: Cell[][], columns: ColumnWidth[]
         rowGap,
       )
     : body;
-  return new StructGroup("Table", table);
+  return new StructGroup({ role: "Table", child: table });
 }
 
 /**

--- a/src/lib/api/table.ts
+++ b/src/lib/api/table.ts
@@ -2,6 +2,7 @@ import { PDFElement, LayoutContext } from "../elements/pdf-element.ts";
 import { BoxConstraints } from "../layout/box-constraints.ts";
 import { RepeatingHeaderElement } from "../elements/layout/repeating-header-element.ts";
 import { DeferredElement } from "../elements/layout/deferred-element.ts";
+import { StructGroup } from "../elements/layout/struct-group.ts";
 import { Column, Row, Box, Expanded, Padding } from "./layout.ts";
 import { Text } from "./text.ts";
 import { Insets } from "./insets.ts";
@@ -96,9 +97,13 @@ function composeTable(opts: TableOptions, rows: Cell[][], columns: ColumnWidth[]
     firstRow: boolean,
     firstCol: boolean,
     ruled: boolean,
+    isHeader: boolean,
   ): PDFElement => {
-    const inner =
+    const content =
       cellPadding !== undefined ? Padding(cellPadding, asElement(cell)) : asElement(cell);
+    // Tag the cell (TH for a header cell, else TD). StructGroup is layout-transparent - visually nothing
+    // changes; it only nests the cell's content under a table-cell element in the accessible structure tree.
+    const inner = new StructGroup(isHeader ? "TH" : "TD", content);
     // The border lives on the wrapper, which stretches to the row height (crisp lines).
     const border = {
       ...borderFor(firstRow, firstCol),
@@ -112,10 +117,13 @@ function composeTable(opts: TableOptions, rows: Cell[][], columns: ColumnWidth[]
   };
 
   // align:stretch → equal-height cells, so a wrapping cell keeps the row's bottom rule straight.
-  const buildRow = (cells: Cell[], firstRow: boolean, ruled = false) =>
-    Row(
-      { gap: colGap, align: "stretch" },
-      cells.map((cell, i) => wrap(cell, columns[i] ?? "1fr", firstRow, i === 0, ruled)),
+  const buildRow = (cells: Cell[], firstRow: boolean, ruled = false, isHeader = false) =>
+    new StructGroup(
+      "TR",
+      Row(
+        { gap: colGap, align: "stretch" },
+        cells.map((cell, i) => wrap(cell, columns[i] ?? "1fr", firstRow, i === 0, ruled, isHeader)),
+      ),
     );
 
   // The first row (which gets the top border) is the header if present, else body row 0.
@@ -128,9 +136,14 @@ function composeTable(opts: TableOptions, rows: Cell[][], columns: ColumnWidth[]
     ),
   );
 
-  return opts.header
-    ? new RepeatingHeaderElement(buildRow(opts.header, true, rule !== undefined), body, rowGap)
+  const table = opts.header
+    ? new RepeatingHeaderElement(
+        buildRow(opts.header, true, rule !== undefined, true),
+        body,
+        rowGap,
+      )
     : body;
+  return new StructGroup("Table", table);
 }
 
 /**

--- a/src/lib/api/text.ts
+++ b/src/lib/api/text.ts
@@ -1,4 +1,4 @@
-import { TextElement, TextSegment } from "../elements/text-element.ts";
+import { TextElement, TextRole, TextSegment } from "../elements/text-element.ts";
 import { HorizontalAlignment } from "../elements/pdf-element.ts";
 import { FontStyle } from "../utils/pdf-object-manager.ts";
 import { TextOverflow } from "../text/line-breaker.ts";
@@ -28,6 +28,9 @@ export interface TextOptions extends TextStyle {
   /** Line-height multiplier (default `1`). `1.4` gives roomier body copy; each line is
    *  `size * lineHeight` tall. */
   lineHeight?: number;
+  /** Accessibility role for the tagged structure tree (only when rendered with `accessible`): a heading
+   *  level `"h1"`..`"h6"` or `"p"` (default). Purely semantic - it does not change the visual style. */
+  role?: TextRole;
 }
 
 /** bold + italic → the single engine `FontStyle`. */
@@ -82,6 +85,7 @@ export function Text(content: string | TextSegment[], opts: TextOptions = {}): T
     maxLines: opts.maxLines,
     overflow: opts.overflow,
     lineHeight: opts.lineHeight,
+    role: opts.role,
   });
 }
 

--- a/src/lib/elements/image-element.ts
+++ b/src/lib/elements/image-element.ts
@@ -124,20 +124,24 @@ interface ImageElementParams {
   fit?: BoxFit;
   /** Corner radius in points; rounds the image box (0 = sharp, default). */
   radius?: number;
+  /** Alternate text for accessibility (tagged PDF). With `alt` the image is a Figure; without, decoration. */
+  alt?: string;
 }
 
 export class ImageElement extends SizedPDFElement {
   private image: CustomImage;
   private fit: BoxFit;
   private radius: number;
+  private readonly alt?: string;
 
-  constructor({ image, width, height, fit = BoxFit.none, radius }: ImageElementParams) {
+  constructor({ image, width, height, fit = BoxFit.none, radius, alt }: ImageElementParams) {
     super({ x: 0, y: 0, width });
 
     this.image = image;
     this.height = height;
     this.fit = fit;
     this.radius = radius ?? 0;
+    this.alt = alt;
   }
 
   calculateLayout(constraints: BoxConstraints, offset: Offset, _ctx: LayoutContext): Size {
@@ -160,6 +164,7 @@ export class ImageElement extends SizedPDFElement {
       image: this.image,
       fit: this.fit,
       radius: this.radius,
+      alt: this.alt,
     };
   }
 }

--- a/src/lib/elements/layout/struct-group.ts
+++ b/src/lib/elements/layout/struct-group.ts
@@ -11,11 +11,13 @@ import { Fragmentable, FragmentResult, isFragmentable } from "../../layout/fragm
  * logical structure element (a table broken over pages is a single <Table>, exactly as Acrobat produces).
  */
 export class StructGroup extends PDFElement implements Fragmentable {
-  constructor(
-    readonly role: string,
-    private child: PDFElement,
-  ) {
+  private role: string;
+  private child: PDFElement;
+
+  constructor({ role, child }: { role: string; child: PDFElement }) {
     super();
+    this.role = role;
+    this.child = child;
   }
 
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
@@ -33,8 +35,12 @@ export class StructGroup extends PDFElement implements Fragmentable {
     const { fitted, remainder } = this.child.fragment(maxHeight, width, ctx);
     // Re-wrap each half with the SAME role + identity, so both pages point at one structure element.
     return {
-      fitted: fitted ? new StructGroup(this.role, fitted).adoptStructId(this) : null,
-      remainder: remainder ? new StructGroup(this.role, remainder).adoptStructId(this) : null,
+      fitted: fitted
+        ? new StructGroup({ role: this.role, child: fitted }).adoptStructId(this)
+        : null,
+      remainder: remainder
+        ? new StructGroup({ role: this.role, child: remainder }).adoptStructId(this)
+        : null,
     };
   }
 

--- a/src/lib/elements/layout/struct-group.ts
+++ b/src/lib/elements/layout/struct-group.ts
@@ -1,0 +1,44 @@
+import { PDFElement, LayoutContext } from "../pdf-element.ts";
+import { BoxConstraints, Offset, Size } from "../../layout/box-constraints.ts";
+import { Fragmentable, FragmentResult, isFragmentable } from "../../layout/fragmentation.ts";
+
+/**
+ * A layout-TRANSPARENT wrapper that assigns an accessibility structure role (Table / TR / TH / TD / …) to
+ * its single child. It delegates ALL layout and fragmentation to the child, so the visual result is byte-
+ * identical; only its renderer opens a structure element and nests the child's tags underneath.
+ *
+ * Split across pages, the fitted and remainder halves share this group's `structId`, so it stays ONE
+ * logical structure element (a table broken over pages is a single <Table>, exactly as Acrobat produces).
+ */
+export class StructGroup extends PDFElement implements Fragmentable {
+  constructor(
+    readonly role: string,
+    private child: PDFElement,
+  ) {
+    super();
+  }
+
+  calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
+    return this.child.calculateLayout(constraints, offset, ctx);
+  }
+
+  /** Only splittable when the wrapped child is - so a StructGroup(Row) is moved whole to the next page,
+   *  not clipped at the boundary (isFragmentable honours this veto). */
+  canFragment(): boolean {
+    return isFragmentable(this.child);
+  }
+
+  fragment(maxHeight: number, width: number, ctx: LayoutContext): FragmentResult {
+    if (!isFragmentable(this.child)) return { fitted: null, remainder: this };
+    const { fitted, remainder } = this.child.fragment(maxHeight, width, ctx);
+    // Re-wrap each half with the SAME role + identity, so both pages point at one structure element.
+    return {
+      fitted: fitted ? new StructGroup(this.role, fitted).adoptStructId(this) : null,
+      remainder: remainder ? new StructGroup(this.role, remainder).adoptStructId(this) : null,
+    };
+  }
+
+  override getProps() {
+    return { role: this.role, child: this.child };
+  }
+}

--- a/src/lib/elements/pdf-element.ts
+++ b/src/lib/elements/pdf-element.ts
@@ -36,7 +36,22 @@ export interface LayoutContext {
   onOverflow?: OverflowPolicy;
 }
 
+let _nextStructId = 0;
+
 export abstract class PDFElement {
+  // Stable identity for accessible (PDF/UA) tagging: assigned once at construction and carried through
+  // fragmentation copies (adoptStructId), so a paragraph or table split across pages stays ONE structure
+  // element. Only the elements that actually tag (Text, Image, StructGroup) read it.
+  private _structId = _nextStructId++;
+  get structId(): number {
+    return this._structId;
+  }
+  /** Make this element share `from`'s tagging identity - used by fragmentation clones. Returns this. */
+  adoptStructId(from: PDFElement): this {
+    this._structId = from._structId;
+    return this;
+  }
+
   // Each subclass overrides this with its own concrete props type; `unknown` forces
   // callers holding only a base `PDFElement` to narrow before reading props.
   abstract getProps(): unknown;

--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -206,7 +206,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       overflow: this.overflow,
       lineHeight: this.lineHeight,
       role: this.role,
-    });
+    }).adoptStructId(this); // a wrapped remainder is the SAME logical paragraph (one P across pages)
   }
 
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {

--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -24,6 +24,9 @@ export interface TextSegment {
   fontSize?: number;
 }
 
+/** Accessibility role for the tagged structure tree: a heading level or a paragraph (the default). */
+export type TextRole = "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p";
+
 interface TextElementParams {
   id?: string;
   /** Unset (undefined) inherits the cascaded size; see ResolvedTextStyle. */
@@ -39,6 +42,8 @@ interface TextElementParams {
   overflow?: TextOverflow;
   /** Line-height multiplier: each line is `fontSize * lineHeight` tall (default `1`). */
   lineHeight?: number;
+  /** Accessibility role for the tagged structure tree (heading level or paragraph; default `"p"`). */
+  role?: TextRole;
 }
 
 export class TextElement extends SizedPDFElement implements Fragmentable {
@@ -63,6 +68,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
   private content: string | TextSegment[];
   private maxLines?: number;
   private overflow: TextOverflow;
+  private readonly role?: TextRole; // accessibility role (tagged PDF); undefined = paragraph
 
   constructor({
     fontSize,
@@ -74,8 +80,10 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     maxLines,
     overflow = "clip",
     lineHeight,
+    role,
   }: TextElementParams) {
     super({ x: 0, y: 0 });
+    this.role = role;
 
     this.rawFontSize = fontSize;
     this.rawFontFamily = fontFamily;
@@ -197,6 +205,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       maxLines: this.maxLines,
       overflow: this.overflow,
       lineHeight: this.lineHeight,
+      role: this.role,
     });
   }
 
@@ -281,6 +290,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       maxLines: this.maxLines,
       overflow: this.overflow,
       lineHeight: this.lineHeight,
+      role: this.role,
     };
   }
 }

--- a/src/lib/ir/display-list.ts
+++ b/src/lib/ir/display-list.ts
@@ -14,6 +14,18 @@ import { FontStyle } from "../utils/pdf-object-manager.ts";
  */
 
 /**
+ * Structure tag for accessible (PDF/UA) tagging. `role` is the PDF structure type the content maps to
+ * (`P`, `H1`..`H6`, `Figure`, `TD`, …); `key` groups the IR nodes of one logical element (e.g. every line
+ * of a paragraph) into a single structure element; `alt` is the alternate text for a figure. A drawable
+ * node WITHOUT a tag is emitted as an Artifact (decoration, skipped by screen readers).
+ */
+export interface StructTag {
+  role: string;
+  key: number;
+  alt?: string;
+}
+
+/**
  * A single positioned run of text in one font / size / color. Line wrapping has
  * already happened upstream: the producer emits one `TextRun` per laid-out line or
  * per styled segment within a line.
@@ -27,6 +39,7 @@ export interface TextRun {
   fontStyle: FontStyle;
   fontSize: number;
   color: Color;
+  tag?: StructTag; // accessible tagging; absent = Artifact
 }
 
 /** An axis-aligned rectangle. An absent `fill` or `stroke` means that part is not drawn. */
@@ -41,6 +54,7 @@ export interface Rect {
   strokeWidth: number;
   /** Corner radius in points; absent/0 = sharp corners (plain `re`). */
   radius?: number;
+  tag?: StructTag; // accessible tagging; absent = Artifact
 }
 
 /** A straight line segment between two points. */
@@ -52,6 +66,7 @@ export interface Line {
   y2: number;
   stroke: Color;
   strokeWidth: number;
+  tag?: StructTag; // accessible tagging; absent = Artifact
 }
 
 /** A raster image, already resolved to bytes by the producer (no `CustomImage` here). */
@@ -71,6 +86,7 @@ export interface Image {
   clip?: { x: number; y: number; width: number; height: number };
   /** Corner radius in points for the image box; absent/0 = sharp corners. */
   radius?: number;
+  tag?: StructTag; // accessible tagging (a Figure needs `alt`); absent = Artifact
 }
 
 /**

--- a/src/lib/ir/display-list.ts
+++ b/src/lib/ir/display-list.ts
@@ -20,9 +20,8 @@ import { FontStyle } from "../utils/pdf-object-manager.ts";
  * node WITHOUT a tag is emitted as an Artifact (decoration, skipped by screen readers).
  */
 export interface StructTag {
-  role: string;
-  key: number;
-  alt?: string;
+  role: string; // the PDF structure type for the BDC marked-content (P, H1, Figure, …)
+  key: number; // the StructElem this content belongs to (registered via StructTree.openElement)
 }
 
 /**

--- a/src/lib/layout/fragmentation.ts
+++ b/src/lib/layout/fragmentation.ts
@@ -26,10 +26,17 @@ export interface Fragmentable {
 }
 
 export function isFragmentable(element: PDFElement): element is PDFElement & Fragmentable {
-  return (
-    "fragment" in element &&
-    typeof (element as PDFElement & { fragment: unknown }).fragment === "function"
-  );
+  if (
+    !("fragment" in element) ||
+    typeof (element as PDFElement & { fragment: unknown }).fragment !== "function"
+  ) {
+    return false;
+  }
+  // An element may veto splitting at runtime via canFragment() - a transparent StructGroup only fragments
+  // when its wrapped child does, so a non-splittable wrapped child (e.g. a table row) is moved whole to the
+  // next page instead of being clipped at the boundary. Elements without canFragment() are always splittable.
+  const canFragment = (element as PDFElement & { canFragment?: () => boolean }).canFragment;
+  return typeof canFragment !== "function" || canFragment.call(element);
 }
 
 /**

--- a/src/lib/renderer/image-renderer.ts
+++ b/src/lib/renderer/image-renderer.ts
@@ -13,10 +13,10 @@ import { IRNode, Image } from "../ir/display-list.ts";
 export class ImageRenderer {
   static async render(
     imageElement: ImageElement,
-    _objectManager: PDFObjectManager,
+    objectManager: PDFObjectManager,
   ): Promise<IRNode[]> {
     // Load the image and convert it in a binary string
-    let { x, y, width, height, image, fit, radius } = imageElement.getProps();
+    let { x, y, width, height, image, fit, radius, alt } = imageElement.getProps();
     await image.init(); // Load and initialize the image
     const imageType = await image.getImageType(); // For the moment we can handle `png` and `jpg/jpeg` files
     const fileData = await image.getFileData();
@@ -114,6 +114,12 @@ export class ImageRenderer {
           }
         : {}),
     };
+
+    // Accessible tagging: an image WITH alt text is a Figure; without, it stays untagged and the backend
+    // treats it as decoration (an Artifact). One struct element per image.
+    if (objectManager.struct.enabled && alt) {
+      node.tag = { role: "Figure", key: objectManager.struct.nextKey(), alt };
+    }
 
     return [node];
   }

--- a/src/lib/renderer/image-renderer.ts
+++ b/src/lib/renderer/image-renderer.ts
@@ -118,7 +118,10 @@ export class ImageRenderer {
     // Accessible tagging: an image WITH alt text is a Figure; without, it stays untagged and the backend
     // treats it as decoration (an Artifact). One struct element per image.
     if (objectManager.struct.enabled && alt) {
-      node.tag = { role: "Figure", key: objectManager.struct.nextKey(), alt };
+      node.tag = {
+        role: "Figure",
+        key: objectManager.struct.openElement(imageElement.structId, "Figure", { alt }),
+      };
     }
 
     return [node];

--- a/src/lib/renderer/page-renderer.ts
+++ b/src/lib/renderer/page-renderer.ts
@@ -80,11 +80,12 @@ export class PageRenderer {
         ? "/ExtGState <<\n" + extGStateReferences.join("\n") + "\n>>\n"
         : "";
 
-    // /StructParents ties this page's marked content to the structure tree's ParentTree (tagging only).
-    const structParents = structCtx ? ` /StructParents ${structCtx.structParents}` : "";
+    // Tagging only: /StructParents links this page's marked content to the ParentTree, /Tabs /S makes the
+    // logical structure order the tab/reading order (a PDF/UA requirement).
+    const structAttrs = structCtx ? ` /StructParents ${structCtx.structParents} /Tabs /S` : "";
     const pageObject = `<< /Type /Page /Parent ${parentObjectNumber} 0 R /Contents ${contentObjectNumber} 0 R /Resources <<\n/Font <<\n${fontReferences.join(
       "\n",
-    )}\n>>\n${imageCode}${extGStateCode}>>\n/MediaBox [0 0 ${width} ${height}]${structParents} >>`;
+    )}\n>>\n${imageCode}${extGStateCode}>>\n/MediaBox [0 0 ${width} ${height}]${structAttrs} >>`;
 
     // Add page as new object; register its object number with the struct tree (for /Pg refs), then return it.
     const pageObjNum = objectManager.addObject(pageObject);

--- a/src/lib/renderer/page-renderer.ts
+++ b/src/lib/renderer/page-renderer.ts
@@ -32,7 +32,14 @@ export class PageRenderer {
         nodes.push(...(await renderer(element, objectManager)));
       }
     }
-    const pageContent = PdfBackend.serialize(PdfBackend.flipY(nodes, height), objectManager);
+    // Accessible tagging: one struct context per page (allocates its StructParents index), threaded into
+    // serialize so each drawable node is wrapped in marked content. Undefined = tagging off (byte-identical).
+    const structCtx = objectManager.struct.enabled ? objectManager.struct.beginPage() : undefined;
+    const pageContent = PdfBackend.serialize(
+      PdfBackend.flipY(nodes, height),
+      objectManager,
+      structCtx,
+    );
 
     // Add the page content as a new object (FlateDecode-compressed when enabled). The /Length is
     // computed inside, with an explicit EOL before `endstream` (PDF/A clause 6.1.7.1).
@@ -73,11 +80,15 @@ export class PageRenderer {
         ? "/ExtGState <<\n" + extGStateReferences.join("\n") + "\n>>\n"
         : "";
 
+    // /StructParents ties this page's marked content to the structure tree's ParentTree (tagging only).
+    const structParents = structCtx ? ` /StructParents ${structCtx.structParents}` : "";
     const pageObject = `<< /Type /Page /Parent ${parentObjectNumber} 0 R /Contents ${contentObjectNumber} 0 R /Resources <<\n/Font <<\n${fontReferences.join(
       "\n",
-    )}\n>>\n${imageCode}${extGStateCode}>>\n/MediaBox [0 0 ${width} ${height}] >>`;
+    )}\n>>\n${imageCode}${extGStateCode}>>\n/MediaBox [0 0 ${width} ${height}]${structParents} >>`;
 
-    // Add page as new object and return the page number
-    return objectManager.addObject(pageObject);
+    // Add page as new object; register its object number with the struct tree (for /Pg refs), then return it.
+    const pageObjNum = objectManager.addObject(pageObject);
+    if (structCtx) objectManager.struct.setPageObject(structCtx.structParents, pageObjNum);
+    return pageObjNum;
   }
 }

--- a/src/lib/renderer/pdf-backend.ts
+++ b/src/lib/renderer/pdf-backend.ts
@@ -1,5 +1,6 @@
 import { IRNode } from "../ir/display-list.ts";
 import { PDFObjectManager } from "../utils/pdf-object-manager.ts";
+import type { PageStructContext } from "../utils/struct-tree.ts";
 
 /**
  * PDF backend - turns display-list primitives into content-stream operators.
@@ -55,9 +56,20 @@ export class PdfBackend {
     });
   }
 
-  /** Serialize a whole display list into one content stream (page-level entry point). */
-  static serialize(nodes: IRNode[], om: PDFObjectManager): string {
-    return nodes.map((node) => PdfBackend.serializeNode(node, om)).join("");
+  /** Serialize a whole display list into one content stream (page-level entry point). When a
+   *  `PageStructContext` is given (accessible tagging on), each drawable node is wrapped in a marked-content
+   *  sequence (`/Role <</MCID n>> BDC … EMC`, or `/Artifact` when untagged); graphics-state and empty nodes
+   *  pass through untouched, so untagged output stays byte-identical. */
+  static serialize(nodes: IRNode[], om: PDFObjectManager, struct?: PageStructContext): string {
+    return nodes
+      .map((node) => {
+        const ops = PdfBackend.serializeNode(node, om);
+        if (!struct || node.type === "clip-push" || node.type === "clip-pop" || ops === "")
+          return ops;
+        const { open, close } = struct.mark(node.tag);
+        return open + ops + close;
+      })
+      .join("");
   }
 
   /**

--- a/src/lib/renderer/pdf-renderer.ts
+++ b/src/lib/renderer/pdf-renderer.ts
@@ -100,7 +100,11 @@ export class PDFRenderer {
     // Accessible tagging: finalize the structure tree (emits StructTreeRoot + StructElems + ParentTree) and
     // fold /MarkInfo + /StructTreeRoot + /Lang into the catalog. Returns "" (no-op) when tagging is off.
     const structCatalog = objectManager.struct.finalize(objectManager);
-    if (structCatalog) catalogParts.push(structCatalog);
+    if (structCatalog) {
+      catalogParts.push(structCatalog);
+      // PDF/UA requires the viewer to show the document title (not the file name).
+      catalogParts.push("/ViewerPreferences << /DisplayDocTitle true >>");
+    }
 
     const catalogObject = `<< ${catalogParts.join(" ")} >>`;
     objectManager.addObject(catalogObject);

--- a/src/lib/renderer/pdf-renderer.ts
+++ b/src/lib/renderer/pdf-renderer.ts
@@ -28,6 +28,8 @@ import { DeferredElement } from "../elements/layout/deferred-element.ts";
 import { DeferredRenderer } from "./deferred-renderer.ts";
 import { PositionedElement } from "../elements/layout/positioned-element.ts";
 import { PositionedRenderer } from "./positioned-renderer.ts";
+import { StructGroup } from "../elements/layout/struct-group.ts";
+import { StructGroupRenderer } from "./struct-group-renderer.ts";
 import { BoxConstraints } from "../layout/box-constraints.ts";
 import { LayoutContext } from "../elements/pdf-element.ts";
 import { DEFAULT_TEXT_STYLE, mergeTextStyle } from "../text/text-style.ts";
@@ -50,6 +52,7 @@ export class PDFRenderer {
     RendererRegistry.register(RepeatingHeaderElement, RepeatingHeaderRenderer.render);
     RendererRegistry.register(DeferredElement, DeferredRenderer.render);
     RendererRegistry.register(PositionedElement, PositionedRenderer.render);
+    RendererRegistry.register(StructGroup, StructGroupRenderer.render);
 
     let pdfContent = "";
 

--- a/src/lib/renderer/pdf-renderer.ts
+++ b/src/lib/renderer/pdf-renderer.ts
@@ -94,6 +94,11 @@ export class PDFRenderer {
       catalogParts.push(`/AF [${af}]`, `/Names << /EmbeddedFiles << /Names [${names}] >> >>`);
     }
 
+    // Accessible tagging: finalize the structure tree (emits StructTreeRoot + StructElems + ParentTree) and
+    // fold /MarkInfo + /StructTreeRoot + /Lang into the catalog. Returns "" (no-op) when tagging is off.
+    const structCatalog = objectManager.struct.finalize(objectManager);
+    if (structCatalog) catalogParts.push(structCatalog);
+
     const catalogObject = `<< ${catalogParts.join(" ")} >>`;
     objectManager.addObject(catalogObject);
 

--- a/src/lib/renderer/struct-group-renderer.ts
+++ b/src/lib/renderer/struct-group-renderer.ts
@@ -1,0 +1,27 @@
+import { StructGroup } from "../elements/layout/struct-group.ts";
+import { PDFObjectManager } from "../utils/pdf-object-manager.ts";
+import { IRNode } from "../ir/display-list.ts";
+import { RendererRegistry } from "../utils/renderer-registry.ts";
+
+/**
+ * Renders a StructGroup: opens its structure element, renders the child under it, closes it. With accessible
+ * tagging off it is fully transparent - just the child's IR.
+ */
+export class StructGroupRenderer {
+  static async render(group: StructGroup, objectManager: PDFObjectManager): Promise<IRNode[]> {
+    const { role, child } = group.getProps();
+    const renderChild = async (): Promise<IRNode[]> => {
+      const renderer = RendererRegistry.getRenderer(child);
+      return renderer ? await renderer(child, objectManager) : [];
+    };
+    if (!objectManager.struct.enabled) return renderChild();
+
+    const key = objectManager.struct.openElement(group.structId, role);
+    objectManager.struct.push(key);
+    try {
+      return await renderChild();
+    } finally {
+      objectManager.struct.pop(); // keep the parent stack balanced even if a child throws
+    }
+  }
+}

--- a/src/lib/renderer/text-renderer.ts
+++ b/src/lib/renderer/text-renderer.ts
@@ -97,8 +97,9 @@ export class TextRenderer {
     // Accessible tagging: every line of this text block is one paragraph (P), grouped under one struct key.
     // (Heading levels + other roles are a later slice; the default role is P.)
     if (objectManager.struct.enabled) {
-      const key = objectManager.struct.nextKey();
       const pdfRole = role ? role.toUpperCase() : "P"; // "h1" -> "H1"; default paragraph
+      // Keyed by the element's structId so a paragraph split across pages stays one P (MCIDs from each page).
+      const key = objectManager.struct.openElement(textElement.structId, pdfRole);
       for (const run of runs) run.tag = { role: pdfRole, key };
     }
     return runs;

--- a/src/lib/renderer/text-renderer.ts
+++ b/src/lib/renderer/text-renderer.ts
@@ -73,6 +73,7 @@ export class TextRenderer {
       maxLines,
       overflow,
       lineHeight,
+      role,
     } = textElement.getProps();
 
     // Component -> display list. Wrapping and positioning stay here; the backend
@@ -97,7 +98,8 @@ export class TextRenderer {
     // (Heading levels + other roles are a later slice; the default role is P.)
     if (objectManager.struct.enabled) {
       const key = objectManager.struct.nextKey();
-      for (const run of runs) run.tag = { role: "P", key };
+      const pdfRole = role ? role.toUpperCase() : "P"; // "h1" -> "H1"; default paragraph
+      for (const run of runs) run.tag = { role: pdfRole, key };
     }
     return runs;
   }

--- a/src/lib/renderer/text-renderer.ts
+++ b/src/lib/renderer/text-renderer.ts
@@ -78,7 +78,7 @@ export class TextRenderer {
     // Component -> display list. Wrapping and positioning stay here; the backend
     // turns each run into BT/Tf/Td/Tj/ET. The wrapping algorithm is unchanged from
     // the original renderer - unifying it into the engine is Phase 3.
-    return TextRenderer._buildRuns(
+    const runs = TextRenderer._buildRuns(
       content,
       fontSize,
       fontFamily,
@@ -93,6 +93,13 @@ export class TextRenderer {
       overflow,
       lineHeight,
     );
+    // Accessible tagging: every line of this text block is one paragraph (P), grouped under one struct key.
+    // (Heading levels + other roles are a later slice; the default role is P.)
+    if (objectManager.struct.enabled) {
+      const key = objectManager.struct.nextKey();
+      for (const run of runs) run.tag = { role: "P", key };
+    }
+    return runs;
   }
 
   // Lay the content out into absolutely-positioned text runs. Glyph positions match

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -769,10 +769,6 @@ endstream`;
     return width;
   }
 
-  private getCharCode(char: string): string {
-    return char.charCodeAt(0).toString();
-  }
-
   private getAVMParserByFont(fullFontName?: string, fontName?: string, fontStyle?: FontStyle) {
     // A non-string family means font bytes were passed where a name belongs - hint at the fix instead of
     // stringifying the byte blob into an unreadable "parser not found".

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -218,8 +218,7 @@ export class PDFObjectManager implements FontMetrics {
   private encJobs: Uint8Array[] = [];
   private encryptObjNum?: number;
 
-  // Accessible (PDF/UA) tagging. Off by default (byte-identical output); the API turns it on. The backend
-  // records marked content here during serialize; PDFRenderer finalizes the structure tree into the catalog.
+  // Accessible (PDF/UA) tagging, off by default (byte-identical output); the API turns it on.
   private _struct = new StructTree();
   get struct(): StructTree {
     return this._struct;

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -9,6 +9,7 @@ import { TTFParser } from "./ttf-parser.ts";
 import { subsetTTF } from "./ttf-subsetter.ts";
 import { getArrayBuffer } from "./utf8-to-windows1252-encoder.ts";
 import type { SecurityHandler } from "../crypto/security-handler.ts";
+import { StructTree } from "./struct-tree.ts";
 // Enums come from the leaf config module (never in a cycle); the config type is
 // erased at runtime so it can come from the cyclic module safely.
 import { ColorMode, Orientation } from "../renderer/pdf-config.ts";
@@ -216,6 +217,13 @@ export class PDFObjectManager implements FontMetrics {
   private security?: SecurityHandler;
   private encJobs: Uint8Array[] = [];
   private encryptObjNum?: number;
+
+  // Accessible (PDF/UA) tagging. Off by default (byte-identical output); the API turns it on. The backend
+  // records marked content here during serialize; PDFRenderer finalizes the structure tree into the catalog.
+  private _struct = new StructTree();
+  get struct(): StructTree {
+    return this._struct;
+  }
 
   constructor();
   constructor(pageSize?: PageSize) {

--- a/src/lib/utils/struct-tree.ts
+++ b/src/lib/utils/struct-tree.ts
@@ -1,23 +1,25 @@
 import type { StructTag } from "../ir/display-list.ts";
 import type { PDFObjectManager } from "./pdf-object-manager.ts";
 
-// The structure tree for accessible (PDF/UA) tagging: a StructTreeRoot -> Document -> per-element StructElem
-// graph, plus the ParentTree that maps each page's marked-content ids (MCIDs) back to their StructElem. The
-// engine owns all of this; components only declare a `role` on the IR (see StructTag). New elements become
-// taggable just by tagging their IR - nothing here needs to change.
+// The structure tree for accessible (PDF/UA) tagging: a StructTreeRoot -> Document -> nested StructElem
+// graph, plus the ParentTree that maps each page's marked-content ids (MCIDs) back to their StructElem.
+//
+// The tree is built DURING the render pass: leaves (a paragraph, a figure) and containers (a table, a row,
+// a cell) both register via openElement(); containers additionally push()/pop() around their children so
+// descendants attach to them (the render pass is sequential depth-first, so a simple stack is exact).
 
-interface McRecord {
-  key: number; // logical-element key (groups the IR nodes of one element)
+interface StructElem {
+  key: number;
   role: string;
   alt?: string;
-  structParents: number; // the page's StructParents index
-  mcid: number; // page-local marked-content id
+  parent?: number; // parent element key; undefined = a direct child of the Document
+  mc: { structParents: number; mcid: number }[]; // marked-content pieces (for leaves)
 }
 
 // Escapes a PDF literal string ( ... ) - the language tag is safe ASCII, but /Alt can carry arbitrary text.
 const esc = (s: string) => s.replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)");
 
-/** Per-page tagging context: hands out page-local MCIDs and records which StructElem owns each. */
+/** Per-page tagging context: hands out page-local MCIDs and links them to their StructElem. */
 export class PageStructContext {
   private mcid = 0;
   constructor(
@@ -25,18 +27,13 @@ export class PageStructContext {
     private readonly tree: StructTree,
   ) {}
 
-  /** Marked-content delimiters for one drawable node. Tagged content gets an MCID + a record; untagged
-   *  content becomes an Artifact (decoration, skipped by assistive technology). */
+  /** Marked-content delimiters for one drawable node. Tagged content gets an MCID linked to its (already
+   *  registered) StructElem; untagged content becomes an Artifact (decoration, skipped by assistive tech). */
   mark(tag?: StructTag): { open: string; close: string } {
-    if (!tag) return { open: "/Artifact BDC\n", close: "EMC\n" };
+    // Artifact = decoration, no properties -> BMC (BDC would need a second operand and is a syntax error).
+    if (!tag) return { open: "/Artifact BMC\n", close: "EMC\n" };
     const mcid = this.mcid++;
-    this.tree.record({
-      key: tag.key,
-      role: tag.role,
-      alt: tag.alt,
-      structParents: this.structParents,
-      mcid,
-    });
+    this.tree.linkMarkedContent(tag.key, this.structParents, mcid);
     return { open: `/${tag.role} <</MCID ${mcid}>> BDC\n`, close: "EMC\n" };
   }
 }
@@ -46,17 +43,39 @@ export class StructTree {
   enabled = false;
   lang = "en-US";
   title?: string;
-  private keyCounter = 0;
+  private counter = 0;
   private structParentsCounter = 0;
-  private records: McRecord[] = [];
+  private elems = new Map<number, StructElem>(); // insertion order = render order = reading order
+  private byStructId = new Map<number, number>(); // element structId -> element key (dedup across pages)
+  private stack: number[] = []; // open containers; top is the current parent
   private pageObjByStructParents = new Map<number, number>();
 
-  /** A fresh logical-element key - groups the IR nodes of one element (e.g. a paragraph's lines) into one StructElem. */
-  nextKey(): number {
-    return this.keyCounter++;
+  /** Register a structure element for a logical element (keyed by its stable `structId`, so a paragraph or
+   *  table split across pages resolves to the SAME element - MCIDs then accrue from every page). Its parent
+   *  is the currently-open container, else the Document. Containers also push()/pop() around their children. */
+  openElement(structId: number, role: string, opts?: { alt?: string }): number {
+    const existing = this.byStructId.get(structId);
+    if (existing !== undefined) return existing; // already opened on an earlier page/fragment
+    const key = this.counter++;
+    this.byStructId.set(structId, key);
+    this.elems.set(key, {
+      key,
+      role,
+      alt: opts?.alt,
+      parent: this.stack[this.stack.length - 1],
+      mc: [],
+    });
+    return key;
   }
 
-  /** Begin a page: allocate its StructParents index. Returns the per-page tagging context. */
+  push(key: number): void {
+    this.stack.push(key);
+  }
+  pop(): void {
+    this.stack.pop();
+  }
+
+  /** Begin a page: allocates its StructParents index (its slot in the ParentTree). */
   beginPage(): PageStructContext {
     return new PageStructContext(this.structParentsCounter++, this);
   }
@@ -66,72 +85,67 @@ export class StructTree {
     this.pageObjByStructParents.set(structParents, pageObjNum);
   }
 
-  record(r: McRecord): void {
-    this.records.push(r);
+  /** Link a page-local MCID to an element (called by the backend while serializing). */
+  linkMarkedContent(key: number, structParents: number, mcid: number): void {
+    this.elems.get(key)?.mc.push({ structParents, mcid });
   }
 
   /** Emit the struct-tree objects and return the catalog additions (`/MarkInfo`, `/StructTreeRoot`, `/Lang`).
    *  A no-op returning "" when disabled or nothing was tagged, so a plain document stays byte-identical. */
   finalize(om: PDFObjectManager): string {
-    if (!this.enabled || this.records.length === 0) return "";
-
-    // Group records into elements by key, preserving first-seen (reading) order.
-    const order: number[] = [];
-    const byKey = new Map<number, { role: string; alt?: string; refs: McRecord[] }>();
-    for (const r of this.records) {
-      let e = byKey.get(r.key);
-      if (!e) {
-        e = { role: r.role, alt: r.alt, refs: [] };
-        byKey.set(r.key, e);
-        order.push(r.key);
-      }
-      e.refs.push(r);
-    }
+    if (!this.enabled || this.elems.size === 0) return "";
 
     // Reserve object numbers first - root <-> Document <-> elements <-> ParentTree reference each other.
     const rootNum = om.addObject("");
     const docNum = om.addObject("");
     const parentTreeNum = om.addObject("");
-    const elemNum = new Map<number, number>();
-    for (const key of order) elemNum.set(key, om.addObject(""));
+    const objNum = new Map<number, number>();
+    for (const key of this.elems.keys()) objNum.set(key, om.addObject(""));
 
     const pg = (structParents: number) => this.pageObjByStructParents.get(structParents)!;
+    const childrenOf = (parent: number | undefined) =>
+      [...this.elems.values()].filter((e) => e.parent === parent); // Map order = reading order
 
-    // One StructElem per logical element, its kids the marked-content references (MCR) on their pages.
-    for (const key of order) {
-      const e = byKey.get(key)!;
-      const kids = e.refs
-        .map((r) => `<< /Type /MCR /Pg ${pg(r.structParents)} 0 R /MCID ${r.mcid} >>`)
-        .join(" ");
+    // One StructElem per registered element: /K = its child elements ++ its marked-content references.
+    for (const e of this.elems.values()) {
+      const kids = [
+        ...childrenOf(e.key).map((c) => `${objNum.get(c.key)!} 0 R`),
+        ...e.mc.map((m) => `<< /Type /MCR /Pg ${pg(m.structParents)} 0 R /MCID ${m.mcid} >>`),
+      ].join(" ");
       const alt = e.alt ? ` /Alt (${esc(e.alt)})` : "";
+      const parentRef = e.parent !== undefined ? objNum.get(e.parent)! : docNum;
       om.replaceObject(
-        elemNum.get(key)!,
-        `<< /Type /StructElem /S /${e.role} /P ${docNum} 0 R${alt} /K [ ${kids} ] >>`,
+        objNum.get(e.key)!,
+        `<< /Type /StructElem /S /${e.role} /P ${parentRef} 0 R${alt} /K [ ${kids} ] >>`,
       );
     }
 
-    // The Document element wraps every element in reading order.
-    const docKids = order.map((k) => `${elemNum.get(k)!} 0 R`).join(" ");
+    // The Document element wraps the top-level elements in reading order.
+    const docKids = childrenOf(undefined)
+      .map((e) => `${objNum.get(e.key)!} 0 R`)
+      .join(" ");
     om.replaceObject(
       docNum,
       `<< /Type /StructElem /S /Document /P ${rootNum} 0 R /K [ ${docKids} ] >>`,
     );
 
     // ParentTree: for each page (StructParents index), an array where [mcid] = the owning StructElem.
-    const bySp = new Map<number, McRecord[]>();
-    for (const r of this.records) {
-      const list = bySp.get(r.structParents) ?? [];
-      list.push(r);
-      bySp.set(r.structParents, list);
+    const byPage = new Map<number, { mcid: number; key: number }[]>();
+    for (const e of this.elems.values()) {
+      for (const m of e.mc) {
+        const list = byPage.get(m.structParents) ?? [];
+        list.push({ mcid: m.mcid, key: e.key });
+        byPage.set(m.structParents, list);
+      }
     }
-    const nums = [...bySp.keys()]
+    const nums = [...byPage.keys()]
       .sort((a, b) => a - b)
       .map((sp) => {
-        const refs = bySp
+        const refs = byPage
           .get(sp)!
           .slice()
           .sort((a, b) => a.mcid - b.mcid)
-          .map((r) => `${elemNum.get(r.key)!} 0 R`)
+          .map((r) => `${objNum.get(r.key)!} 0 R`)
           .join(" ");
         return `${sp} [ ${refs} ]`;
       });

--- a/src/lib/utils/struct-tree.ts
+++ b/src/lib/utils/struct-tree.ts
@@ -113,10 +113,13 @@ export class StructTree {
         ...e.mc.map((m) => `<< /Type /MCR /Pg ${pg(m.structParents)} 0 R /MCID ${m.mcid} >>`),
       ].join(" ");
       const alt = e.alt ? ` /Alt (${esc(e.alt)})` : "";
+      // PDF/UA 7.5: a header cell needs a Scope so a reader can associate data cells with it. Our headers
+      // are a header ROW (the Table `header` option), so each TH is the head of its Column.
+      const attr = e.role === "TH" ? " /A << /O /Table /Scope /Column >>" : "";
       const parentRef = e.parent !== undefined ? objNum.get(e.parent)! : docNum;
       om.replaceObject(
         objNum.get(e.key)!,
-        `<< /Type /StructElem /S /${e.role} /P ${parentRef} 0 R${alt} /K [ ${kids} ] >>`,
+        `<< /Type /StructElem /S /${e.role} /P ${parentRef} 0 R${alt}${attr} /K [ ${kids} ] >>`,
       );
     }
 

--- a/src/lib/utils/struct-tree.ts
+++ b/src/lib/utils/struct-tree.ts
@@ -19,6 +19,11 @@ interface StructElem {
 // Escapes a PDF literal string ( ... ) - the language tag is safe ASCII, but /Alt can carry arbitrary text.
 const esc = (s: string) => s.replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)");
 
+// A structure role reaches the PDF as a raw name (/H1, /S /Table). Roles come from a controlled set,
+// but restrict them to a safe PDF-name token anyway (defence-in-depth) so a stray "/", whitespace, or
+// operator can never corrupt the content stream / object dictionary. Empty after stripping -> /Span.
+const roleName = (role: string): string => role.replace(/[^A-Za-z0-9]/g, "") || "Span";
+
 /** Per-page tagging context: hands out page-local MCIDs and links them to their StructElem. */
 export class PageStructContext {
   private mcid = 0;
@@ -34,7 +39,7 @@ export class PageStructContext {
     if (!tag) return { open: "/Artifact BMC\n", close: "EMC\n" };
     const mcid = this.mcid++;
     this.tree.linkMarkedContent(tag.key, this.structParents, mcid);
-    return { open: `/${tag.role} <</MCID ${mcid}>> BDC\n`, close: "EMC\n" };
+    return { open: `/${roleName(tag.role)} <</MCID ${mcid}>> BDC\n`, close: "EMC\n" };
   }
 }
 
@@ -119,7 +124,7 @@ export class StructTree {
       const parentRef = e.parent !== undefined ? objNum.get(e.parent)! : docNum;
       om.replaceObject(
         objNum.get(e.key)!,
-        `<< /Type /StructElem /S /${e.role} /P ${parentRef} 0 R${alt}${attr} /K [ ${kids} ] >>`,
+        `<< /Type /StructElem /S /${roleName(e.role)} /P ${parentRef} 0 R${alt}${attr} /K [ ${kids} ] >>`,
       );
     }
 

--- a/src/lib/utils/struct-tree.ts
+++ b/src/lib/utils/struct-tree.ts
@@ -1,0 +1,148 @@
+import type { StructTag } from "../ir/display-list.ts";
+import type { PDFObjectManager } from "./pdf-object-manager.ts";
+
+// The structure tree for accessible (PDF/UA) tagging: a StructTreeRoot -> Document -> per-element StructElem
+// graph, plus the ParentTree that maps each page's marked-content ids (MCIDs) back to their StructElem. The
+// engine owns all of this; components only declare a `role` on the IR (see StructTag). New elements become
+// taggable just by tagging their IR - nothing here needs to change.
+
+interface McRecord {
+  key: number; // logical-element key (groups the IR nodes of one element)
+  role: string;
+  alt?: string;
+  structParents: number; // the page's StructParents index
+  mcid: number; // page-local marked-content id
+}
+
+// Escapes a PDF literal string ( ... ) - the language tag is safe ASCII, but /Alt can carry arbitrary text.
+const esc = (s: string) => s.replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)");
+
+/** Per-page tagging context: hands out page-local MCIDs and records which StructElem owns each. */
+export class PageStructContext {
+  private mcid = 0;
+  constructor(
+    readonly structParents: number,
+    private readonly tree: StructTree,
+  ) {}
+
+  /** Marked-content delimiters for one drawable node. Tagged content gets an MCID + a record; untagged
+   *  content becomes an Artifact (decoration, skipped by assistive technology). */
+  mark(tag?: StructTag): { open: string; close: string } {
+    if (!tag) return { open: "/Artifact BDC\n", close: "EMC\n" };
+    const mcid = this.mcid++;
+    this.tree.record({
+      key: tag.key,
+      role: tag.role,
+      alt: tag.alt,
+      structParents: this.structParents,
+      mcid,
+    });
+    return { open: `/${tag.role} <</MCID ${mcid}>> BDC\n`, close: "EMC\n" };
+  }
+}
+
+/** Builds the PDF structure tree for accessible tagging. One instance per document (held by the object manager). */
+export class StructTree {
+  enabled = false;
+  lang = "en-US";
+  title?: string;
+  private keyCounter = 0;
+  private structParentsCounter = 0;
+  private records: McRecord[] = [];
+  private pageObjByStructParents = new Map<number, number>();
+
+  /** A fresh logical-element key - groups the IR nodes of one element (e.g. a paragraph's lines) into one StructElem. */
+  nextKey(): number {
+    return this.keyCounter++;
+  }
+
+  /** Begin a page: allocate its StructParents index. Returns the per-page tagging context. */
+  beginPage(): PageStructContext {
+    return new PageStructContext(this.structParentsCounter++, this);
+  }
+
+  /** Tie a page's StructParents index to its now-known page object number (for /Pg references). */
+  setPageObject(structParents: number, pageObjNum: number): void {
+    this.pageObjByStructParents.set(structParents, pageObjNum);
+  }
+
+  record(r: McRecord): void {
+    this.records.push(r);
+  }
+
+  /** Emit the struct-tree objects and return the catalog additions (`/MarkInfo`, `/StructTreeRoot`, `/Lang`).
+   *  A no-op returning "" when disabled or nothing was tagged, so a plain document stays byte-identical. */
+  finalize(om: PDFObjectManager): string {
+    if (!this.enabled || this.records.length === 0) return "";
+
+    // Group records into elements by key, preserving first-seen (reading) order.
+    const order: number[] = [];
+    const byKey = new Map<number, { role: string; alt?: string; refs: McRecord[] }>();
+    for (const r of this.records) {
+      let e = byKey.get(r.key);
+      if (!e) {
+        e = { role: r.role, alt: r.alt, refs: [] };
+        byKey.set(r.key, e);
+        order.push(r.key);
+      }
+      e.refs.push(r);
+    }
+
+    // Reserve object numbers first - root <-> Document <-> elements <-> ParentTree reference each other.
+    const rootNum = om.addObject("");
+    const docNum = om.addObject("");
+    const parentTreeNum = om.addObject("");
+    const elemNum = new Map<number, number>();
+    for (const key of order) elemNum.set(key, om.addObject(""));
+
+    const pg = (structParents: number) => this.pageObjByStructParents.get(structParents)!;
+
+    // One StructElem per logical element, its kids the marked-content references (MCR) on their pages.
+    for (const key of order) {
+      const e = byKey.get(key)!;
+      const kids = e.refs
+        .map((r) => `<< /Type /MCR /Pg ${pg(r.structParents)} 0 R /MCID ${r.mcid} >>`)
+        .join(" ");
+      const alt = e.alt ? ` /Alt (${esc(e.alt)})` : "";
+      om.replaceObject(
+        elemNum.get(key)!,
+        `<< /Type /StructElem /S /${e.role} /P ${docNum} 0 R${alt} /K [ ${kids} ] >>`,
+      );
+    }
+
+    // The Document element wraps every element in reading order.
+    const docKids = order.map((k) => `${elemNum.get(k)!} 0 R`).join(" ");
+    om.replaceObject(
+      docNum,
+      `<< /Type /StructElem /S /Document /P ${rootNum} 0 R /K [ ${docKids} ] >>`,
+    );
+
+    // ParentTree: for each page (StructParents index), an array where [mcid] = the owning StructElem.
+    const bySp = new Map<number, McRecord[]>();
+    for (const r of this.records) {
+      const list = bySp.get(r.structParents) ?? [];
+      list.push(r);
+      bySp.set(r.structParents, list);
+    }
+    const nums = [...bySp.keys()]
+      .sort((a, b) => a - b)
+      .map((sp) => {
+        const refs = bySp
+          .get(sp)!
+          .slice()
+          .sort((a, b) => a.mcid - b.mcid)
+          .map((r) => `${elemNum.get(r.key)!} 0 R`)
+          .join(" ");
+        return `${sp} [ ${refs} ]`;
+      });
+    om.replaceObject(parentTreeNum, `<< /Nums [ ${nums.join(" ")} ] >>`);
+
+    om.replaceObject(
+      rootNum,
+      `<< /Type /StructTreeRoot /K ${docNum} 0 R /ParentTree ${parentTreeNum} 0 R ` +
+        `/ParentTreeNextKey ${this.structParentsCounter} >>`,
+    );
+
+    return `/MarkInfo << /Marked true >> /StructTreeRoot ${rootNum} 0 R /Lang (${esc(this.lang)})`;
+  }
+}

--- a/src/lib/utils/ua-xmp.ts
+++ b/src/lib/utils/ua-xmp.ts
@@ -1,14 +1,26 @@
-const esc = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+// Escapes text for XML AND keeps the packet ASCII-safe: XML metacharacters become entities, and any
+// non-ASCII / control character becomes a numeric character reference. The PDF writer emits the
+// metadata stream one byte per char (Latin-1), so a raw non-ASCII title like "R\u00E9sum\u00E9" would corrupt
+// the UTF-8 XMP (and misalign /Length); escaping keeps every char <= 0x7e.
+const esc = (s: string): string =>
+  s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/[^ -~]/gu, (c) => `&#${c.codePointAt(0)};`); // any non printable-ASCII char
 
 /**
  * XMP metadata packet that identifies the document as PDF/UA-1 (accessible). A fully conformant PDF/UA file
  * also needs a displayed title (the /ViewerPreferences /DisplayDocTitle flag + this dc:title) and embedded
- * fonts - the same font rule PDF/A has, so the standard-14 fonts do not qualify.
+ * fonts - the same font rule PDF/A has, so the standard-14 fonts do not qualify. Language is declared once
+ * in the catalog `/Lang`, not here (the dc:title uses `x-default`), so this takes only the title.
  */
-export function uaXmp(opts: { title?: string; lang?: string } = {}): string {
+export function uaXmp(opts: { title?: string } = {}): string {
   const title = esc(opts.title ?? "");
   return (
-    `<?xpacket begin="\uFEFF" id="W5M0MpCehiHzreSzNTczkc9d"?>` +
+    // The xpacket marker is the 3-byte UTF-8 BOM (EF BB BF) written as Latin-1 chars so the
+    // single-byte writer emits it verbatim - a literal U+FEFF would be mangled to "?".
+    `<?xpacket begin="\u00EF\u00BB\u00BF" id="W5M0MpCehiHzreSzNTczkc9d"?>` +
     `<x:xmpmeta xmlns:x="adobe:ns:meta/">` +
     `<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">` +
     `<rdf:Description rdf:about="" xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/">` +

--- a/src/lib/utils/ua-xmp.ts
+++ b/src/lib/utils/ua-xmp.ts
@@ -1,0 +1,23 @@
+const esc = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+/**
+ * XMP metadata packet that identifies the document as PDF/UA-1 (accessible). A fully conformant PDF/UA file
+ * also needs a displayed title (the /ViewerPreferences /DisplayDocTitle flag + this dc:title) and embedded
+ * fonts - the same font rule PDF/A has, so the standard-14 fonts do not qualify.
+ */
+export function uaXmp(opts: { title?: string; lang?: string } = {}): string {
+  const title = esc(opts.title ?? "");
+  return (
+    `<?xpacket begin="\uFEFF" id="W5M0MpCehiHzreSzNTczkc9d"?>` +
+    `<x:xmpmeta xmlns:x="adobe:ns:meta/">` +
+    `<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">` +
+    `<rdf:Description rdf:about="" xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/">` +
+    `<pdfuaid:part>1</pdfuaid:part>` +
+    `</rdf:Description>` +
+    `<rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/">` +
+    `<dc:title><rdf:Alt><rdf:li xml:lang="x-default">${title}</rdf:li></rdf:Alt></dc:title>` +
+    `</rdf:Description>` +
+    `</rdf:RDF></x:xmpmeta>` +
+    `<?xpacket end="w"?>`
+  );
+}

--- a/tests/unit/api/table.test.ts
+++ b/tests/unit/api/table.test.ts
@@ -7,9 +7,15 @@ import { ExpandedElement } from "../../../src/lib/elements/layout/expanded-eleme
 import { RepeatingHeaderElement } from "../../../src/lib/elements/layout/repeating-header-element";
 import { DeferredElement } from "../../../src/lib/elements/layout/deferred-element";
 import { PDFElement } from "../../../src/lib/elements/pdf-element";
+import { StructGroup } from "../../../src/lib/elements/layout/struct-group";
 
-const rowsOf = (t: PDFElement) => (t.getProps() as { children: RowElement[] }).children;
-const cellsOf = (r: RowElement) => (r.getProps() as { children: unknown[] }).children;
+// Tables now wrap the table / rows / cells in layout-transparent StructGroups (accessibility). These
+// helpers see through them, so the tests still assert the underlying Column / Row / Box structure.
+const unwrap = (el: PDFElement): PDFElement =>
+  el instanceof StructGroup ? unwrap((el.getProps() as { child: PDFElement }).child) : el;
+const rowsOf = (t: PDFElement) =>
+  (unwrap(t).getProps() as { children: PDFElement[] }).children.map(unwrap) as RowElement[];
+const cellsOf = (r: RowElement) => (unwrap(r).getProps() as { children: unknown[] }).children;
 
 describe("Table factory", () => {
   it("is a Column of Rows (one Row per data row)", () => {
@@ -17,7 +23,7 @@ describe("Table factory", () => {
       ["a", "b"],
       ["c", "d"],
     ]);
-    expect(t).toBeInstanceOf(ContainerElement);
+    expect(unwrap(t)).toBeInstanceOf(ContainerElement);
     const rows = rowsOf(t);
     expect(rows).toHaveLength(2);
     expect(rows[0]).toBeInstanceOf(RowElement);
@@ -35,7 +41,7 @@ describe("Table factory", () => {
   it("string cells are wrapped in Text", () => {
     const t = Table({ columns: [100] }, [["hello"]]);
     const box = cellsOf(rowsOf(t)[0])[0] as RectangleElement;
-    const inner = (box.getProps().children as unknown[])[0];
+    const inner = unwrap((box.getProps().children as PDFElement[])[0]); // Box > StructGroup(TD) > Text
     expect((inner as { getProps(): { content: unknown } }).getProps().content).toBe("hello");
   });
 
@@ -44,7 +50,7 @@ describe("Table factory", () => {
       ["a", "b"],
       ["c", "d"],
     ]);
-    expect((t.getProps() as { gap: number }).gap).toBe(8); // rowGap falls back to gap
+    expect((unwrap(t).getProps() as { gap: number }).gap).toBe(8); // rowGap falls back to gap
     expect((rowsOf(t)[0].getProps() as { gap: number }).gap).toBe(4); // colGap overrides
   });
 
@@ -80,8 +86,8 @@ describe("Table factory", () => {
   });
 
   it("a `header` option returns a repeating-header element; without it, a plain Column", () => {
-    expect(Table({ columns: ["1fr"] }, [["a"]])).toBeInstanceOf(ContainerElement);
-    expect(Table({ columns: ["1fr"], header: ["H"] }, [["a"]])).toBeInstanceOf(
+    expect(unwrap(Table({ columns: ["1fr"] }, [["a"]]))).toBeInstanceOf(ContainerElement);
+    expect(unwrap(Table({ columns: ["1fr"], header: ["H"] }, [["a"]]))).toBeInstanceOf(
       RepeatingHeaderElement,
     );
   });

--- a/tests/unit/layout/struct-group.test.ts
+++ b/tests/unit/layout/struct-group.test.ts
@@ -19,20 +19,21 @@ describe("StructGroup fragmentation transparency", () => {
   it("is NOT fragmentable around a non-fragmentable child (a table row moves whole, not clipped)", () => {
     const row = Row({}, []); // a Row is atomic (not fragmentable)
     expect(isFragmentable(row)).toBe(false);
-    expect(isFragmentable(new StructGroup("TR", row))).toBe(false);
+    expect(isFragmentable(new StructGroup({ role: "TR", child: row }))).toBe(false);
   });
 
   it("IS fragmentable around a fragmentable child (the table body paginates)", () => {
     const col = Column({}, [Text("x")]); // a Column fragments (paginates its children)
     expect(isFragmentable(col)).toBe(true);
-    expect(isFragmentable(new StructGroup("Table", col))).toBe(true);
+    expect(isFragmentable(new StructGroup({ role: "Table", child: col }))).toBe(true);
   });
 
   // The actual regression: a tagged table row that doesn't fit must move WHOLE to the next page, never be
   // clipped onto the current one. (Before the canFragment fix, the StructGroup(TR) claimed to be splittable,
   // so packChildren force-placed the whole - too-tall - row into `fitted` and it rendered clipped.)
   it("a tagged row that doesn't fit moves whole to the next page (never clipped)", () => {
-    const tr = () => new StructGroup("TR", Row({}, [Box({ width: 50, height: 100 }, [])]));
+    const tr = () =>
+      new StructGroup({ role: "TR", child: Row({}, [Box({ width: 50, height: 100 }, [])]) });
     const rows = [tr(), tr(), tr()]; // 100pt tall each
     const { fitted, remainder } = packChildren(rows, 250, 200, ctx, 0); // region holds exactly two rows
     expect(fitted).toHaveLength(2); // two whole rows fit

--- a/tests/unit/layout/struct-group.test.ts
+++ b/tests/unit/layout/struct-group.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { StructGroup } from "../../../src/lib/elements/layout/struct-group";
+import { isFragmentable, packChildren } from "../../../src/lib/layout/fragmentation";
+import { Row, Column, Box } from "../../../src/lib/api/layout";
+import { Text } from "../../../src/lib/api/text";
+import { PDFObjectManager } from "../../../src/lib/utils/pdf-object-manager";
+import { DEFAULT_TEXT_STYLE } from "../../../src/lib/text/text-style";
+import type { LayoutContext } from "../../../src/lib/elements/pdf-element";
+
+const om = new PDFObjectManager();
+const ctx: LayoutContext = {
+  metrics: om,
+  pageConfig: om.getPDFConfig(),
+  textStyle: DEFAULT_TEXT_STYLE,
+  onOverflow: "ignore",
+};
+
+describe("StructGroup fragmentation transparency", () => {
+  it("is NOT fragmentable around a non-fragmentable child (a table row moves whole, not clipped)", () => {
+    const row = Row({}, []); // a Row is atomic (not fragmentable)
+    expect(isFragmentable(row)).toBe(false);
+    expect(isFragmentable(new StructGroup("TR", row))).toBe(false);
+  });
+
+  it("IS fragmentable around a fragmentable child (the table body paginates)", () => {
+    const col = Column({}, [Text("x")]); // a Column fragments (paginates its children)
+    expect(isFragmentable(col)).toBe(true);
+    expect(isFragmentable(new StructGroup("Table", col))).toBe(true);
+  });
+
+  // The actual regression: a tagged table row that doesn't fit must move WHOLE to the next page, never be
+  // clipped onto the current one. (Before the canFragment fix, the StructGroup(TR) claimed to be splittable,
+  // so packChildren force-placed the whole - too-tall - row into `fitted` and it rendered clipped.)
+  it("a tagged row that doesn't fit moves whole to the next page (never clipped)", () => {
+    const tr = () => new StructGroup("TR", Row({}, [Box({ width: 50, height: 100 }, [])]));
+    const rows = [tr(), tr(), tr()]; // 100pt tall each
+    const { fitted, remainder } = packChildren(rows, 250, 200, ctx, 0); // region holds exactly two rows
+    expect(fitted).toHaveLength(2); // two whole rows fit
+    expect(remainder).toHaveLength(1); // the third moved whole - NOT clipped into `fitted`
+  });
+});

--- a/tests/unit/renderer/image-renderer.test.ts
+++ b/tests/unit/renderer/image-renderer.test.ts
@@ -277,7 +277,7 @@ describe("ImageRenderer", () => {
     } as unknown as ImageElement;
     const mockObjectManager = {
       registerImage: vi.fn().mockReturnValue(1),
-      struct: { enabled: true, nextKey: () => 7 },
+      struct: { enabled: true, openElement: () => 7 },
     } as unknown as PDFObjectManager;
     vi.spyOn(imageHelper, "applyFitNone").mockReturnValue({
       width: 100,
@@ -286,10 +286,6 @@ describe("ImageRenderer", () => {
       offsetY: 0,
     });
     const [node] = await ImageRenderer.render(mockImageElement, mockObjectManager);
-    expect((node as { tag?: unknown }).tag).toEqual({
-      role: "Figure",
-      key: 7,
-      alt: "a sample photo",
-    });
+    expect((node as { tag?: unknown }).tag).toEqual({ role: "Figure", key: 7 });
   });
 });

--- a/tests/unit/renderer/image-renderer.test.ts
+++ b/tests/unit/renderer/image-renderer.test.ts
@@ -30,6 +30,7 @@ describe("ImageRenderer", () => {
     // Mock PDFObjectManager
     const mockObjectManager = {
       registerImage: vi.fn().mockReturnValue(1),
+      struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
     // Mock applyCoverFit using vi.mock or by mocking the module directly
@@ -85,6 +86,7 @@ describe("ImageRenderer", () => {
     // Mock PDFObjectManager
     const mockObjectManager = {
       registerImage: vi.fn().mockReturnValue(2),
+      struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
     // Mock applyContainFit using vi.spyOn for the whole module
@@ -169,6 +171,7 @@ describe("ImageRenderer", () => {
     // Mock PDFObjectManager
     const mockObjectManager = {
       registerImage: vi.fn().mockReturnValue(3),
+      struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
     // Mock applyFillFit using vi.spyOn for the whole module
@@ -224,6 +227,7 @@ describe("ImageRenderer", () => {
     // Mock PDFObjectManager
     const mockObjectManager = {
       registerImage: vi.fn().mockReturnValue(4),
+      struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
     // Mock applyFitNone using vi.spyOn for the whole module
@@ -253,5 +257,39 @@ describe("ImageRenderer", () => {
 
     expect(result).toContain("q");
     expect(result).toContain("/IM4 Do");
+  });
+  it("tags an image with alt text as a Figure (accessible)", async () => {
+    const mockImageElement = {
+      getProps: vi.fn().mockReturnValue({
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+        image: {
+          init: vi.fn().mockResolvedValue(undefined),
+          getImageType: vi.fn().mockResolvedValue("jpeg"),
+          getFileData: vi.fn().mockResolvedValue("mockImageData"),
+          getImageDimensions: vi.fn().mockResolvedValue({ width: 200, height: 200 }),
+        },
+        fit: BoxFit.none,
+        alt: "a sample photo",
+      }),
+    } as unknown as ImageElement;
+    const mockObjectManager = {
+      registerImage: vi.fn().mockReturnValue(1),
+      struct: { enabled: true, nextKey: () => 7 },
+    } as unknown as PDFObjectManager;
+    vi.spyOn(imageHelper, "applyFitNone").mockReturnValue({
+      width: 100,
+      height: 100,
+      offsetX: 0,
+      offsetY: 0,
+    });
+    const [node] = await ImageRenderer.render(mockImageElement, mockObjectManager);
+    expect((node as { tag?: unknown }).tag).toEqual({
+      role: "Figure",
+      key: 7,
+      alt: "a sample photo",
+    });
   });
 });

--- a/tests/unit/renderer/page-renderer.test.ts
+++ b/tests/unit/renderer/page-renderer.test.ts
@@ -50,6 +50,7 @@ describe("PageRenderer", () => {
       ),
       getAllImagesRaw: vi.fn().mockReturnValue(new Map()),
       getAllExtGStatesRaw: vi.fn().mockReturnValue(new Map()),
+      struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
     const pageNumber = await PageRenderer.render(mockPageElement, mockObjectManager);
@@ -81,6 +82,7 @@ describe("PageRenderer", () => {
       getAllFontsRaw: vi.fn().mockReturnValue(new Map()),
       getAllImagesRaw: vi.fn().mockReturnValue(new Map([["image1", 2]])),
       getAllExtGStatesRaw: vi.fn().mockReturnValue(new Map()),
+      struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
     const pageNumber = await PageRenderer.render(mockPageElement, mockObjectManager);
@@ -132,6 +134,7 @@ describe("PageRenderer", () => {
       ),
       getAllImagesRaw: vi.fn().mockReturnValue(new Map()),
       getAllExtGStatesRaw: vi.fn().mockReturnValue(new Map()),
+      struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
     const pageNumber = await PageRenderer.render(mockPageElement, mockObjectManager);

--- a/tests/unit/renderer/pdf-renderer.test.ts
+++ b/tests/unit/renderer/pdf-renderer.test.ts
@@ -32,6 +32,7 @@ describe("PDFRenderer", () => {
       getHeader: vi.fn().mockReturnValue("%PDF-1.4\n"),
       finalizeCustomFonts: vi.fn(),
       finalizeEncryption: vi.fn().mockResolvedValue(undefined),
+      struct: { enabled: false, finalize: vi.fn().mockReturnValue("") },
     } as unknown as PDFObjectManager;
 
     vi.spyOn(PDFDocumentRenderer, "render").mockResolvedValue(1);

--- a/tests/unit/renderer/struct-group-renderer.test.ts
+++ b/tests/unit/renderer/struct-group-renderer.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { StructGroupRenderer } from "../../../src/lib/renderer/struct-group-renderer";
+import { StructGroup } from "../../../src/lib/elements/layout/struct-group";
+import { RendererRegistry } from "../../../src/lib/utils/renderer-registry";
+import { PDFObjectManager } from "../../../src/lib/utils/pdf-object-manager";
+import { PDFElement } from "../../../src/lib/elements/pdf-element";
+import { IRNode } from "../../../src/lib/ir/display-list";
+
+const group = (): StructGroup =>
+  new StructGroup({ role: "Table", child: {} as unknown as PDFElement });
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("StructGroupRenderer", () => {
+  it("is transparent when accessible tagging is off (no structure element opened)", async () => {
+    const childIR = [{ type: "text" }] as unknown as IRNode[];
+    vi.spyOn(RendererRegistry, "getRenderer").mockReturnValue(vi.fn().mockResolvedValue(childIR));
+    const struct = { enabled: false, openElement: vi.fn(), push: vi.fn(), pop: vi.fn() };
+    const om = { struct } as unknown as PDFObjectManager;
+
+    const out = await StructGroupRenderer.render(group(), om);
+    expect(out).toBe(childIR); // just the child's IR
+    expect(struct.openElement).not.toHaveBeenCalled();
+    expect(struct.push).not.toHaveBeenCalled();
+    expect(struct.pop).not.toHaveBeenCalled();
+  });
+
+  it("opens + pushes the structure element, then always pops - even if the child renderer throws", async () => {
+    vi.spyOn(RendererRegistry, "getRenderer").mockReturnValue(
+      vi.fn().mockRejectedValue(new Error("boom")),
+    );
+    const struct = {
+      enabled: true,
+      openElement: vi.fn().mockReturnValue(7),
+      push: vi.fn(),
+      pop: vi.fn(),
+    };
+    const om = { struct } as unknown as PDFObjectManager;
+
+    await expect(StructGroupRenderer.render(group(), om)).rejects.toThrow("boom");
+    expect(struct.openElement).toHaveBeenCalledWith(expect.any(Number), "Table");
+    expect(struct.push).toHaveBeenCalledWith(7);
+    expect(struct.pop).toHaveBeenCalledTimes(1); // the finally block ran despite the throw
+  });
+});

--- a/tests/unit/renderer/tagged-pdf.test.ts
+++ b/tests/unit/renderer/tagged-pdf.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Document, Page, Column, Box, Text, renderPdf } from "../../../src/lib/index";
+import { Document, Page, Column, Box, Text, Table, mm, renderPdf } from "../../../src/lib/index";
 
 const doc = () =>
   Document([Page({ margin: 40 }, [Column([Text("Heading"), Text("A paragraph of body text.")])])]);
@@ -40,6 +40,34 @@ describe("accessible tagging (PDF/UA foundation)", () => {
     expect(pdf).toContain("/S /H1");
     expect(pdf).toContain("/S /P");
     expect(pdf).toMatch(/\/H1 <<\/MCID \d+>> BDC/);
-    expect(pdf).toContain("/Artifact BDC"); // the box background rect
+    expect(pdf).toContain("/Artifact BMC"); // the box background rect
+  });
+
+  it("keeps a paragraph split across pages as ONE P element (Acrobat-level)", async () => {
+    const long = Array.from(
+      { length: 60 },
+      (_, i) => `Sentence number ${i} of a long paragraph.`,
+    ).join(" ");
+    const doc = Document([Page({ size: mm(80, 45), margin: 8 }, [Text(long)])]);
+    const pdf = await renderPdf(doc, { accessible: true, compress: false });
+    // It paginates onto several physical pages...
+    expect((pdf.match(/\/Type \/Page\b/g) ?? []).length).toBeGreaterThan(1);
+    // ...but the structure tree has exactly ONE P (its content marked across those pages).
+    expect((pdf.match(/\/S \/P\b/g) ?? []).length).toBe(1);
+  });
+
+  it("tags a table as Table > TR > TH/TD, ONE logical Table across pages", async () => {
+    const rows = Array.from({ length: 24 }, (_, i) => [`Item ${i}`, `${i} EUR`]);
+    const doc = Document([
+      Page({ size: mm(95, 55), margin: 8 }, [
+        Table({ columns: ["1fr", "auto"], header: ["Item", "Price"], cellPadding: 4 }, rows),
+      ]),
+    ]);
+    const pdf = await renderPdf(doc, { accessible: true, compress: false });
+    expect((pdf.match(/\/Type \/Page\b/g) ?? []).length).toBeGreaterThan(1); // paginates
+    expect((pdf.match(/\/S \/Table\b/g) ?? []).length).toBe(1); // ONE logical <Table>
+    expect(pdf).toContain("/S /TR");
+    expect(pdf).toContain("/S /TH");
+    expect(pdf).toContain("/S /TD");
   });
 });

--- a/tests/unit/renderer/tagged-pdf.test.ts
+++ b/tests/unit/renderer/tagged-pdf.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { Document, Page, Column, Text, renderPdf } from "../../../src/lib/index";
+
+const doc = () =>
+  Document([Page({ margin: 40 }, [Column([Text("Heading"), Text("A paragraph of body text.")])])]);
+
+describe("accessible tagging (PDF/UA foundation)", () => {
+  it("emits a tagged structure tree when accessible", async () => {
+    const pdf = await renderPdf(doc(), { accessible: true, lang: "de-DE", compress: false });
+    expect(pdf).toContain("/MarkInfo << /Marked true >>");
+    expect(pdf).toContain("/StructTreeRoot");
+    expect(pdf).toContain("/Lang (de-DE)");
+    expect(pdf).toContain("/StructParents");
+    expect(pdf).toContain("/S /Document");
+    expect(pdf).toContain("/S /P");
+    expect(pdf).toMatch(/\/P <<\/MCID \d+>> BDC/);
+    expect(pdf).toContain("EMC");
+    expect(pdf).toContain("/ParentTree");
+  });
+
+  it("does not tag by default (gate off = no structure markers)", async () => {
+    const off = await renderPdf(doc(), { compress: false });
+    const on = await renderPdf(doc(), { accessible: true, compress: false });
+    expect(off).not.toContain("/StructTreeRoot");
+    expect(off).not.toContain("/MarkInfo");
+    expect(off).not.toContain("BDC");
+    expect(on).not.toBe(off); // sanity: tagging did change the output
+  });
+});

--- a/tests/unit/renderer/tagged-pdf.test.ts
+++ b/tests/unit/renderer/tagged-pdf.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Document, Page, Column, Text, renderPdf } from "../../../src/lib/index";
+import { Document, Page, Column, Box, Text, renderPdf } from "../../../src/lib/index";
 
 const doc = () =>
   Document([Page({ margin: 40 }, [Column([Text("Heading"), Text("A paragraph of body text.")])])]);
@@ -25,5 +25,21 @@ describe("accessible tagging (PDF/UA foundation)", () => {
     expect(off).not.toContain("/MarkInfo");
     expect(off).not.toContain("BDC");
     expect(on).not.toBe(off); // sanity: tagging did change the output
+  });
+  it("tags heading roles and auto-marks decoration as an artifact", async () => {
+    const doc = Document([
+      Page({ margin: 40 }, [
+        Column([
+          Text("Title", { role: "h1" }),
+          Text("Body paragraph."),
+          Box({ bg: "#eeeeee", padding: 8 }, [Text("Boxed text.")]),
+        ]),
+      ]),
+    ]);
+    const pdf = await renderPdf(doc, { accessible: true, compress: false });
+    expect(pdf).toContain("/S /H1");
+    expect(pdf).toContain("/S /P");
+    expect(pdf).toMatch(/\/H1 <<\/MCID \d+>> BDC/);
+    expect(pdf).toContain("/Artifact BDC"); // the box background rect
   });
 });

--- a/tests/unit/renderer/tagged-pdf.test.ts
+++ b/tests/unit/renderer/tagged-pdf.test.ts
@@ -70,4 +70,24 @@ describe("accessible tagging (PDF/UA foundation)", () => {
     expect(pdf).toContain("/S /TH");
     expect(pdf).toContain("/S /TD");
   });
+
+  it("declares PDF/UA-1: metadata, DisplayDocTitle, page Tabs, TH scope, title", async () => {
+    const doc = Document([
+      Page({ margin: 40 }, [
+        Text("Title", { role: "h1" }),
+        Table({ columns: ["1fr", "auto"], header: ["Name", "Value"] }, [["a", "1"]]),
+      ]),
+    ]);
+    const pdf = await renderPdf(doc, {
+      accessible: true,
+      title: "My Doc",
+      lang: "de-DE",
+      compress: false,
+    });
+    expect(pdf).toContain("<pdfuaid:part>1</pdfuaid:part>"); // PDF/UA-1 identification (XMP)
+    expect(pdf).toContain("/ViewerPreferences << /DisplayDocTitle true >>");
+    expect(pdf).toContain("/Tabs /S"); // logical tab/reading order on the page
+    expect(pdf).toContain("/Scope /Column"); // header cells carry a Scope
+    expect(pdf).toContain("My Doc"); // dc:title
+  });
 });

--- a/tests/unit/renderer/text-renderer.test.ts
+++ b/tests/unit/renderer/text-renderer.test.ts
@@ -11,6 +11,7 @@ describe("TextRenderer - calculateTextHeight", () => {
     const mockObjectManager = {
       getStringWidth: vi.fn().mockReturnValue(10), // String width is used for each word = 20
       getCharWidth: vi.fn().mockReturnValue(5), // Used for empty spaces = 5
+      struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
     const textHeight = TextRenderer.calculateTextHeight(
@@ -29,6 +30,7 @@ describe("TextRenderer - calculateTextHeight", () => {
     const mockObjectManager = {
       getStringWidth: vi.fn().mockReturnValue(10), // String width is used for each word = 60
       getCharWidth: vi.fn().mockReturnValue(5), // Used for empty spaces = 25
+      struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
     const textHeight = TextRenderer.calculateTextHeight(
@@ -47,6 +49,7 @@ describe("TextRenderer - calculateTextHeight", () => {
     const mockObjectManager = {
       getStringWidth: vi.fn().mockReturnValue(10),
       getCharWidth: vi.fn().mockReturnValue(5),
+      struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
     const segments = [
@@ -86,6 +89,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       isCustomFont: vi.fn().mockReturnValue(false),
       getStringWidth: vi.fn().mockReturnValue(10),
       getCharWidth: vi.fn().mockReturnValue(5),
+      struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
     const result = PdfBackend.serialize(
@@ -122,6 +126,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       isCustomFont: vi.fn().mockReturnValue(false),
       getStringWidth: vi.fn().mockReturnValue(10),
       getCharWidth: vi.fn().mockReturnValue(5),
+      struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
     const result = PdfBackend.serialize(
@@ -155,6 +160,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       isCustomFont: vi.fn().mockReturnValue(false),
       getStringWidth: vi.fn().mockReturnValue(25), // Here we get the widht of the "complete" string, because the renderer renders each "line", not only the words/segments: 25
       getCharWidth: vi.fn().mockReturnValue(0), // For empty spaces: 0
+      struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
     const result = PdfBackend.serialize(
@@ -189,6 +195,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       isCustomFont: vi.fn().mockReturnValue(false),
       getStringWidth: vi.fn().mockReturnValue(25), // Here we get the widht of the "complete" string, because the renderer renders each "line", not only the words/segments: 25
       getCharWidth: vi.fn().mockReturnValue(0),
+      struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
     const result = PdfBackend.serialize(
@@ -222,6 +229,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       isCustomFont: vi.fn().mockReturnValue(false),
       getStringWidth: vi.fn().mockReturnValue(0),
       getCharWidth: vi.fn().mockReturnValue(0),
+      struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
     const result = PdfBackend.serialize(
@@ -274,6 +282,7 @@ describe("TextRenderer - calculateTextHeight", () => {
         return content.length * fontSize; // Einfacher Algorithmus zur Rückgabe der Breite
       }),
       getCharWidth: vi.fn().mockReturnValue(10),
+      struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
     const result = PdfBackend.serialize(
@@ -325,6 +334,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       isCustomFont: vi.fn().mockReturnValue(false),
       getStringWidth: vi.fn().mockReturnValue(25), // Here we get the widht of each segment: 50
       getCharWidth: vi.fn().mockReturnValue(0), // For empty spaces: 0
+      struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
     const result = PdfBackend.serialize(

--- a/tests/unit/utils/ua-xmp.test.ts
+++ b/tests/unit/utils/ua-xmp.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { uaXmp } from "../../../src/lib/utils/ua-xmp";
+
+describe("uaXmp", () => {
+  it("declares PDF/UA-1 and carries the title", () => {
+    const xmp = uaXmp({ title: "My Report" });
+    expect(xmp).toContain("<pdfuaid:part>1</pdfuaid:part>");
+    expect(xmp).toContain("My Report");
+  });
+
+  it("stays byte-safe (every char <= 0xFF) so the stream /Length matches, BOM = UTF-8 bytes", () => {
+    const xmp = uaXmp({ title: "Résumé — €" });
+    // The PDF writer emits one byte per char (Latin-1); every char must fit so /Length is correct.
+    expect([...xmp].every((c) => c.codePointAt(0)! <= 0xff)).toBe(true);
+    expect(xmp).not.toContain("﻿"); // a raw U+FEFF would be mangled to "?"
+    expect(xmp.startsWith('<?xpacket begin="ï»¿"')).toBe(true); // 3-byte UTF-8 BOM
+  });
+
+  it("escapes non-ASCII and XML metacharacters in the title", () => {
+    const xmp = uaXmp({ title: "Résumé <b> & Co" });
+    expect(xmp).toContain("R&#233;sum&#233;"); // é -> numeric character references
+    expect(xmp).toContain("&lt;b&gt; &amp; Co"); // < > & escaped
+    expect(xmp).not.toContain("é"); // no raw non-ASCII survives
+  });
+});


### PR DESCRIPTION
## Summary

Implemented full PDF/UA support including page breaks (only one element per table e.g.) - veraPDF certified

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AES-256 (V5/R6) PDF password protection, configurable via `renderOptions.encrypt`.
  * Added accessible/tagged PDF output (PDF/UA-1) via `accessible`, including document language/title, structured headings/paragraphs, image `alt`, and tagged table semantics (TH/TD/TR).
* **Documentation**
  * Updated README and package docs with encryption and accessibility usage examples.
* **Bug Fixes**
  * Preserved byte-identical output when accessibility tagging is disabled.
  * Improved logical grouping across page breaks for tagged content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->