### PR TITLE
fix: handle wrong font size

### DIFF
--- a/src/lib/api/text.ts
+++ b/src/lib/api/text.ts
@@ -57,10 +57,13 @@ function toFontSize(size: unknown): number | undefined {
   if (typeof size !== "number" || !Number.isFinite(size) || size <= 0) {
     // Quote a string so "A4" reads as a string; show a bare number/NaN as-is (JSON turns NaN into null).
     const shown = typeof size === "string" ? JSON.stringify(size) : String(size);
-    throw new Error(
-      `Invalid font size ${shown} (expected a positive number of points). ` +
-        `Note: the page size goes on Page({ size: "A4" }), not on Document or Text.`,
-    );
+    // The Page-vs-font-size mix-up only happens with a string like "A4"; for a plain bad number
+    // (NaN, negative, 0) the hint would just be noise, so keep the message generic there.
+    const hint =
+      typeof size === "string"
+        ? ` Note: the page size goes on Page({ size: "A4" }), not on Document or Text.`
+        : "";
+    throw new Error(`Invalid font size ${shown} (expected a positive number of points).${hint}`);
   }
   return size;
 }

--- a/src/lib/api/text.ts
+++ b/src/lib/api/text.ts
@@ -48,13 +48,31 @@ const ALIGN: Record<NonNullable<TextOptions["align"]>, HorizontalAlignment> = {
 };
 
 /**
+ * Validates a font `size` (a number of points). Rejects anything that would silently become a NaN
+ * height deep in layout - notably `Document({ size: "A4" })`, where `"A4"` is the PAGE size and belongs
+ * on `Page`, not a font size. `undefined` passes through (unset = inherit the cascade).
+ */
+function toFontSize(size: unknown): number | undefined {
+  if (size === undefined) return undefined;
+  if (typeof size !== "number" || !Number.isFinite(size) || size <= 0) {
+    // Quote a string so "A4" reads as a string; show a bare number/NaN as-is (JSON turns NaN into null).
+    const shown = typeof size === "string" ? JSON.stringify(size) : String(size);
+    throw new Error(
+      `Invalid font size ${shown} (expected a positive number of points). ` +
+        `Note: the page size goes on Page({ size: "A4" }), not on Document or Text.`,
+    );
+  }
+  return size;
+}
+
+/**
  * An inline run for mixed-style `Text` (`Text([span("a", {bold:true}), span("b")])`). Each
  * field overrides the enclosing `Text`'s defaults for just this run; omitted fields inherit.
  */
 export function span(text: string, style: TextStyle = {}): TextSegment {
   return {
     content: text,
-    fontSize: style.size,
+    fontSize: toFontSize(style.size),
     fontFamily: style.font,
     fontStyle:
       style.bold !== undefined || style.italic !== undefined
@@ -74,7 +92,7 @@ export function Text(content: string | TextSegment[], opts: TextOptions = {}): T
   // built-in). Only bold/italic that the caller actually set become an explicit FontStyle.
   return new TextElement({
     content,
-    fontSize: opts.size,
+    fontSize: toFontSize(opts.size),
     fontFamily: opts.font,
     fontStyle:
       opts.bold !== undefined || opts.italic !== undefined
@@ -110,7 +128,7 @@ export interface TextDefaults {
  *  fields), for seeding the inheritance cascade. */
 export function toTextStyleOverride(opts: TextDefaults): Partial<ResolvedTextStyle> {
   const style: Partial<ResolvedTextStyle> = {};
-  if (opts.size !== undefined) style.fontSize = opts.size;
+  if (opts.size !== undefined) style.fontSize = toFontSize(opts.size);
   if (opts.font !== undefined) style.fontFamily = opts.font;
   if (opts.bold !== undefined || opts.italic !== undefined) {
     style.fontStyle = toFontStyle(opts.bold, opts.italic);

--- a/tests/unit/api/font-size-validation.test.ts
+++ b/tests/unit/api/font-size-validation.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { Text, span } from "../../../src/lib/api/text";
+import { Document } from "../../../src/lib/api/structure";
+import { Page } from "../../../src/lib/api/structure";
+
+// A non-numeric / non-positive font size used to become a silent NaN height deep in layout (it only
+// surfaced as a misleading "StructGroup is NaNpt tall" crash once the page paginated). The classic
+// footgun is Document({ size: "A4" }), where "A4" is the PAGE size. These lock in a clear early error.
+const bad = (v: unknown) => v as unknown as number;
+
+describe("font size validation", () => {
+  it("rejects a string size and points at the page-size mistake", () => {
+    expect(() => Document({ size: bad("A4") }, [Page([Text("hi")])])).toThrow(
+      /Invalid font size "A4"/,
+    );
+    expect(() => Document({ size: bad("A4") }, [Page([Text("hi")])])).toThrow(/Page\(\{ size/);
+  });
+
+  it("rejects a string / negative / NaN size on Text and span", () => {
+    expect(() => Text("hi", { size: bad("A4") })).toThrow(/Invalid font size/);
+    expect(() => span("hi", { size: bad(-5) })).toThrow(/Invalid font size -5/);
+    expect(() => Text("hi", { size: bad(NaN) })).toThrow(/Invalid font size NaN/);
+    expect(() => Text("hi", { size: bad(0) })).toThrow(/Invalid font size 0/);
+  });
+
+  it("accepts a valid positive size, and leaves an unset size to inherit", () => {
+    expect(() => Text("hi", { size: 11 })).not.toThrow();
+    expect(() => Document({ size: 12 }, [Page([Text("hi")])])).not.toThrow();
+    expect(() => Text("hi")).not.toThrow(); // unset -> inherits the cascade
+  });
+});

--- a/tests/unit/api/font-size-validation.test.ts
+++ b/tests/unit/api/font-size-validation.test.ts
@@ -23,6 +23,18 @@ describe("font size validation", () => {
     expect(() => Text("hi", { size: bad(0) })).toThrow(/Invalid font size 0/);
   });
 
+  it("adds the Page-size hint only for a string, not for a plain bad number", () => {
+    expect(() => Document({ size: bad("A4") }, [Page([Text("hi")])])).toThrow(/Page\(\{ size/);
+    let msg = "";
+    try {
+      span("hi", { size: bad(-5) });
+    } catch (e) {
+      msg = (e as Error).message;
+    }
+    expect(msg).toMatch(/expected a positive number/);
+    expect(msg).not.toContain("Page("); // no page hint for a plain invalid number
+  });
+
   it("accepts a valid positive size, and leaves an unset size to inherit", () => {
     expect(() => Text("hi", { size: 11 })).not.toThrow();
     expect(() => Document({ size: 12 }, [Page([Text("hi")])])).not.toThrow();


### PR DESCRIPTION
## Summary

If you set a wrong font size jasy crashed. Now the fix handles wrong size params correctly.

## Related issue(s)

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [x] No breaking changes (or called out above)
- [ ] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved font size validation to reject invalid values early instead of applying them silently.
  * Invalid font sizes now produce clear error messages, including a hint when common page-size mix-ups are detected.
  * Font size can still be omitted to preserve inherited styling behavior.

* **Tests**
  * Added unit tests covering invalid and valid font sizes across text rendering entry points, including message accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->