### PR TITLE
feat: relative and percentage sizes for box, column/row and image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,8 +308,10 @@ The authoritative plan + ground rules live in **`todo.md`** (gitignored, repo ro
 starting work. Working agreement: **phase by phase, Flo approves each gate, Claude never commits/pushes
 unprompted, comments English + sensible, don't break the font math.**
 
-Status: **LAUNCHED 2026-06-27** — all five packages live on npm (`@jasy/pdf`@alpha.3, `@jasy/zugferd`@alpha.1,
-`@jasy/cli`@alpha.3, `@jasy/vue`@alpha.3, `@jasy/nuxt`@alpha.2), repo public + locked, full CI + changelog +
+Status: **LAUNCHED 2026-06-27**, still shipping alpha increments (no beta/rc/stable until the feature set is
+complete — see `todo.md`). All five packages live on npm; **current (2026-07-02): `@jasy/pdf`@alpha.5,
+`@jasy/zugferd`@alpha.2, `@jasy/cli`@alpha.4, `@jasy/vue`@alpha.5, `@jasy/nuxt`@alpha.4** (the alpha.5 cascade =
+color emoji + PDF/UA). Repo public + locked, full CI + changelog +
 bots in place (see Repo facts). The engine is **feature-complete for the alpha** — inheritance, `onOverflow`,
 custom formats, the line-breaker fixes; **~415 tests green**. The **landing**
 (`~/projects/jasy-landing` → **jasy.dev**) is built: showroom (9 cards), validator, docs, a home-page
@@ -326,8 +328,10 @@ prefixed components; custom fonts + images load as `Uint8Array` (`<JasyDocument 
 components; **`@jasy/vue@1.0.0-alpha.2`** — the `jasyVue` GLOBAL plugin was **REMOVED** (global registration
 never resolves in `renderToPdf`'s fresh app; plain Vue = explicit imports, prefix is Nuxt-only). The
 **`@jasy/nuxt` Nuxt module shipped** (`@1.0.0-alpha.1` — client OR server, zero-config; see Repo facts +
-`packages/nuxt`). Still open: the `style`-object CSS layer; plus the 🔮 wish-list (read/edit existing PDFs,
-forms, security + signatures, more e-invoice profiles, framework bindings). See `todo.md` "⭐ Active".
+`packages/nuxt`). A `style`-object CSS layer + `@media` are **won't-do** (props + `DefaultTextStyle` cover styling;
+media queries are meaningless for a fixed-size PDF). Wanted-additive instead: **relative/percentage sizing** +
+**paint-only rotate** (1.x minors). Plus the 🔮 wish-list (read/edit existing PDFs, forms, security + signatures,
+more e-invoice profiles, framework bindings). See `todo.md` "⭐ Active" + "🔮 Layout & styling".
 
 ## Repo facts
 
@@ -341,8 +345,8 @@ forms, security + signatures, more e-invoice profiles, framework bindings). See 
   Content 3). It has its **own CLAUDE.md + HARD RULES: never start/stop its dev server (Flo runs it),
   only Flo commits.** Package links there use **npmx.dev** (Daniel Roe's registry browser), not npmjs.com.
 - License MIT, author Florian Heuberger. **Launched 2026-06-27** (Bluesky + npm; landed with the Vue/Nuxt core
-  crew). npm (alpha dist-tag): `@jasy/pdf`@alpha.3, `@jasy/zugferd`@alpha.1, `@jasy/cli`@alpha.3,
-  `@jasy/vue`@alpha.3, `@jasy/nuxt`@alpha.2 (released via `scripts/release.sh <pkg> <version>` → `<pkg>-v*` tag →
+  crew). npm current (alpha + latest dist-tags): `@jasy/pdf`@alpha.5, `@jasy/zugferd`@alpha.2, `@jasy/cli`@alpha.4,
+  `@jasy/vue`@alpha.5, `@jasy/nuxt`@alpha.4 (released via `scripts/release.sh <pkg> <version>` → `<pkg>-v*` tag →
   CI publish; order matters, deps `workspace:*` pin EXACT so dependents re-release when a dep does; the tag also
   builds the GitHub Release notes via `scripts/gh-release.mjs` — changelogen groups + per-commit contributors,
   idempotent upsert). `latest` dist-tag points at the newest alpha per package.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,8 +329,12 @@ components; **`@jasy/vue@1.0.0-alpha.2`** — the `jasyVue` GLOBAL plugin was **
 never resolves in `renderToPdf`'s fresh app; plain Vue = explicit imports, prefix is Nuxt-only). The
 **`@jasy/nuxt` Nuxt module shipped** (`@1.0.0-alpha.1` — client OR server, zero-config; see Repo facts +
 `packages/nuxt`). A `style`-object CSS layer + `@media` are **won't-do** (props + `DefaultTextStyle` cover styling;
-media queries are meaningless for a fixed-size PDF). Wanted-additive instead: **relative/percentage sizing** +
-**paint-only rotate** (1.x minors). Plus the 🔮 wish-list (read/edit existing PDFs, forms, security + signatures,
+media queries are meaningless for a fixed-size PDF). **✅ Relative/percentage sizing DONE (2026-07-05)**:
+`width`/`height` as `"50%"`/pt on Box/Column/Row/Image, image aspect auto-size, and `%` children in flex
+containers resolved against `line − gaps` (so N columns at (100/N)%+gaps fit exactly - better than
+react-pdf/CSS). One shared `resolveExtent` (`layout/box-constraints.ts`); the core is untouched. Still
+**wanted-additive**: **paint-only rotate** + the small relative-sizing follow-ups (`aspectRatio` on any Box,
+`min/max` w/h, `%` on padding/margin/Positioned) — all 1.x minors. Plus the 🔮 wish-list (read/edit existing PDFs, forms, security + signatures,
 more e-invoice profiles, framework bindings). See `todo.md` "⭐ Active" + "🔮 Layout & styling".
 
 ## Repo facts

--- a/src/lib/api/content.ts
+++ b/src/lib/api/content.ts
@@ -10,6 +10,7 @@ import {
 import { PDFElement } from "../elements/pdf-element.ts";
 import { ColorInput, toColor } from "./color.ts";
 import { Insets, toEdges } from "./insets.ts";
+import { SizeInput, toDimension } from "./dimension.ts";
 
 /** A horizontal rule (locked §4). */
 export interface DividerOptions {
@@ -58,9 +59,11 @@ const FIT: Record<ImageFit, BoxFit> = {
 };
 
 export interface ImageOptions {
-  width?: number;
-  height?: number;
-  /** Fit within the box (default `none`). */
+  /** Size on each axis: points (fixed) or a percentage string like `"50%"` (a fraction of the offered
+   *  space). Pin exactly ONE axis and the other follows the image's aspect ratio (CSS `height: auto`). */
+  width?: SizeInput;
+  height?: SizeInput;
+  /** Fit within the box (default `none`; `fill` when exactly one axis is pinned so it scales to fit). */
   fit?: ImageFit;
   /** Corner radius in points (rounds the image box). */
   radius?: number;
@@ -74,6 +77,13 @@ export interface ImageOptions {
  * `CustomImage` for non-filesystem sources. Maps to an `ImageElement`.
  */
 export function Image(src: ImageSource, opts: ImageOptions = {}): ImageElement {
+  const w = opts.width !== undefined ? toDimension(opts.width) : undefined;
+  const h = opts.height !== undefined ? toDimension(opts.height) : undefined;
+  // Exactly one axis pinned -> the other is derived from the aspect ratio, so scale the image to the
+  // resulting box (fit: fill). Both or neither pinned keeps the default fit (none).
+  const autoScale = (opts.width !== undefined) !== (opts.height !== undefined);
+  const fit = opts.fit ? FIT[opts.fit] : autoScale ? BoxFit.fill : undefined;
+
   return new ImageElement({
     image:
       typeof src === "string"
@@ -81,9 +91,11 @@ export function Image(src: ImageSource, opts: ImageOptions = {}): ImageElement {
         : src instanceof Uint8Array
           ? new CustomBytesImage(src)
           : src,
-    width: opts.width,
-    height: opts.height,
-    fit: opts.fit ? FIT[opts.fit] : undefined,
+    width: w?.points,
+    height: h?.points,
+    widthFactor: w?.factor,
+    heightFactor: h?.factor,
+    fit,
     radius: opts.radius,
     alt: opts.alt,
   });

--- a/src/lib/api/dimension.ts
+++ b/src/lib/api/dimension.ts
@@ -15,11 +15,17 @@ export interface Dimension {
   factor?: number;
 }
 
-const PERCENT = /^(-?\d+(?:\.\d+)?)%$/;
+const PERCENT = /^(\d+(?:\.\d+)?)%$/; // no leading "-": a size cannot be negative
 
-/** Normalizes a `SizeInput` to a `Dimension` (a point size or a fraction). */
+/**
+ * Normalizes a `SizeInput` to a `Dimension` (a point size or a fraction). Rejects negatives at this
+ * boundary so `resolveExtent` and the layout never see a negative size.
+ */
 export function toDimension(value: SizeInput): Dimension {
-  if (typeof value === "number") return { points: value };
+  if (typeof value === "number") {
+    if (value < 0) throw new Error(`Invalid size ${value}: a size cannot be negative.`);
+    return { points: value };
+  }
   const m = PERCENT.exec(value.trim());
   if (m) return { factor: parseFloat(m[1]) / 100 };
   throw new Error(`Invalid size "${value}": use a number of points or a percentage like "50%".`);

--- a/src/lib/api/dimension.ts
+++ b/src/lib/api/dimension.ts
@@ -1,0 +1,26 @@
+/**
+ * Size input for a Box's `width` / `height` (relative sizing). Either a number of PDF points (a
+ * fixed size) or a percentage string like `"50%"` - a fraction of the space the parent offers on
+ * that axis. Every form normalizes to a `Dimension` via `toDimension`, so the engine only ever sees
+ * points and factors, never a string. A percentage resolves against the parent's offered extent, so
+ * it only has meaning inside a bounded region (a fraction of an unbounded axis is a no-op).
+ */
+export type SizeInput = number | `${number}%`;
+
+/** A resolved `SizeInput`: exactly one of an absolute point size or a 0..1 fraction of the parent. */
+export interface Dimension {
+  /** Absolute size in PDF points. */
+  points?: number;
+  /** Fraction of the parent's offered extent on this axis; a `"50%"` input is `0.5`. */
+  factor?: number;
+}
+
+const PERCENT = /^(-?\d+(?:\.\d+)?)%$/;
+
+/** Normalizes a `SizeInput` to a `Dimension` (a point size or a fraction). */
+export function toDimension(value: SizeInput): Dimension {
+  if (typeof value === "number") return { points: value };
+  const m = PERCENT.exec(value.trim());
+  if (m) return { factor: parseFloat(m[1]) / 100 };
+  throw new Error(`Invalid size "${value}": use a number of points or a percentage like "50%".`);
+}

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -3,6 +3,7 @@
 // core classes stay untouched and remain exported for power users.
 export * from "./color.ts";
 export * from "./insets.ts";
+export * from "./dimension.ts";
 export * from "./text.ts";
 export * from "./layout.ts";
 export * from "./content.ts";

--- a/src/lib/api/layout.ts
+++ b/src/lib/api/layout.ts
@@ -8,6 +8,7 @@ import { PDFElement } from "../elements/pdf-element.ts";
 import { MainAlign, CrossAlign } from "../utils/flex-layout.ts";
 import { ColorInput, toColor } from "./color.ts";
 import { Insets, toEdges } from "./insets.ts";
+import { SizeInput, toDimension } from "./dimension.ts";
 import { splitArgs } from "./args.ts";
 
 /** Options shared by the `Column` and `Row` stacks (locked §4). */
@@ -70,9 +71,11 @@ export interface BoxOptions {
   bg?: ColorInput;
   /** Inner padding between the border and the children. */
   padding?: Insets;
-  /** Fixed size; omit to fill the offered width and shrink-wrap the height. */
-  width?: number;
-  height?: number;
+  /** Size on each axis: a number of points (fixed) or a percentage string like `"50%"` (a fraction
+   *  of the space the parent offers on that axis). Omit `width` to fill the offered width, omit
+   *  `height` to shrink-wrap the content. A percentage only resolves in a bounded region. */
+  width?: SizeInput;
+  height?: SizeInput;
   /** Corner radius in points. */
   radius?: number;
   /** Make this box a positioning frame: `Positioned` children placed inside it resolve their
@@ -114,6 +117,10 @@ export function Box(a: BoxOptions | PDFElement[], b?: PDFElement[]): RectangleEl
 
   const hasBorder = opts.border !== undefined || opts.borderWidth !== undefined || hasPerSide;
 
+  // A point size fills `width`/`height`; a percentage fills `widthFactor`/`heightFactor`.
+  const w = opts.width !== undefined ? toDimension(opts.width) : undefined;
+  const h = opts.height !== undefined ? toDimension(opts.height) : undefined;
+
   return new RectangleElement({
     x: 0,
     y: 0,
@@ -121,8 +128,10 @@ export function Box(a: BoxOptions | PDFElement[], b?: PDFElement[]): RectangleEl
     color: opts.border !== undefined ? toColor(opts.border) : undefined,
     backgroundColor: opts.bg !== undefined ? toColor(opts.bg) : undefined,
     borderWidth: hasBorder ? (opts.borderWidth ?? 1) : 0,
-    width: opts.width,
-    height: opts.height,
+    width: w?.points,
+    height: h?.points,
+    widthFactor: w?.factor,
+    heightFactor: h?.factor,
     radius: opts.radius,
     sideBorders: hasPerSide
       ? {

--- a/src/lib/api/layout.ts
+++ b/src/lib/api/layout.ts
@@ -20,6 +20,18 @@ export interface StackOptions {
   justify?: MainAlign;
   /** Position across the axis (CSS `align-items`): start (default) · center · end · stretch. */
   align?: CrossAlign;
+  /** Size on each axis: points (fixed) or a percentage string like `"50%"` (a fraction of the offered
+   *  space). Omit to fill the offered width / shrink-wrap to the children. A percentage needs a bounded
+   *  axis (`height: "50%"` only resolves where the parent bounds the height). */
+  width?: SizeInput;
+  height?: SizeInput;
+}
+
+/** Splits `StackOptions` width/height into the fixed points + fraction the stack elements expect. */
+function stackSize(opts: StackOptions) {
+  const w = opts.width !== undefined ? toDimension(opts.width) : undefined;
+  const h = opts.height !== undefined ? toDimension(opts.height) : undefined;
+  return { width: w?.points, height: h?.points, widthFactor: w?.factor, heightFactor: h?.factor };
 }
 
 // The public default for `cross` is `start` (locked §5) - i.e. don't stretch a child unless
@@ -38,6 +50,7 @@ export function Column(a: StackOptions | PDFElement[], b?: PDFElement[]): Contai
     gap: opts.gap,
     main: opts.justify, // undefined → engine default `start` (matches §5)
     cross: opts.align ?? DEFAULT_CROSS,
+    ...stackSize(opts),
   });
 }
 
@@ -51,6 +64,7 @@ export function Row(a: StackOptions | PDFElement[], b?: PDFElement[]): RowElemen
     gap: opts.gap,
     main: opts.justify,
     cross: opts.align ?? DEFAULT_CROSS,
+    ...stackSize(opts),
   });
 }
 

--- a/src/lib/elements/container-element.ts
+++ b/src/lib/elements/container-element.ts
@@ -1,5 +1,5 @@
 import { FlexLayoutHelper, VERTICAL_AXIS, MainAlign, CrossAlign } from "../utils/flex-layout.ts";
-import { BoxConstraints, Offset, Size } from "../layout/box-constraints.ts";
+import { BoxConstraints, Offset, Size, resolveExtent } from "../layout/box-constraints.ts";
 import { Fragmentable, FragmentResult, packChildren } from "../layout/fragmentation.ts";
 import {
   LayoutContext,
@@ -16,6 +16,9 @@ interface ContainerElementParams extends SizedElement, WithChildren {
   main?: MainAlign;
   /** Horizontal alignment of each child (cross axis); defaults to `stretch`. */
   cross?: CrossAlign;
+  /** Width/height as a fraction (0..1) of the offered box instead of `width`/`height` (relative sizing). */
+  widthFactor?: number;
+  heightFactor?: number;
 }
 
 export class ContainerElement extends SizedPDFElement implements Fragmentable {
@@ -23,14 +26,29 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
   private gap: number;
   private main: MainAlign;
   private cross: CrossAlign;
+  // The requested size, snapshot at construction so re-layouts (fragmentation measuring, which
+  // mutate this.width/height) still see what the user asked for. `undefined` = fill / shrink-wrap.
+  private requested: { width?: number; height?: number; widthFactor?: number; heightFactor?: number };
 
-  constructor({ x, y, width, height, children, gap, main, cross }: ContainerElementParams) {
+  constructor({
+    x,
+    y,
+    width,
+    height,
+    children,
+    gap,
+    main,
+    cross,
+    widthFactor,
+    heightFactor,
+  }: ContainerElementParams) {
     super({ x, y, width, height });
 
     this.children = children;
     this.gap = gap ?? 0;
     this.main = main ?? "start";
     this.cross = cross ?? "stretch";
+    this.requested = { width, height, widthFactor, heightFactor };
   }
 
   /**
@@ -60,8 +78,10 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
     return new ContainerElement({
       x: this.x,
       y: this.y,
-      width: this.width,
-      height: this.height,
+      // Carry the requested WIDTH (a %-width column keeps its width on every page); the height is
+      // intentionally dropped so each fragment shrink-wraps to the content it actually holds.
+      width: this.requested.width,
+      widthFactor: this.requested.widthFactor,
       children,
       gap: this.gap,
       main: this.main,
@@ -69,18 +89,45 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
     });
   }
 
+  override relativeSizeFactor(horizontal: boolean): number | undefined {
+    return horizontal ? this.requested.widthFactor : this.requested.heightFactor;
+  }
+
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
-    // The container fills the width/height it is offered; when an axis is unbounded it
-    // shrink-wraps to its children instead (mirrors how Row shrink-wraps). Width unbounded
-    // happens for a Column nested in a Row (the Row offers its fixed children unbounded
-    // width); passing 0 there would collapse every child to width 0.
-    if (constraints.hasBoundedWidth) this.width = constraints.maxWidth;
-    if (constraints.hasBoundedHeight) this.height = constraints.maxHeight;
     this.x = offset.x;
     this.y = offset.y;
 
-    const crossAvail = constraints.hasBoundedWidth ? this.width! : Infinity;
-    const mainAvail = constraints.hasBoundedHeight ? this.height! : Infinity;
+    // Relative sizing: a pinned extent (fixed points or a fraction of the offered box, clamped into
+    // the constraints) wins; else fill a bounded axis; else stay `undefined` and shrink-wrap below.
+    // A Column nested in a Row gets unbounded width - passing 0 there would collapse children to 0.
+    const explicitWidth = resolveExtent(
+      this.requested.width,
+      this.requested.widthFactor,
+      constraints.maxWidth,
+      constraints.hasBoundedWidth,
+    );
+    const explicitHeight = resolveExtent(
+      this.requested.height,
+      this.requested.heightFactor,
+      constraints.maxHeight,
+      constraints.hasBoundedHeight,
+    );
+    const boundedWidth =
+      explicitWidth !== undefined
+        ? constraints.constrainWidth(explicitWidth)
+        : constraints.hasBoundedWidth
+          ? constraints.maxWidth
+          : undefined;
+    const boundedHeight =
+      explicitHeight !== undefined
+        ? constraints.constrainHeight(explicitHeight)
+        : constraints.hasBoundedHeight
+          ? constraints.maxHeight
+          : undefined;
+
+    // Vertical stack: cross = width (children fill it), main = height (the stacking extent).
+    const crossAvail = boundedWidth ?? Infinity;
+    const mainAvail = boundedHeight ?? Infinity;
 
     let result = { mainUsed: 0, crossUsed: 0 };
     if (this.children) {
@@ -99,14 +146,12 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
       );
     }
 
-    // Bounded: fill the offered extent. Unbounded: shrink to the children (height = the
-    // stack, width = the widest child). Top-left coordinates; the container draws nothing,
-    // and the Y-flip happens once at the IR -> backend seam.
-    const width = constraints.hasBoundedWidth ? this.width! : result.crossUsed;
-    const height = constraints.hasBoundedHeight ? this.height! : result.mainUsed;
-    this.width = width;
-    this.height = height;
-    return { width, height };
+    // Pinned/bounded axis takes that extent; an unbounded one shrink-wraps to the children (height =
+    // the stack, width = the widest child). Top-left coordinates; the container draws nothing, and
+    // the Y-flip happens once at the IR -> backend seam.
+    this.width = boundedWidth ?? result.crossUsed;
+    this.height = boundedHeight ?? result.mainUsed;
+    return { width: this.width, height: this.height };
   }
 
   override getProps(): ContainerElementParams {

--- a/src/lib/elements/container-element.ts
+++ b/src/lib/elements/container-element.ts
@@ -28,7 +28,12 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
   private cross: CrossAlign;
   // The requested size, snapshot at construction so re-layouts (fragmentation measuring, which
   // mutate this.width/height) still see what the user asked for. `undefined` = fill / shrink-wrap.
-  private requested: { width?: number; height?: number; widthFactor?: number; heightFactor?: number };
+  private requested: {
+    width?: number;
+    height?: number;
+    widthFactor?: number;
+    heightFactor?: number;
+  };
 
   constructor({
     x,

--- a/src/lib/elements/image-element.ts
+++ b/src/lib/elements/image-element.ts
@@ -1,7 +1,7 @@
 import { getImageDimensions } from "../utils/image-helper.ts";
 import { latin1FromBytes } from "../utils/bytes.ts";
 import { readFileBytesAsync } from "../platform/node-fs.ts";
-import { BoxConstraints, Offset, Size } from "../layout/box-constraints.ts";
+import { BoxConstraints, Offset, Size, resolveExtent } from "../layout/box-constraints.ts";
 import { LayoutContext, SizedPDFElement } from "./pdf-element.ts";
 
 // path.extname without node:path (browser-safe): the substring from the last dot, if it sits after the
@@ -37,6 +37,7 @@ export class CustomLocalImage extends CustomImage {
   }
 
   async init(): Promise<void> {
+    if (this.fileBuffer) return; // idempotent: the pre-layout size pass and the renderer both call init()
     try {
       // Loading image and convert it to base64
       await this.loadImage(this.imagePath);
@@ -121,6 +122,10 @@ interface ImageElementParams {
   image: CustomImage; // binary image data
   width?: number;
   height?: number;
+  /** Width as a fraction (0..1) of the offered width instead of a fixed `width` (relative sizing). */
+  widthFactor?: number;
+  /** Height as a fraction (0..1) of the offered height; see `widthFactor`. */
+  heightFactor?: number;
   fit?: BoxFit;
   /** Corner radius in points; rounds the image box (0 = sharp, default). */
   radius?: number;
@@ -130,26 +135,70 @@ interface ImageElementParams {
 
 export class ImageElement extends SizedPDFElement {
   private image: CustomImage;
+  private widthFactor?: number;
+  private heightFactor?: number;
   private fit: BoxFit;
   private radius: number;
   private readonly alt?: string;
+  // Intrinsic pixel size, resolved asynchronously before layout (see resolveIntrinsicSize). Layout
+  // reads it to derive a proportional height for a width-only image (and vice versa).
+  private intrinsic?: { width: number; height: number };
 
-  constructor({ image, width, height, fit = BoxFit.none, radius, alt }: ImageElementParams) {
+  constructor({
+    image,
+    width,
+    height,
+    widthFactor,
+    heightFactor,
+    fit = BoxFit.none,
+    radius,
+    alt,
+  }: ImageElementParams) {
     super({ x: 0, y: 0, width });
 
     this.image = image;
     this.height = height;
+    this.widthFactor = widthFactor;
+    this.heightFactor = heightFactor;
     this.fit = fit;
     this.radius = radius ?? 0;
     this.alt = alt;
   }
 
+  /**
+   * Loads the image and records its intrinsic pixel size. Runs in the async pre-layout pass (layout
+   * itself is synchronous and cannot await jimp) so `calculateLayout` can turn a width-only image
+   * into a proportional box. Best-effort: a load failure leaves the size unresolved (the renderer
+   * surfaces the real error) and the image just keeps whatever explicit size it was given.
+   */
+  async resolveIntrinsicSize(): Promise<void> {
+    try {
+      await this.image.init();
+      this.intrinsic = await this.image.getImageDimensions();
+    } catch {
+      // leave intrinsic undefined - aspect derivation simply doesn't fire
+    }
+  }
+
   calculateLayout(constraints: BoxConstraints, offset: Offset, _ctx: LayoutContext): Size {
     this.x = offset.x;
     this.y = offset.y;
-    // A bounded axis overrides the intrinsic/explicit size; otherwise keep our own.
-    if (constraints.hasBoundedWidth) this.width = constraints.maxWidth;
-    if (constraints.hasBoundedHeight) this.height = constraints.maxHeight;
+
+    // Relative sizing: a fixed size or a fraction of the offered box (fraction only in a bounded axis).
+    let w = resolveExtent(this.width, this.widthFactor, constraints.maxWidth, constraints.hasBoundedWidth);
+    let h = resolveExtent(this.height, this.heightFactor, constraints.maxHeight, constraints.hasBoundedHeight);
+
+    // Aspect auto-size: when the user pinned exactly ONE axis, derive the other from the intrinsic
+    // ratio (CSS `width: 50%; height: auto`). Only fires once the pre-pass resolved the pixel size.
+    if (this.intrinsic && this.intrinsic.width > 0 && this.intrinsic.height > 0) {
+      const ratio = this.intrinsic.width / this.intrinsic.height;
+      if (w !== undefined && h === undefined) h = w / ratio;
+      else if (h !== undefined && w === undefined) w = h * ratio;
+    }
+
+    // Fall back to the prior behavior for an unpinned axis: a bounded axis fills, otherwise keep our own.
+    this.width = w ?? (constraints.hasBoundedWidth ? constraints.maxWidth : this.width);
+    this.height = h ?? (constraints.hasBoundedHeight ? constraints.maxHeight : this.height);
 
     // Top-left coordinates; the fit logic (renderer) and the Y-flip (seam) run later.
     return { width: this.width ?? 0, height: this.height ?? 0 };

--- a/src/lib/elements/image-element.ts
+++ b/src/lib/elements/image-element.ts
@@ -180,6 +180,10 @@ export class ImageElement extends SizedPDFElement {
     }
   }
 
+  override relativeSizeFactor(horizontal: boolean): number | undefined {
+    return horizontal ? this.widthFactor : this.heightFactor;
+  }
+
   calculateLayout(constraints: BoxConstraints, offset: Offset, _ctx: LayoutContext): Size {
     this.x = offset.x;
     this.y = offset.y;

--- a/src/lib/elements/image-element.ts
+++ b/src/lib/elements/image-element.ts
@@ -30,6 +30,7 @@ export class CustomLocalImage extends CustomImage {
   private imagePath: string;
   private fileBuffer!: Uint8Array;
   private fileRawData!: string;
+  private dims?: { width: number; height: number }; // memoized so the decode happens once
 
   constructor(imagePath: string) {
     super();
@@ -78,14 +79,12 @@ export class CustomLocalImage extends CustomImage {
   }
 
   async getImageDimensions(): Promise<{ width: number; height: number }> {
+    if (this.dims) return this.dims; // reuse: the pre-layout size pass and the renderer both ask
     if (!this.fileBuffer) {
       throw new Error("You must first call the `loadAndConvertImage` method");
     }
-
-    // Since now (30.09.2024) we using "Jimp" - So we don't need our custom method to get the image dimension.
-    // But at the moment I let it still here...
-    const dimensions = await getImageDimensions(this.fileBuffer);
-    return dimensions;
+    this.dims = await getImageDimensions(this.fileBuffer);
+    return this.dims;
   }
 }
 
@@ -95,6 +94,7 @@ export class CustomLocalImage extends CustomImage {
  */
 export class CustomBytesImage extends CustomImage {
   private fileRawData: string;
+  private dims?: { width: number; height: number }; // memoized so the decode happens once
   constructor(private bytes: Uint8Array) {
     super();
     this.fileRawData = latin1FromBytes(bytes);
@@ -114,7 +114,8 @@ export class CustomBytesImage extends CustomImage {
   }
 
   async getImageDimensions(): Promise<{ width: number; height: number }> {
-    return getImageDimensions(this.bytes);
+    if (!this.dims) this.dims = await getImageDimensions(this.bytes); // reuse across pre-pass + render
+    return this.dims;
   }
 }
 
@@ -140,6 +141,10 @@ export class ImageElement extends SizedPDFElement {
   private fit: BoxFit;
   private radius: number;
   private readonly alt?: string;
+  // The requested size (fixed points), kept separate from the laid-out this.width/height so a
+  // re-layout (fragmentation measures more than once) still resolves the factor, instead of
+  // freezing to the first pass's result. Mirrors ContainerElement / RowElement.
+  private requested: { width?: number; height?: number };
   // Intrinsic pixel size, resolved asynchronously before layout (see resolveIntrinsicSize). Layout
   // reads it to derive a proportional height for a width-only image (and vice versa).
   private intrinsic?: { width: number; height: number };
@@ -154,10 +159,13 @@ export class ImageElement extends SizedPDFElement {
     radius,
     alt,
   }: ImageElementParams) {
+    // Seed this.width/height from the request so getProps() reflects it before layout; calculateLayout
+    // then reads `requested` (never the mutated fields) and overwrites these with the laid-out size.
     super({ x: 0, y: 0, width });
 
     this.image = image;
     this.height = height;
+    this.requested = { width, height };
     this.widthFactor = widthFactor;
     this.heightFactor = heightFactor;
     this.fit = fit;
@@ -189,14 +197,15 @@ export class ImageElement extends SizedPDFElement {
     this.y = offset.y;
 
     // Relative sizing: a fixed size or a fraction of the offered box (fraction only in a bounded axis).
+    // Read from `requested` (not this.width/height, which we overwrite below) so every pass re-resolves.
     let w = resolveExtent(
-      this.width,
+      this.requested.width,
       this.widthFactor,
       constraints.maxWidth,
       constraints.hasBoundedWidth,
     );
     let h = resolveExtent(
-      this.height,
+      this.requested.height,
       this.heightFactor,
       constraints.maxHeight,
       constraints.hasBoundedHeight,
@@ -210,9 +219,11 @@ export class ImageElement extends SizedPDFElement {
       else if (h !== undefined && w === undefined) w = h * ratio;
     }
 
-    // Fall back to the prior behavior for an unpinned axis: a bounded axis fills, otherwise keep our own.
-    this.width = w ?? (constraints.hasBoundedWidth ? constraints.maxWidth : this.width);
-    this.height = h ?? (constraints.hasBoundedHeight ? constraints.maxHeight : this.height);
+    // Fall back to the prior behavior for an unpinned axis: a bounded axis fills, otherwise keep the
+    // requested fixed size (or undefined). Read from `requested`, never the mutated this.width/height.
+    this.width = w ?? (constraints.hasBoundedWidth ? constraints.maxWidth : this.requested.width);
+    this.height =
+      h ?? (constraints.hasBoundedHeight ? constraints.maxHeight : this.requested.height);
 
     // Top-left coordinates; the fit logic (renderer) and the Y-flip (seam) run later.
     return { width: this.width ?? 0, height: this.height ?? 0 };

--- a/src/lib/elements/image-element.ts
+++ b/src/lib/elements/image-element.ts
@@ -189,8 +189,18 @@ export class ImageElement extends SizedPDFElement {
     this.y = offset.y;
 
     // Relative sizing: a fixed size or a fraction of the offered box (fraction only in a bounded axis).
-    let w = resolveExtent(this.width, this.widthFactor, constraints.maxWidth, constraints.hasBoundedWidth);
-    let h = resolveExtent(this.height, this.heightFactor, constraints.maxHeight, constraints.hasBoundedHeight);
+    let w = resolveExtent(
+      this.width,
+      this.widthFactor,
+      constraints.maxWidth,
+      constraints.hasBoundedWidth,
+    );
+    let h = resolveExtent(
+      this.height,
+      this.heightFactor,
+      constraints.maxHeight,
+      constraints.hasBoundedHeight,
+    );
 
     // Aspect auto-size: when the user pinned exactly ONE axis, derive the other from the intrinsic
     // ratio (CSS `width: 50%; height: auto`). Only fires once the pre-pass resolved the pixel size.

--- a/src/lib/elements/pdf-element.ts
+++ b/src/lib/elements/pdf-element.ts
@@ -63,6 +63,16 @@ export abstract class PDFElement {
    * happens once at the IR -> backend seam.
    */
   abstract calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size;
+
+  /**
+   * The relative-size fraction (0..1) this element asked for on the given axis, if any (`horizontal` =
+   * width). A flex parent reads it to resolve a percentage child against its OWN main size - e.g. a
+   * `Box({ width: "50%" })` inside a Row, where the child otherwise gets an unbounded main axis and the
+   * fraction would have nothing to resolve against. Default: the element is not relatively sized.
+   */
+  relativeSizeFactor(_horizontal: boolean): number | undefined {
+    return undefined;
+  }
 }
 
 export abstract class SizedPDFElement extends PDFElement {

--- a/src/lib/elements/rectangle-element.ts
+++ b/src/lib/elements/rectangle-element.ts
@@ -1,5 +1,5 @@
 import { Color } from "../common/color.ts";
-import { BoxConstraints, Offset, Size } from "../layout/box-constraints.ts";
+import { BoxConstraints, Offset, Size, resolveExtent } from "../layout/box-constraints.ts";
 import { Fragmentable, FragmentResult, packChildren } from "../layout/fragmentation.ts";
 import {
   LayoutContext,
@@ -32,6 +32,11 @@ interface RectangleElementParams extends SizedElement, WithChildren {
   /** `"hidden"` crops children to the box (CSS `overflow: hidden`); `"visible"` (default) lets a
    *  `Positioned` child spill over the edge. */
   overflow?: "hidden" | "visible";
+  /** Width as a fraction (0..1) of the offered width, instead of a fixed `width` (CSS `50%`). Only
+   *  resolves in a bounded region; an explicit `width` wins over it. */
+  widthFactor?: number;
+  /** Height as a fraction (0..1) of the offered height; see `widthFactor`. */
+  heightFactor?: number;
 }
 
 export class RectangleElement extends SizedPDFElement implements Fragmentable {
@@ -49,6 +54,8 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
     y: number;
     width?: number;
     height?: number;
+    widthFactor?: number;
+    heightFactor?: number;
   };
 
   constructor({
@@ -62,6 +69,8 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
     sideBorders,
     relative,
     overflow,
+    widthFactor,
+    heightFactor,
   }: RectangleElementParams) {
     super({ x: 0, y: 0, width, height });
 
@@ -74,7 +83,7 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
     this.sideBorders = sideBorders;
     this.relative = relative ?? false;
     this.overflow = overflow ?? "visible";
-    this.sizeMemory = { x: 0, y: 0, width, height };
+    this.sizeMemory = { x: 0, y: 0, width, height, widthFactor, heightFactor };
   }
 
   /**
@@ -86,7 +95,11 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
    * box is sized by what it actually holds on each page.
    */
   fragment(maxHeight: number, width: number, ctx: LayoutContext): FragmentResult {
-    const boxWidth = this.sizeMemory.width ?? width;
+    // A percentage width resolves against the region width the page driver hands us, so a
+    // paginating %-box keeps its fraction on every page.
+    const boxWidth =
+      this.sizeMemory.width ??
+      (this.sizeMemory.widthFactor !== undefined ? width * this.sizeMemory.widthFactor : width);
     const innerWidth = Math.max(0, boxWidth - 2 * this.borderWidth);
     // Border-box: the content is inset by the border on top and bottom, so a fragment
     // holding `c` of content is `c + 2*border` tall. (Derived, not a fudge factor.)
@@ -115,6 +128,9 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
       x: 0,
       y: 0,
       width: this.sizeMemory.width,
+      widthFactor: this.sizeMemory.widthFactor,
+      // A split box is sized by its per-page content (height passed in), so the height factor
+      // is intentionally dropped here - box-decoration-break, same as an explicit height.
       height,
       children,
       color: this.color,
@@ -128,24 +144,39 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
   }
 
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
+    // An explicit extent is a fixed point size or a fraction of the offered box (relative sizing);
+    // the fraction only resolves in a bounded region. `undefined` = fill / shrink-wrap below.
+    const explicitWidth = resolveExtent(
+      this.sizeMemory.width,
+      this.sizeMemory.widthFactor,
+      constraints.maxWidth,
+      constraints.hasBoundedWidth,
+    );
+    const explicitHeight = resolveExtent(
+      this.sizeMemory.height,
+      this.sizeMemory.heightFactor,
+      constraints.maxHeight,
+      constraints.hasBoundedHeight,
+    );
+
     // Width: an explicit size wins (clamped), else fill the offered box. (Without this a
     // fixed box would balloon to the parent's size.)
     this.width =
-      this.sizeMemory.width !== undefined
-        ? constraints.constrainWidth(this.sizeMemory.width)
+      explicitWidth !== undefined
+        ? constraints.constrainWidth(explicitWidth)
         : constraints.hasBoundedWidth
           ? constraints.maxWidth
           : this.width;
     // Width shrink-wrap: no explicit width AND an unbounded region (e.g. a `Box` badge inside a
     // `Positioned`). Resolved after the children are measured, just below.
-    const shrinkWrapWidth = this.sizeMemory.width === undefined && !constraints.hasBoundedWidth;
+    const shrinkWrapWidth = explicitWidth === undefined && !constraints.hasBoundedWidth;
     // Height: explicit wins; otherwise FILL a bounded region (e.g. inside an Expanded) but
     // SHRINK-WRAP the content in an unbounded one (a note box in a stack). Shrink-wrap is
     // resolved after the children are measured, just below.
-    const shrinkWrapHeight = this.sizeMemory.height === undefined && !constraints.hasBoundedHeight;
+    const shrinkWrapHeight = explicitHeight === undefined && !constraints.hasBoundedHeight;
     this.height =
-      this.sizeMemory.height !== undefined
-        ? constraints.constrainHeight(this.sizeMemory.height)
+      explicitHeight !== undefined
+        ? constraints.constrainHeight(explicitHeight)
         : constraints.hasBoundedHeight
           ? constraints.maxHeight
           : this.height;

--- a/src/lib/elements/rectangle-element.ts
+++ b/src/lib/elements/rectangle-element.ts
@@ -143,6 +143,10 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
     });
   }
 
+  override relativeSizeFactor(horizontal: boolean): number | undefined {
+    return horizontal ? this.sizeMemory.widthFactor : this.sizeMemory.heightFactor;
+  }
+
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
     // An explicit extent is a fixed point size or a fraction of the offered box (relative sizing);
     // the fraction only resolves in a bounded region. `undefined` = fill / shrink-wrap below.

--- a/src/lib/elements/row-element.ts
+++ b/src/lib/elements/row-element.ts
@@ -1,4 +1,4 @@
-import { BoxConstraints, Offset, Size } from "../layout/box-constraints.ts";
+import { BoxConstraints, Offset, Size, resolveExtent } from "../layout/box-constraints.ts";
 import { FlexLayoutHelper, HORIZONTAL_AXIS, MainAlign, CrossAlign } from "../utils/flex-layout.ts";
 import { LayoutContext, PDFElement, SizedPDFElement, WithChildren } from "./pdf-element.ts";
 
@@ -9,6 +9,11 @@ interface RowElementParams extends WithChildren {
   main?: MainAlign;
   /** Vertical alignment of each child (cross axis); defaults to `stretch`. */
   cross?: CrossAlign;
+  /** Width/height as points (fixed) or a fraction (0..1) of the offered box (relative sizing). */
+  width?: number;
+  height?: number;
+  widthFactor?: number;
+  heightFactor?: number;
 }
 
 /**
@@ -28,23 +33,56 @@ export class RowElement extends SizedPDFElement {
   private gap: number;
   private main: MainAlign;
   private cross: CrossAlign;
+  // The requested size (fixed points or a fraction), kept separate from the laid-out this.width/height.
+  private requested: { width?: number; height?: number; widthFactor?: number; heightFactor?: number };
 
-  constructor({ children, gap, main, cross }: RowElementParams) {
+  constructor({ children, gap, main, cross, width, height, widthFactor, heightFactor }: RowElementParams) {
     super({ x: 0, y: 0 });
     this.children = children;
     this.gap = gap ?? 0;
     this.main = main ?? "start";
     this.cross = cross ?? "stretch";
+    this.requested = { width, height, widthFactor, heightFactor };
+  }
+
+  override relativeSizeFactor(horizontal: boolean): number | undefined {
+    return horizontal ? this.requested.widthFactor : this.requested.heightFactor;
   }
 
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
     this.x = offset.x;
     this.y = offset.y;
 
-    // Width fills the offered space (flex children split the leftover); height is the
-    // tallest child unless the parent bounds it.
-    const mainAvail = constraints.hasBoundedWidth ? constraints.maxWidth : Infinity;
-    const crossAvail = constraints.hasBoundedHeight ? constraints.maxHeight : Infinity;
+    // Relative sizing: a pinned extent (fixed or a fraction of the offered box, clamped) wins; else
+    // width fills the offered space (flex children split the leftover) and height is the tallest child.
+    const explicitWidth = resolveExtent(
+      this.requested.width,
+      this.requested.widthFactor,
+      constraints.maxWidth,
+      constraints.hasBoundedWidth,
+    );
+    const explicitHeight = resolveExtent(
+      this.requested.height,
+      this.requested.heightFactor,
+      constraints.maxHeight,
+      constraints.hasBoundedHeight,
+    );
+    const boundedWidth =
+      explicitWidth !== undefined
+        ? constraints.constrainWidth(explicitWidth)
+        : constraints.hasBoundedWidth
+          ? constraints.maxWidth
+          : undefined;
+    const boundedHeight =
+      explicitHeight !== undefined
+        ? constraints.constrainHeight(explicitHeight)
+        : constraints.hasBoundedHeight
+          ? constraints.maxHeight
+          : undefined;
+
+    // Horizontal stack: main = width (children fill it), cross = height (children can stretch to it).
+    const mainAvail = boundedWidth ?? Infinity;
+    const crossAvail = boundedHeight ?? Infinity;
 
     let result = { mainUsed: 0, crossUsed: 0 };
     if (this.children.length > 0) {
@@ -60,8 +98,8 @@ export class RowElement extends SizedPDFElement {
       );
     }
 
-    this.width = constraints.hasBoundedWidth ? constraints.maxWidth : result.mainUsed;
-    this.height = constraints.hasBoundedHeight ? constraints.maxHeight : result.crossUsed;
+    this.width = boundedWidth ?? result.mainUsed;
+    this.height = boundedHeight ?? result.crossUsed;
 
     return { width: this.width, height: this.height };
   }

--- a/src/lib/elements/row-element.ts
+++ b/src/lib/elements/row-element.ts
@@ -34,9 +34,23 @@ export class RowElement extends SizedPDFElement {
   private main: MainAlign;
   private cross: CrossAlign;
   // The requested size (fixed points or a fraction), kept separate from the laid-out this.width/height.
-  private requested: { width?: number; height?: number; widthFactor?: number; heightFactor?: number };
+  private requested: {
+    width?: number;
+    height?: number;
+    widthFactor?: number;
+    heightFactor?: number;
+  };
 
-  constructor({ children, gap, main, cross, width, height, widthFactor, heightFactor }: RowElementParams) {
+  constructor({
+    children,
+    gap,
+    main,
+    cross,
+    width,
+    height,
+    widthFactor,
+    heightFactor,
+  }: RowElementParams) {
     super({ x: 0, y: 0 });
     this.children = children;
     this.gap = gap ?? 0;

--- a/src/lib/layout/box-constraints.ts
+++ b/src/lib/layout/box-constraints.ts
@@ -89,6 +89,24 @@ export class BoxConstraints {
   }
 }
 
+/**
+ * Resolves a sized element's extent on one axis (relative sizing). An explicit point size (`fixed`)
+ * always wins; otherwise a `factor` (0..1) of the offered extent, but ONLY when that axis is bounded -
+ * a fraction of an unbounded axis has no meaning (Flutter's FractionallySizedBox under unbounded
+ * constraints). Returns `undefined` to mean "no explicit extent", i.e. fill the box or shrink-wrap.
+ * Shared by every sized element so `width: "50%"` behaves identically across Box / Column / Row / Image.
+ */
+export function resolveExtent(
+  fixed: number | undefined,
+  factor: number | undefined,
+  boundedMax: number,
+  hasBounded: boolean,
+): number | undefined {
+  if (fixed !== undefined) return fixed;
+  if (factor !== undefined && hasBounded) return boundedMax * factor;
+  return undefined;
+}
+
 /** The size an element resolves to and returns UP the tree. */
 export interface Size {
   width: number;

--- a/src/lib/layout/collect-images.ts
+++ b/src/lib/layout/collect-images.ts
@@ -1,0 +1,24 @@
+import { PDFElement, hasChildrenProp, hasChildProp } from "../elements/pdf-element.ts";
+import { ImageElement } from "../elements/image-element.ts";
+
+/**
+ * Walks the element tree (via `getProps`, the same shallow-reflection style as the validator) and
+ * returns every `ImageElement`. A pre-layout pass uses this to resolve each image's intrinsic pixel
+ * size asynchronously: layout is synchronous and cannot await jimp, yet it needs the aspect ratio to
+ * give a width-only image its proportional height. Cheap - images are few and this runs once.
+ */
+export function collectImageElements(root: PDFElement): ImageElement[] {
+  const out: ImageElement[] = [];
+  const visit = (el: PDFElement): void => {
+    if (el instanceof ImageElement) out.push(el);
+    const props = el.getProps() as object;
+    if (hasChildrenProp(props)) for (const c of props.children) visit(c);
+    else if (hasChildProp(props)) visit(props.child);
+    // A page carries its header / footer outside `children`.
+    const pg = props as { header?: unknown; footer?: unknown };
+    if (pg.header instanceof PDFElement) visit(pg.header);
+    if (pg.footer instanceof PDFElement) visit(pg.footer);
+  };
+  visit(root);
+  return out;
+}

--- a/src/lib/layout/collect-images.ts
+++ b/src/lib/layout/collect-images.ts
@@ -14,10 +14,14 @@ export function collectImageElements(root: PDFElement): ImageElement[] {
     const props = el.getProps() as object;
     if (hasChildrenProp(props)) for (const c of props.children) visit(c);
     else if (hasChildProp(props)) visit(props.child);
-    // A page carries its header / footer outside `children`.
-    const pg = props as { header?: unknown; footer?: unknown };
-    if (pg.header instanceof PDFElement) visit(pg.header);
-    if (pg.footer instanceof PDFElement) visit(pg.footer);
+    // Wrappers that hold a subtree outside `children`/`child`: a Page's header/footer and a
+    // RepeatingHeaderElement's `body` (a Table with a header wraps its rows there). A
+    // DeferredElement's `composed` is null until layout runs, so it cannot be reached from this
+    // pre-layout pass; an image inside a deferred subtree just skips aspect pre-resolution.
+    const w = props as { header?: unknown; footer?: unknown; body?: unknown };
+    if (w.header instanceof PDFElement) visit(w.header);
+    if (w.footer instanceof PDFElement) visit(w.footer);
+    if (w.body instanceof PDFElement) visit(w.body);
   };
   visit(root);
   return out;

--- a/src/lib/renderer/pdf-renderer.ts
+++ b/src/lib/renderer/pdf-renderer.ts
@@ -31,6 +31,7 @@ import { PositionedRenderer } from "./positioned-renderer.ts";
 import { StructGroup } from "../elements/layout/struct-group.ts";
 import { StructGroupRenderer } from "./struct-group-renderer.ts";
 import { BoxConstraints } from "../layout/box-constraints.ts";
+import { collectImageElements } from "../layout/collect-images.ts";
 import { LayoutContext } from "../elements/pdf-element.ts";
 import { DEFAULT_TEXT_STYLE, mergeTextStyle } from "../text/text-style.ts";
 
@@ -68,6 +69,11 @@ export class PDFRenderer {
       textStyle: mergeTextStyle(DEFAULT_TEXT_STYLE, document.getDefaultTextStyle()),
       onOverflow: objectManager.getOverflowPolicy(),
     };
+    // Pre-layout: resolve every image's intrinsic pixel size (async), so the synchronous layout can
+    // give a width-only image a proportional height. init() is idempotent, so the renderer reuses it.
+    const images = collectImageElements(document);
+    if (images.length > 0) await Promise.all(images.map((img) => img.resolveIntrinsicSize()));
+
     document.calculateLayout(new BoxConstraints(), { x: 0, y: 0 }, ctx);
 
     // Render pages and contents (the driver paginates overflowing pages).

--- a/src/lib/utils/flex-layout.ts
+++ b/src/lib/utils/flex-layout.ts
@@ -15,18 +15,25 @@ export type CrossAlign = "start" | "center" | "end" | "stretch";
  * (main = width). "main" is the stacking direction; "cross" is perpendicular.
  */
 export interface FlexAxis {
+  /** Whether the MAIN (stacking) axis is horizontal - i.e. this is a Row. Used to ask a child for the
+   *  right relative-size factor (width vs height) when resolving a percentage child. */
+  mainHorizontal: boolean;
   mainOf(size: Size): number;
   crossOf(size: Size): number;
   /**
-   * Constraints for a fixed child: the main extent is unbounded (it takes its natural
-   * size); the cross extent is ALWAYS capped to what the line offers. The cap is a hard
+   * Constraints for a fixed child: the main extent is unbounded by default (the child takes its
+   * natural size); the cross extent is ALWAYS capped to what the line offers. The cap is a hard
    * ceiling regardless of `cross` alignment - it is what guarantees nothing ever overflows
    * (a paragraph wraps at the column width instead of running one line off the page). A
    * child smaller than the cap keeps its size and is positioned by `crossOffset`; a child
    * that wants to fill (Container, Text) fills the cap. So `stretch` vs `start/center/end`
    * differ only in where a smaller child sits, never in the ceiling.
+   *
+   * `mainMax` bounds the main axis too (default unbounded): passed only for a PERCENTAGE child, so its
+   * `width: "50%"` can resolve against the space the line offers its items. A plain child keeps the
+   * unbounded main axis and shrink-wraps as before.
    */
-  measureConstraints(crossAvail: number): BoxConstraints;
+  measureConstraints(crossAvail: number, mainMax?: number): BoxConstraints;
   /** Constraints for a flex child (fills the cross axis like a stretched child). */
   flexConstraints(mainExtent: number, crossAvail: number): BoxConstraints;
   /** Absolute offset for a child at main position `mainPos`, cross position `crossPos`. */
@@ -34,17 +41,19 @@ export interface FlexAxis {
 }
 
 export const VERTICAL_AXIS: FlexAxis = {
+  mainHorizontal: false,
   mainOf: (s) => s.height,
   crossOf: (s) => s.width,
-  measureConstraints: (crossAvail) => BoxConstraints.loose(crossAvail, Infinity),
+  measureConstraints: (crossAvail, mainMax = Infinity) => BoxConstraints.loose(crossAvail, mainMax),
   flexConstraints: (mainExtent, crossAvail) => BoxConstraints.loose(crossAvail, mainExtent),
   offsetAt: (mainPos, crossPos) => ({ x: crossPos, y: mainPos }),
 };
 
 export const HORIZONTAL_AXIS: FlexAxis = {
+  mainHorizontal: true,
   mainOf: (s) => s.width,
   crossOf: (s) => s.height,
-  measureConstraints: (crossAvail) => BoxConstraints.loose(Infinity, crossAvail),
+  measureConstraints: (crossAvail, mainMax = Infinity) => BoxConstraints.loose(mainMax, crossAvail),
   flexConstraints: (mainExtent, crossAvail) => BoxConstraints.loose(mainExtent, crossAvail),
   offsetAt: (mainPos, crossPos) => ({ x: mainPos, y: crossPos }),
 };
@@ -86,6 +95,19 @@ export class FlexLayoutHelper {
     const main = options.main ?? "start";
     const cross = options.cross ?? "stretch";
     const count = children.length;
+    const totalGap = Math.max(0, count - 1) * gap;
+
+    // The main extent a percentage child resolves against: the line's own extent minus the gaps
+    // between the items. So N children at (100/N)% + gaps fit exactly, instead of overflowing by the
+    // gaps (the flexbox `width: 33%` + gap trap). Only finite when the line's main axis is bounded -
+    // a fraction of an unbounded main axis has no meaning, so `%` children fall back to shrink-wrap.
+    const percentBase = mainAvail !== Infinity ? Math.max(0, mainAvail - totalGap) : Infinity;
+    // The main cap to hand a child: `percentBase` for a percentage child (so its fraction resolves),
+    // unbounded for everyone else (they keep their natural / fixed size and never fill the line).
+    const mainCapFor = (child: PDFElement): number =>
+      percentBase !== Infinity && child.relativeSizeFactor(axis.mainHorizontal) !== undefined
+        ? percentBase
+        : Infinity;
 
     // Pass 1: measure the fixed children (main extent + cross size) and total the flex.
     let fixedMain = 0;
@@ -97,7 +119,7 @@ export class FlexLayoutHelper {
         totalFlex += child.getFlex();
       } else {
         const size = child.calculateLayout(
-          axis.measureConstraints(crossAvail),
+          axis.measureConstraints(crossAvail, mainCapFor(child)),
           axis.offsetAt(mainStart, crossOrigin),
           ctx,
         );
@@ -107,7 +129,6 @@ export class FlexLayoutHelper {
       }
     }
 
-    const totalGap = Math.max(0, count - 1) * gap;
     const leftover = mainAvail - fixedMain - totalGap;
     const remaining = Math.max(leftover, 0); // for flex children
 
@@ -165,7 +186,7 @@ export class FlexLayoutHelper {
       } else {
         const childCross = axis.crossOf(fixedSize.get(child)!);
         const size = child.calculateLayout(
-          axis.measureConstraints(stretch ? crossExtent : crossAvail),
+          axis.measureConstraints(stretch ? crossExtent : crossAvail, mainCapFor(child)),
           axis.offsetAt(mainPos, crossOrigin + crossOffset(cross, crossExtent, childCross)),
           ctx,
         );

--- a/tests/unit/api/dimension.test.ts
+++ b/tests/unit/api/dimension.test.ts
@@ -21,4 +21,10 @@ describe("toDimension", () => {
     expect(() => toDimension("50px" as `${number}%`)).toThrow(/Invalid size/);
     expect(() => toDimension("wide" as `${number}%`)).toThrow(/Invalid size/);
   });
+
+  it("rejects a negative size (points or percentage)", () => {
+    expect(() => toDimension(-10)).toThrow(/negative/);
+    expect(() => toDimension("-50%" as `${number}%`)).toThrow(/Invalid size/);
+    expect(toDimension(0)).toEqual({ points: 0 }); // zero is still valid
+  });
 });

--- a/tests/unit/api/dimension.test.ts
+++ b/tests/unit/api/dimension.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { toDimension } from "../../../src/lib/api/dimension";
+
+describe("toDimension", () => {
+  it("a number is a fixed point size", () => {
+    expect(toDimension(120)).toEqual({ points: 120 });
+    expect(toDimension(0)).toEqual({ points: 0 });
+  });
+
+  it("a percentage string is a 0..1 factor", () => {
+    expect(toDimension("50%")).toEqual({ factor: 0.5 });
+    expect(toDimension("100%")).toEqual({ factor: 1 });
+    expect(toDimension("12.5%")).toEqual({ factor: 0.125 });
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(toDimension(" 25% " as `${number}%`)).toEqual({ factor: 0.25 });
+  });
+
+  it("rejects a size that is neither a number nor a percentage", () => {
+    expect(() => toDimension("50px" as `${number}%`)).toThrow(/Invalid size/);
+    expect(() => toDimension("wide" as `${number}%`)).toThrow(/Invalid size/);
+  });
+});

--- a/tests/unit/api/image-relative-sizing.test.ts
+++ b/tests/unit/api/image-relative-sizing.test.ts
@@ -69,4 +69,15 @@ describe("Image relative sizing + aspect auto-height", () => {
       BoxFit.contain,
     );
   });
+
+  it("re-resolves the factor on every layout pass instead of freezing it (fragmentation-safe)", async () => {
+    const img = Image(new FakeImage(400, 200), { width: "50%" });
+    await img.resolveIntrinsicSize();
+    const first = img.calculateLayout(BoxConstraints.loose(400, Infinity), { x: 0, y: 0 }, ctx);
+    expect(first.width).toBe(200);
+    // A second pass at a narrower width must recompute, not stay frozen at 200.
+    const second = img.calculateLayout(BoxConstraints.loose(300, Infinity), { x: 0, y: 0 }, ctx);
+    expect(second.width).toBe(150);
+    expect(second.height).toBe(75); // aspect follows the re-resolved width
+  });
 });

--- a/tests/unit/api/image-relative-sizing.test.ts
+++ b/tests/unit/api/image-relative-sizing.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { Image } from "../../../src/lib/api/content";
+import { CustomImage, BoxFit } from "../../../src/lib/elements/image-element";
+import { BoxConstraints } from "../../../src/lib/layout/box-constraints";
+import { LayoutContext } from "../../../src/lib/elements/pdf-element";
+
+// A stand-in image with a fixed intrinsic size, so aspect math is deterministic and needs no IO.
+class FakeImage extends CustomImage {
+  constructor(
+    private w: number,
+    private h: number,
+  ) {
+    super();
+  }
+  async init(): Promise<void> {}
+  async getImageType(): Promise<string> {
+    return "DCTDecode";
+  }
+  async getFileData(): Promise<string> {
+    return "x";
+  }
+  async getImageDimensions(): Promise<{ width: number; height: number }> {
+    return { width: this.w, height: this.h };
+  }
+}
+
+const ctx = {} as LayoutContext;
+const region = BoxConstraints.loose(400, Infinity);
+
+describe("Image relative sizing + aspect auto-height", () => {
+  it("a fixed width gives a proportional height from the intrinsic ratio (400x200 -> ratio 2)", async () => {
+    const img = Image(new FakeImage(400, 200), { width: 100 });
+    await img.resolveIntrinsicSize();
+    const size = img.calculateLayout(region, { x: 0, y: 0 }, ctx);
+    expect(size.width).toBe(100);
+    expect(size.height).toBe(50); // 100 / 2
+  });
+
+  it("a percentage width resolves against the offered width, height follows the ratio", async () => {
+    const img = Image(new FakeImage(400, 200), { width: "50%" });
+    await img.resolveIntrinsicSize();
+    const size = img.calculateLayout(region, { x: 0, y: 0 }, ctx);
+    expect(size.width).toBe(200); // 50% of 400
+    expect(size.height).toBe(100); // 200 / 2
+  });
+
+  it("pinning the height instead derives the width from the ratio", async () => {
+    const img = Image(new FakeImage(400, 200), { height: 80 });
+    await img.resolveIntrinsicSize();
+    const size = img.calculateLayout(region, { x: 0, y: 0 }, ctx);
+    expect(size.height).toBe(80);
+    expect(size.width).toBe(160); // 80 * 2
+  });
+
+  it("pinning exactly one axis scales the image to the box (fit: fill)", () => {
+    expect(Image(new FakeImage(400, 200), { width: 100 }).getProps().fit).toBe(BoxFit.fill);
+    expect(Image(new FakeImage(400, 200), { height: 80 }).getProps().fit).toBe(BoxFit.fill);
+  });
+
+  it("both axes or neither keep the default fit (none) - unchanged behavior", () => {
+    expect(Image(new FakeImage(400, 200), { width: 100, height: 100 }).getProps().fit).toBe(
+      BoxFit.none,
+    );
+    expect(Image(new FakeImage(400, 200)).getProps().fit).toBe(BoxFit.none);
+  });
+
+  it("an explicit fit always wins over the auto-fill default", () => {
+    expect(Image(new FakeImage(400, 200), { width: 100, fit: "contain" }).getProps().fit).toBe(
+      BoxFit.contain,
+    );
+  });
+});

--- a/tests/unit/api/relative-sizing.test.ts
+++ b/tests/unit/api/relative-sizing.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { Box } from "../../../src/lib/api/layout";
+import { RectangleElement } from "../../../src/lib/elements/rectangle-element";
+import { BoxConstraints } from "../../../src/lib/layout/box-constraints";
+import { LayoutContext } from "../../../src/lib/elements/pdf-element";
+
+// A childless, border-less box so its size is purely what relative sizing resolves to (no border,
+// no content). Layout needs no metrics because there are no children to measure.
+const box = (opts: { width?: `${number}%` | number; height?: `${number}%` | number }) =>
+  Box({ borderWidth: 0, ...opts }, []);
+const ctx = {} as LayoutContext;
+
+describe("relative sizing (Box width/height as a percentage)", () => {
+  it("width '50%' takes half the offered (bounded) width", () => {
+    const size = box({ width: "50%" }).calculateLayout(
+      BoxConstraints.loose(200, Infinity),
+      { x: 0, y: 0 },
+      ctx,
+    );
+    expect(size.width).toBe(100);
+  });
+
+  it("height '50%' takes half the offered (bounded) height", () => {
+    const size = box({ height: "50%" }).calculateLayout(
+      BoxConstraints.loose(200, 400),
+      { x: 0, y: 0 },
+      ctx,
+    );
+    expect(size.height).toBe(200);
+  });
+
+  it("a fixed point width still passes straight through", () => {
+    const size = box({ width: 120 }).calculateLayout(
+      BoxConstraints.loose(200, Infinity),
+      { x: 0, y: 0 },
+      ctx,
+    );
+    expect(size.width).toBe(120);
+  });
+
+  it("a percentage over 100% is clamped to the region (never overflows the parent)", () => {
+    const size = box({ width: "150%" }).calculateLayout(
+      BoxConstraints.loose(200, Infinity),
+      { x: 0, y: 0 },
+      ctx,
+    );
+    expect(size.width).toBe(200);
+  });
+
+  it("a percentage width is a no-op in an unbounded region (shrink-wraps instead)", () => {
+    // A fixed 40pt child so shrink-wrap is observable; maxWidth Infinity = unbounded.
+    const child = new RectangleElement({ x: 0, y: 0, children: [], width: 40, height: 20 });
+    const size = Box({ borderWidth: 0, width: "50%" }, [child]).calculateLayout(
+      BoxConstraints.loose(Infinity, Infinity),
+      { x: 0, y: 0 },
+      ctx,
+    );
+    expect(size.width).toBe(40); // the child's width, not a fraction of infinity
+  });
+});

--- a/tests/unit/api/relative-sizing.test.ts
+++ b/tests/unit/api/relative-sizing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Box } from "../../../src/lib/api/layout";
+import { Box, Column, Row } from "../../../src/lib/api/layout";
 import { RectangleElement } from "../../../src/lib/elements/rectangle-element";
 import { BoxConstraints } from "../../../src/lib/layout/box-constraints";
 import { LayoutContext } from "../../../src/lib/elements/pdf-element";
@@ -56,5 +56,69 @@ describe("relative sizing (Box width/height as a percentage)", () => {
       ctx,
     );
     expect(size.width).toBe(40); // the child's width, not a fraction of infinity
+  });
+});
+
+describe("relative sizing on flex stacks (Column / Row)", () => {
+  it("a Column takes a percentage of the offered width", () => {
+    const size = Column({ width: "50%" }, []).calculateLayout(
+      BoxConstraints.loose(400, Infinity),
+      { x: 0, y: 0 },
+      ctx,
+    );
+    expect(size.width).toBe(200);
+  });
+
+  it("a Row takes a percentage of the offered width", () => {
+    const size = Row({ width: "50%" }, []).calculateLayout(
+      BoxConstraints.loose(400, Infinity),
+      { x: 0, y: 0 },
+      ctx,
+    );
+    expect(size.width).toBe(200);
+  });
+
+  it("a Column height percentage resolves against a bounded height", () => {
+    const size = Column({ height: "50%" }, []).calculateLayout(
+      BoxConstraints.loose(400, 300),
+      { x: 0, y: 0 },
+      ctx,
+    );
+    expect(size.height).toBe(150);
+  });
+
+  it("without a size a Column still fills a bounded width (unchanged behavior)", () => {
+    const size = Column([]).calculateLayout(BoxConstraints.loose(400, Infinity), { x: 0, y: 0 }, ctx);
+    expect(size.width).toBe(400);
+  });
+});
+
+describe("percentage children inside a Row (resolve against the line minus the gaps)", () => {
+  const box = (w: `${number}%`) => Box({ borderWidth: 0, width: w }, []);
+
+  it("two 50% children tile the Row exactly, with the gap between them", () => {
+    const b1 = box("50%");
+    const b2 = box("50%");
+    Row({ gap: 20 }, [b1, b2]).calculateLayout(BoxConstraints.loose(400, Infinity), { x: 0, y: 0 }, ctx);
+    // percent base = 400 - 20 gap = 380 -> each 190; they meet the gap, last edge = row width.
+    expect(b1.getProps().width).toBe(190);
+    expect(b2.getProps().width).toBe(190);
+    expect(b2.getProps().x).toBe(210); // 190 + 20 gap
+    expect(b2.getProps().x + b2.getProps().width).toBe(400); // no overflow
+  });
+
+  it("three 33% children fit inside the Row instead of overflowing the gaps", () => {
+    const boxes = [box("33%"), box("33%"), box("33%")];
+    Row({ gap: 10 }, boxes).calculateLayout(BoxConstraints.loose(310, Infinity), { x: 0, y: 0 }, ctx);
+    // base = 310 - 20 gaps = 290; each 0.33*290 = 95.7; last right edge stays within 310.
+    for (const b of boxes) expect(b.getProps().width).toBeCloseTo(95.7, 3);
+    const last = boxes[2].getProps();
+    expect(last.x + last.width).toBeLessThanOrEqual(310);
+  });
+
+  it("a percentage child stays a no-op in an unbounded Row (nothing to resolve against)", () => {
+    const b = Box({ borderWidth: 0, width: "50%" }, []);
+    Row({}, [b]).calculateLayout(BoxConstraints.loose(Infinity, Infinity), { x: 0, y: 0 }, ctx);
+    expect(b.getProps().width).toBe(0); // no bounded main axis -> shrink-wraps (empty box)
   });
 });

--- a/tests/unit/api/relative-sizing.test.ts
+++ b/tests/unit/api/relative-sizing.test.ts
@@ -88,7 +88,11 @@ describe("relative sizing on flex stacks (Column / Row)", () => {
   });
 
   it("without a size a Column still fills a bounded width (unchanged behavior)", () => {
-    const size = Column([]).calculateLayout(BoxConstraints.loose(400, Infinity), { x: 0, y: 0 }, ctx);
+    const size = Column([]).calculateLayout(
+      BoxConstraints.loose(400, Infinity),
+      { x: 0, y: 0 },
+      ctx,
+    );
     expect(size.width).toBe(400);
   });
 });
@@ -99,7 +103,11 @@ describe("percentage children inside a Row (resolve against the line minus the g
   it("two 50% children tile the Row exactly, with the gap between them", () => {
     const b1 = box("50%");
     const b2 = box("50%");
-    Row({ gap: 20 }, [b1, b2]).calculateLayout(BoxConstraints.loose(400, Infinity), { x: 0, y: 0 }, ctx);
+    Row({ gap: 20 }, [b1, b2]).calculateLayout(
+      BoxConstraints.loose(400, Infinity),
+      { x: 0, y: 0 },
+      ctx,
+    );
     // percent base = 400 - 20 gap = 380 -> each 190; they meet the gap, last edge = row width.
     expect(b1.getProps().width).toBe(190);
     expect(b2.getProps().width).toBe(190);
@@ -109,7 +117,11 @@ describe("percentage children inside a Row (resolve against the line minus the g
 
   it("three 33% children fit inside the Row instead of overflowing the gaps", () => {
     const boxes = [box("33%"), box("33%"), box("33%")];
-    Row({ gap: 10 }, boxes).calculateLayout(BoxConstraints.loose(310, Infinity), { x: 0, y: 0 }, ctx);
+    Row({ gap: 10 }, boxes).calculateLayout(
+      BoxConstraints.loose(310, Infinity),
+      { x: 0, y: 0 },
+      ctx,
+    );
     // base = 310 - 20 gaps = 290; each 0.33*290 = 95.7; last right edge stays within 310.
     for (const b of boxes) expect(b.getProps().width).toBeCloseTo(95.7, 3);
     const last = boxes[2].getProps();

--- a/tests/unit/renderer/pdf-renderer.test.ts
+++ b/tests/unit/renderer/pdf-renderer.test.ts
@@ -63,6 +63,7 @@ describe("PDFRenderer", () => {
     const mockDocumentElement = {
       calculateLayout: vi.fn(),
       getDefaultTextStyle: vi.fn(),
+      getProps: vi.fn().mockReturnValue({ children: [] }),
     } as unknown as PDFDocumentElement;
 
     await PDFRenderer.render(mockDocumentElement, mockObjectManager);
@@ -75,6 +76,7 @@ describe("PDFRenderer", () => {
     const mockDocumentElement = {
       calculateLayout: vi.fn(),
       getDefaultTextStyle: vi.fn(),
+      getProps: vi.fn().mockReturnValue({ children: [] }),
     } as unknown as PDFDocumentElement;
 
     const result = await PDFRenderer.render(mockDocumentElement, mockObjectManager);
@@ -90,6 +92,7 @@ describe("PDFRenderer", () => {
     const mockDocumentElement = {
       calculateLayout: vi.fn(),
       getDefaultTextStyle: vi.fn(),
+      getProps: vi.fn().mockReturnValue({ children: [] }),
     } as unknown as PDFDocumentElement;
 
     await PDFRenderer.render(mockDocumentElement, mockObjectManager);
@@ -101,6 +104,7 @@ describe("PDFRenderer", () => {
     const mockDocumentElement = {
       calculateLayout: vi.fn(),
       getDefaultTextStyle: vi.fn(),
+      getProps: vi.fn().mockReturnValue({ children: [] }),
     } as unknown as PDFDocumentElement;
 
     const result = await PDFRenderer.render(mockDocumentElement, mockObjectManager);


### PR DESCRIPTION
## Summary

Relative width/height for `Box`, `Rect` and `Image` element. Now we can set `width: 40%` relative to its parent, including padding and gap!

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added percentage-based sizing via a new size conversion utility, including factor-based extents for boxes, stacks (rows/columns), and images.
  * Images now support relative sizing and can auto-derive the unpinned axis from intrinsic dimensions.
  * Expanded the public API surface to include the new sizing utilities.
* **Bug Fixes**
  * Improved layout and page-fragment behavior to preserve expected width/height (including shrink-wrap on split fragments).
  * Renderer now resolves intrinsic image dimensions before layout.
* **Tests**
  * Added unit tests for size conversion, relative sizing, image scaling, and updated renderer mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->