### PR TITLE
feat: hyperlinks, bookmarks and anchors

### DIFF
--- a/src/lib/api/layout.ts
+++ b/src/lib/api/layout.ts
@@ -6,6 +6,7 @@ import { PaddingElement } from "../elements/layout/padding-element.ts";
 import { PositionedElement, PositionedInsets } from "../elements/layout/positioned-element.ts";
 import { LinkElement } from "../elements/layout/link-element.ts";
 import { BookmarkElement } from "../elements/layout/bookmark-element.ts";
+import { AnchorElement } from "../elements/layout/anchor-element.ts";
 import { PDFElement } from "../elements/pdf-element.ts";
 import { MainAlign, CrossAlign } from "../utils/flex-layout.ts";
 import { ColorInput, toColor } from "./color.ts";
@@ -179,14 +180,30 @@ export function Positioned(opts: PositionedInsets, child: PDFElement): Positione
 }
 
 /**
- * Makes any `child` a clickable hyperlink to `href` (an external URL) - the child's whole box is the
- * clickable region (an image, a box, a row). The link draws nothing itself, so style the child if you
- * want it to look like one - e.g. `Link({ href }, Text("jasy.dev", { color: "#1450aa" }))`. It becomes
- * a /Link annotation on the page. For a link on part of a line, put `href` on a `Text`/`span` instead
- * (`Text([span("Visit "), span("jasy.dev", { href, color: "#1450aa" })])`), which links just that run.
+ * Makes any `child` a clickable hyperlink - the child's whole box is the clickable region (an image, a
+ * box, a row). Pass `href` for an external URL, or `to` for an internal jump to an `Anchor({ name })`
+ * elsewhere in the document (e.g. a clickable table-of-contents row). Exactly one of the two. The link
+ * draws nothing itself, so style the child - e.g. `Link({ href }, Text("jasy.dev", { color: "#1450aa" }))`
+ * or `Link({ to: "chapter-2" }, Text("Chapter 2 ....... 5"))`. For a link on part of a line, put `href`/
+ * `to` on a `span` instead (`Text([span("Visit "), span("jasy.dev", { href })])`), linking just that run.
  */
-export function Link(opts: { href: string }, child: PDFElement): LinkElement {
-  return new LinkElement({ href: opts.href, child });
+export function Link(opts: { href?: string; to?: string }, child: PDFElement): LinkElement {
+  if ((opts.href === undefined) === (opts.to === undefined)) {
+    throw new Error(
+      "Link needs exactly one of `href` (external URL) or `to` (internal Anchor name).",
+    );
+  }
+  return new LinkElement({ href: opts.href, dest: opts.to, child });
+}
+
+/**
+ * Marks `child` as a named jump target that an internal `Link({ to: name })` can point at (a table of
+ * contents linking to sections, cross-references). Layout-transparent: `child` renders exactly as it
+ * would on its own, on whatever page it lands on. `name` must match the link's `to`.
+ * `Anchor({ name: "chapter-2" }, Text("Chapter 2", { size: 24 }))`.
+ */
+export function Anchor(opts: { name: string }, child: PDFElement): AnchorElement {
+  return new AnchorElement({ name: opts.name, child });
 }
 
 /**

--- a/src/lib/api/layout.ts
+++ b/src/lib/api/layout.ts
@@ -4,6 +4,8 @@ import { RectangleElement } from "../elements/rectangle-element.ts";
 import { ExpandedElement } from "../elements/layout/expanded-element.ts";
 import { PaddingElement } from "../elements/layout/padding-element.ts";
 import { PositionedElement, PositionedInsets } from "../elements/layout/positioned-element.ts";
+import { LinkElement } from "../elements/layout/link-element.ts";
+import { BookmarkElement } from "../elements/layout/bookmark-element.ts";
 import { PDFElement } from "../elements/pdf-element.ts";
 import { MainAlign, CrossAlign } from "../utils/flex-layout.ts";
 import { ColorInput, toColor } from "./color.ts";
@@ -174,6 +176,30 @@ export function Padding(padding: Insets, child: PDFElement): PaddingElement {
  */
 export function Positioned(opts: PositionedInsets, child: PDFElement): PositionedElement {
   return new PositionedElement({ child, ...opts });
+}
+
+/**
+ * Makes any `child` a clickable hyperlink to `href` (an external URL) - the child's whole box is the
+ * clickable region (an image, a box, a row). The link draws nothing itself, so style the child if you
+ * want it to look like one - e.g. `Link({ href }, Text("jasy.dev", { color: "#1450aa" }))`. It becomes
+ * a /Link annotation on the page. For a link on part of a line, put `href` on a `Text`/`span` instead
+ * (`Text([span("Visit "), span("jasy.dev", { href, color: "#1450aa" })])`), which links just that run.
+ */
+export function Link(opts: { href: string }, child: PDFElement): LinkElement {
+  return new LinkElement({ href: opts.href, child });
+}
+
+/**
+ * Adds a bookmark to the document outline (the viewer's sidebar) that jumps to `child`. `title` is the
+ * label; `level` (1-based, default 1) nests it - a `level: 2` bookmark hangs under the nearest preceding
+ * `level: 1`, so you get a collapsible tree (chapters -> sections). It is layout-transparent: `child`
+ * renders exactly as it would on its own. `Bookmark({ title: "Chapter 2", level: 1 }, Text("Chapter 2"))`.
+ */
+export function Bookmark(
+  opts: { title: string; level?: number },
+  child: PDFElement,
+): BookmarkElement {
+  return new BookmarkElement({ title: opts.title, level: opts.level, child });
 }
 
 /**

--- a/src/lib/api/text.ts
+++ b/src/lib/api/text.ts
@@ -18,6 +18,9 @@ export interface TextStyle {
   /** External URL - makes this run an inline hyperlink (a /Link annotation over its glyphs). On a
    *  `span` it links just that run; on a whole `Text` (plain string) it links the whole text. */
   href?: string;
+  /** Internal jump target - the `name` of an `Anchor` elsewhere in the document (like `href`, but a
+   *  same-document /GoTo instead of a URL). Use for a clickable table of contents / cross-reference. */
+  to?: string;
 }
 
 export interface TextOptions extends TextStyle {
@@ -86,6 +89,7 @@ export function span(text: string, style: TextStyle = {}): TextSegment {
         : undefined,
     fontColor: style.color !== undefined ? toColor(style.color) : undefined,
     href: style.href,
+    dest: style.to,
   };
 }
 
@@ -95,11 +99,11 @@ export function span(text: string, style: TextStyle = {}): TextSegment {
  * text-internal `align`.
  */
 export function Text(content: string | TextSegment[], opts: TextOptions = {}): TextElement {
-  // A plain string given an `href` becomes a single link span, so `Text("jasy.dev", { href })` is a
-  // whole-text link (inline links use `span(...)`). This routes through the styled-segment path,
-  // which lays a single default-font segment out identically - only the /Link annotation is added.
-  const body =
-    typeof content === "string" && opts.href !== undefined ? [span(content, opts)] : content;
+  // A plain string given an `href`/`to` becomes a single link span, so `Text("jasy.dev", { href })` (or
+  // `{ to }`) is a whole-text link (inline links use `span(...)`). This routes through the styled-segment
+  // path, which lays a single default-font segment out identically - only the /Link annotation is added.
+  const isLink = opts.href !== undefined || opts.to !== undefined;
+  const body = typeof content === "string" && isLink ? [span(content, opts)] : content;
   // Unset properties are left undefined so they inherit the cascaded TextStyle (Document default /
   // built-in). Only bold/italic that the caller actually set become an explicit FontStyle.
   return new TextElement({

--- a/src/lib/api/text.ts
+++ b/src/lib/api/text.ts
@@ -15,6 +15,9 @@ export interface TextStyle {
   bold?: boolean;
   italic?: boolean;
   color?: ColorInput;
+  /** External URL - makes this run an inline hyperlink (a /Link annotation over its glyphs). On a
+   *  `span` it links just that run; on a whole `Text` (plain string) it links the whole text. */
+  href?: string;
 }
 
 export interface TextOptions extends TextStyle {
@@ -82,6 +85,7 @@ export function span(text: string, style: TextStyle = {}): TextSegment {
         ? toFontStyle(style.bold, style.italic)
         : undefined,
     fontColor: style.color !== undefined ? toColor(style.color) : undefined,
+    href: style.href,
   };
 }
 
@@ -91,10 +95,15 @@ export function span(text: string, style: TextStyle = {}): TextSegment {
  * text-internal `align`.
  */
 export function Text(content: string | TextSegment[], opts: TextOptions = {}): TextElement {
+  // A plain string given an `href` becomes a single link span, so `Text("jasy.dev", { href })` is a
+  // whole-text link (inline links use `span(...)`). This routes through the styled-segment path,
+  // which lays a single default-font segment out identically - only the /Link annotation is added.
+  const body =
+    typeof content === "string" && opts.href !== undefined ? [span(content, opts)] : content;
   // Unset properties are left undefined so they inherit the cascaded TextStyle (Document default /
   // built-in). Only bold/italic that the caller actually set become an explicit FontStyle.
   return new TextElement({
-    content,
+    content: body,
     fontSize: toFontSize(opts.size),
     fontFamily: opts.font,
     fontStyle:

--- a/src/lib/elements/index.ts
+++ b/src/lib/elements/index.ts
@@ -8,5 +8,7 @@ export * from "./layout/expanded-element.ts";
 export * from "./layout/padding-element.ts";
 export * from "./layout/default-text-style-element.ts";
 export * from "./layout/positioned-element.ts";
+export * from "./layout/link-element.ts";
+export * from "./layout/bookmark-element.ts";
 export * from "./line-element.ts";
 export * from "./row-element.ts";

--- a/src/lib/elements/index.ts
+++ b/src/lib/elements/index.ts
@@ -10,5 +10,6 @@ export * from "./layout/default-text-style-element.ts";
 export * from "./layout/positioned-element.ts";
 export * from "./layout/link-element.ts";
 export * from "./layout/bookmark-element.ts";
+export * from "./layout/anchor-element.ts";
 export * from "./line-element.ts";
 export * from "./row-element.ts";

--- a/src/lib/elements/layout/anchor-element.ts
+++ b/src/lib/elements/layout/anchor-element.ts
@@ -1,0 +1,34 @@
+import { PDFElement, LayoutContext } from "../pdf-element.ts";
+import { BoxConstraints, Offset, Size } from "../../layout/box-constraints.ts";
+
+/**
+ * Marks its child as a named jump target for an internal `Link({ to: name })`. Layout-transparent: it
+ * delegates `calculateLayout` to the child and records the child's top, which the renderer turns into an
+ * `Anchor` IR node (and PDFRenderer into a /Names /Dests entry). It draws nothing - the child renders
+ * exactly as it would on its own.
+ */
+export class AnchorElement extends PDFElement {
+  private name: string;
+  private child: PDFElement;
+  private y = 0;
+
+  constructor({ name, child }: { name: string; child: PDFElement }) {
+    super();
+    this.name = name;
+    this.child = child;
+  }
+
+  calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
+    const size = this.child.calculateLayout(constraints, offset, ctx);
+    this.y = offset.y; // the child's top - the scroll target for a link that jumps here
+    return size;
+  }
+
+  override getProps() {
+    return {
+      name: this.name,
+      child: this.child,
+      y: this.y,
+    };
+  }
+}

--- a/src/lib/elements/layout/bookmark-element.ts
+++ b/src/lib/elements/layout/bookmark-element.ts
@@ -1,0 +1,38 @@
+import { PDFElement, LayoutContext } from "../pdf-element.ts";
+import { BoxConstraints, Offset, Size } from "../../layout/box-constraints.ts";
+
+/**
+ * Adds a document-outline entry (a bookmark) that jumps to its child. Layout-transparent: it delegates
+ * `calculateLayout` to the child and records the child's top, which the renderer turns into an `Outline`
+ * IR node (and PDFRenderer into a /Outlines tree entry). `title` is the label shown in the viewer's
+ * bookmark panel; `level` (1-based, default 1) nests it under the nearest preceding smaller level. It
+ * draws nothing - the child renders exactly as it would without the bookmark.
+ */
+export class BookmarkElement extends PDFElement {
+  private title: string;
+  private level: number;
+  private child: PDFElement;
+  private y = 0;
+
+  constructor({ title, level = 1, child }: { title: string; level?: number; child: PDFElement }) {
+    super();
+    this.title = title;
+    this.level = level;
+    this.child = child;
+  }
+
+  calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
+    const size = this.child.calculateLayout(constraints, offset, ctx);
+    this.y = offset.y; // the child's top - the scroll target for the bookmark
+    return size;
+  }
+
+  override getProps() {
+    return {
+      title: this.title,
+      level: this.level,
+      child: this.child,
+      y: this.y,
+    };
+  }
+}

--- a/src/lib/elements/layout/link-element.ts
+++ b/src/lib/elements/layout/link-element.ts
@@ -2,22 +2,25 @@ import { PDFElement, LayoutContext } from "../pdf-element.ts";
 import { BoxConstraints, Offset, Size } from "../../layout/box-constraints.ts";
 
 /**
- * Makes its child a clickable hyperlink to `href` (an external URL). Layout-transparent: it delegates
- * `calculateLayout` to the child and records the resulting box, which the renderer turns into a `Link`
- * IR node (and the page renderer into a /Link annotation). The link draws nothing itself - style the
- * child (e.g. a blue underlined Text) if you want it to look like a link.
+ * Makes its child a clickable hyperlink. `href` is an external URL; `dest` is an internal named
+ * destination (an `Anchor` elsewhere in the document) - exactly one is set. Layout-transparent: it
+ * delegates `calculateLayout` to the child and records the resulting box, which the renderer turns into
+ * a `Link` IR node (and the page renderer into a /Link annotation). The link draws nothing itself -
+ * style the child (e.g. a blue Text) if you want it to look like a link.
  */
 export class LinkElement extends PDFElement {
-  private href: string;
+  private href?: string;
+  private dest?: string;
   private child: PDFElement;
   private x = 0;
   private y = 0;
   private width = 0;
   private height = 0;
 
-  constructor({ href, child }: { href: string; child: PDFElement }) {
+  constructor({ href, dest, child }: { href?: string; dest?: string; child: PDFElement }) {
     super();
     this.href = href;
+    this.dest = dest;
     this.child = child;
   }
 
@@ -33,6 +36,7 @@ export class LinkElement extends PDFElement {
   override getProps() {
     return {
       href: this.href,
+      dest: this.dest,
       child: this.child,
       x: this.x,
       y: this.y,

--- a/src/lib/elements/layout/link-element.ts
+++ b/src/lib/elements/layout/link-element.ts
@@ -1,0 +1,43 @@
+import { PDFElement, LayoutContext } from "../pdf-element.ts";
+import { BoxConstraints, Offset, Size } from "../../layout/box-constraints.ts";
+
+/**
+ * Makes its child a clickable hyperlink to `href` (an external URL). Layout-transparent: it delegates
+ * `calculateLayout` to the child and records the resulting box, which the renderer turns into a `Link`
+ * IR node (and the page renderer into a /Link annotation). The link draws nothing itself - style the
+ * child (e.g. a blue underlined Text) if you want it to look like a link.
+ */
+export class LinkElement extends PDFElement {
+  private href: string;
+  private child: PDFElement;
+  private x = 0;
+  private y = 0;
+  private width = 0;
+  private height = 0;
+
+  constructor({ href, child }: { href: string; child: PDFElement }) {
+    super();
+    this.href = href;
+    this.child = child;
+  }
+
+  calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
+    const size = this.child.calculateLayout(constraints, offset, ctx);
+    this.x = offset.x;
+    this.y = offset.y;
+    this.width = size.width;
+    this.height = size.height;
+    return size;
+  }
+
+  override getProps() {
+    return {
+      href: this.href,
+      child: this.child,
+      x: this.x,
+      y: this.y,
+      width: this.width,
+      height: this.height,
+    };
+  }
+}

--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -22,6 +22,8 @@ export interface TextSegment {
   fontColor?: Color;
   fontFamily?: string;
   fontSize?: number;
+  /** External URL: this segment becomes an inline hyperlink (a /Link annotation over its glyphs). */
+  href?: string;
 }
 
 /** Accessibility role for the tagged structure tree: a heading level or a paragraph (the default). */

--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -24,6 +24,8 @@ export interface TextSegment {
   fontSize?: number;
   /** External URL: this segment becomes an inline hyperlink (a /Link annotation over its glyphs). */
   href?: string;
+  /** Internal named destination (an `Anchor`): this segment links to it (a /GoTo /Link annotation). */
+  dest?: string;
 }
 
 /** Accessibility role for the tagged structure tree: a heading level or a paragraph (the default). */

--- a/src/lib/ir/display-list.ts
+++ b/src/lib/ir/display-list.ts
@@ -109,9 +109,10 @@ export interface ClipPop {
 
 /**
  * A hyperlink over a rectangle. Unlike every other IR node this draws NOTHING into the content stream -
- * it becomes a PDF Link ANNOTATION on the page (`/Annots`), a side channel next to the drawing. `href`
- * is an external URL (a `/URI` action). The rect is the clickable region in top-left engine coords; the
- * Y-flip converts it to PDF page space at the seam like any other rect.
+ * it becomes a PDF Link ANNOTATION on the page (`/Annots`), a side channel next to the drawing. Exactly
+ * one target is set: `href` is an external URL (a `/URI` action); `dest` is a named destination inside
+ * this document (a `/GoTo` action, resolved via the catalog `/Names /Dests` tree - see `Anchor`). The
+ * rect is the clickable region in top-left engine coords; the Y-flip converts it to PDF page space.
  */
 export interface Link {
   type: "link";
@@ -119,7 +120,19 @@ export interface Link {
   y: number;
   width: number;
   height: number;
-  href: string;
+  href?: string;
+  dest?: string;
+}
+
+/**
+ * A named destination anchor - a jump TARGET for an internal `Link({ to })`. Like `Link` it draws
+ * NOTHING; it registers `name` -> (this page, `y`) in the catalog `/Names /Dests` name tree. `y` is the
+ * top of the target in top-left engine coords (the Y-flip turns it into the page-space scroll target).
+ */
+export interface Anchor {
+  type: "anchor";
+  y: number;
+  name: string;
 }
 
 /**
@@ -192,4 +205,14 @@ export interface Path {
 }
 
 /** The closed set of primitives the PDF backend knows how to draw. */
-export type IRNode = TextRun | Rect | Line | Image | ClipPush | ClipPop | Path | Link | Outline;
+export type IRNode =
+  | TextRun
+  | Rect
+  | Line
+  | Image
+  | ClipPush
+  | ClipPop
+  | Path
+  | Link
+  | Outline
+  | Anchor;

--- a/src/lib/ir/display-list.ts
+++ b/src/lib/ir/display-list.ts
@@ -108,6 +108,34 @@ export interface ClipPop {
 }
 
 /**
+ * A hyperlink over a rectangle. Unlike every other IR node this draws NOTHING into the content stream -
+ * it becomes a PDF Link ANNOTATION on the page (`/Annots`), a side channel next to the drawing. `href`
+ * is an external URL (a `/URI` action). The rect is the clickable region in top-left engine coords; the
+ * Y-flip converts it to PDF page space at the seam like any other rect.
+ */
+export interface Link {
+  type: "link";
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  href: string;
+}
+
+/**
+ * A document-outline (bookmark) anchor. Like `Link` it draws NOTHING - it becomes an entry in the PDF
+ * outline tree (`/Outlines`), a side channel the viewer shows in its bookmark panel. `y` is the top of
+ * the target in top-left engine coords (the Y-flip turns it into the page-space scroll target); `level`
+ * (1-based) nests the entry under the nearest preceding entry of a smaller level.
+ */
+export interface Outline {
+  type: "outline";
+  y: number;
+  title: string;
+  level: number;
+}
+
+/**
  * One drawing command of a `Path`, in absolute page coordinates. Curves are CUBIC because PDF
  * content streams have no quadratic operator - a producer converts TrueType quads to cubics before
  * emitting. `z` closes the current subpath (a glyph contour).
@@ -164,4 +192,4 @@ export interface Path {
 }
 
 /** The closed set of primitives the PDF backend knows how to draw. */
-export type IRNode = TextRun | Rect | Line | Image | ClipPush | ClipPop | Path;
+export type IRNode = TextRun | Rect | Line | Image | ClipPush | ClipPop | Path | Link | Outline;

--- a/src/lib/renderer/anchor-renderer.ts
+++ b/src/lib/renderer/anchor-renderer.ts
@@ -1,0 +1,17 @@
+import { PDFObjectManager } from "../utils/pdf-object-manager.ts";
+import { AnchorElement } from "../elements/layout/anchor-element.ts";
+import { RendererRegistry } from "../utils/renderer-registry.ts";
+import { IRNode } from "../ir/display-list.ts";
+
+export class AnchorRenderer {
+  static async render(element: AnchorElement, objectManager: PDFObjectManager): Promise<IRNode[]> {
+    const { name, child, y } = element.getProps();
+
+    const renderer = RendererRegistry.getRenderer(child);
+    const childNodes = renderer ? await renderer(child, objectManager) : [];
+
+    // The child draws normally; an Anchor IR node carries the name + scroll target for the page renderer
+    // to register as a named destination (it produces no content-stream ops itself).
+    return [...childNodes, { type: "anchor", y, name }];
+  }
+}

--- a/src/lib/renderer/bookmark-renderer.ts
+++ b/src/lib/renderer/bookmark-renderer.ts
@@ -1,0 +1,20 @@
+import { PDFObjectManager } from "../utils/pdf-object-manager.ts";
+import { BookmarkElement } from "../elements/layout/bookmark-element.ts";
+import { RendererRegistry } from "../utils/renderer-registry.ts";
+import { IRNode } from "../ir/display-list.ts";
+
+export class BookmarkRenderer {
+  static async render(
+    element: BookmarkElement,
+    objectManager: PDFObjectManager,
+  ): Promise<IRNode[]> {
+    const { title, level, child, y } = element.getProps();
+
+    const renderer = RendererRegistry.getRenderer(child);
+    const childNodes = renderer ? await renderer(child, objectManager) : [];
+
+    // The child draws normally; an Outline IR node carries the title + nesting + scroll target for the
+    // page renderer to collect into the /Outlines tree (it produces no content-stream ops itself).
+    return [...childNodes, { type: "outline", y, title, level }];
+  }
+}

--- a/src/lib/renderer/link-renderer.ts
+++ b/src/lib/renderer/link-renderer.ts
@@ -1,0 +1,17 @@
+import { PDFObjectManager } from "../utils/pdf-object-manager.ts";
+import { LinkElement } from "../elements/layout/link-element.ts";
+import { RendererRegistry } from "../utils/renderer-registry.ts";
+import { IRNode } from "../ir/display-list.ts";
+
+export class LinkRenderer {
+  static async render(element: LinkElement, objectManager: PDFObjectManager): Promise<IRNode[]> {
+    const { href, child, x, y, width, height } = element.getProps();
+
+    const renderer = RendererRegistry.getRenderer(child);
+    const childNodes = renderer ? await renderer(child, objectManager) : [];
+
+    // The child draws normally; a Link IR node carries the clickable rect + target for the page
+    // renderer to emit as a /Link annotation (it produces no content-stream ops itself).
+    return [...childNodes, { type: "link", x, y, width, height, href }];
+  }
+}

--- a/src/lib/renderer/link-renderer.ts
+++ b/src/lib/renderer/link-renderer.ts
@@ -5,13 +5,13 @@ import { IRNode } from "../ir/display-list.ts";
 
 export class LinkRenderer {
   static async render(element: LinkElement, objectManager: PDFObjectManager): Promise<IRNode[]> {
-    const { href, child, x, y, width, height } = element.getProps();
+    const { href, dest, child, x, y, width, height } = element.getProps();
 
     const renderer = RendererRegistry.getRenderer(child);
     const childNodes = renderer ? await renderer(child, objectManager) : [];
 
-    // The child draws normally; a Link IR node carries the clickable rect + target for the page
-    // renderer to emit as a /Link annotation (it produces no content-stream ops itself).
-    return [...childNodes, { type: "link", x, y, width, height, href }];
+    // The child draws normally; a Link IR node carries the clickable rect + target (external href or
+    // internal dest) for the page renderer to emit as a /Link annotation (no content-stream ops itself).
+    return [...childNodes, { type: "link", x, y, width, height, href, dest }];
   }
 }

--- a/src/lib/renderer/page-renderer.ts
+++ b/src/lib/renderer/page-renderer.ts
@@ -35,11 +35,8 @@ export class PageRenderer {
     // Accessible tagging: one struct context per page (allocates its StructParents index), threaded into
     // serialize so each drawable node is wrapped in marked content. Undefined = tagging off (byte-identical).
     const structCtx = objectManager.struct.enabled ? objectManager.struct.beginPage() : undefined;
-    const pageContent = PdfBackend.serialize(
-      PdfBackend.flipY(nodes, height),
-      objectManager,
-      structCtx,
-    );
+    const flipped = PdfBackend.flipY(nodes, height);
+    const pageContent = PdfBackend.serialize(flipped, objectManager, structCtx);
 
     // Add the page content as a new object (FlateDecode-compressed when enabled). The /Length is
     // computed inside, with an explicit EOL before `endstream` (PDF/A clause 6.1.7.1).
@@ -88,16 +85,45 @@ export class PageRenderer {
     const shadingCode =
       shadingReferences.length > 0 ? "/Shading <<\n" + shadingReferences.join("\n") + "\n>>\n" : "";
 
+    // Hyperlinks: a `Link` IR node drew nothing into the content stream - here its (already Y-flipped)
+    // rect + href become a /Link annotation object. `/Border [0 0 0]` hides the default visible frame;
+    // the URL is escaped like any PDF literal string. Refs are collected into the page's /Annots below.
+    const num = (n: number) => Number(n.toFixed(2));
+    const annotRefs: string[] = [];
+    for (const node of flipped) {
+      if (node.type !== "link") continue;
+      const rect = `[${num(node.x)} ${num(node.y)} ${num(node.x + node.width)} ${num(node.y + node.height)}]`;
+      const uri = PdfBackend.escapePdfString(node.href);
+      const annot = objectManager.addObject(
+        `<< /Type /Annot /Subtype /Link /Rect ${rect} /Border [0 0 0] /A << /S /URI /URI (${uri}) >> >>`,
+      );
+      annotRefs.push(`${annot} 0 R`);
+    }
+    const annotsCode = annotRefs.length > 0 ? ` /Annots [${annotRefs.join(" ")}]` : "";
+
     // Tagging only: /StructParents links this page's marked content to the ParentTree, /Tabs /S makes the
     // logical structure order the tab/reading order (a PDF/UA requirement).
     const structAttrs = structCtx ? ` /StructParents ${structCtx.structParents} /Tabs /S` : "";
     const pageObject = `<< /Type /Page /Parent ${parentObjectNumber} 0 R /Contents ${contentObjectNumber} 0 R /Resources <<\n/Font <<\n${fontReferences.join(
       "\n",
-    )}\n>>\n${imageCode}${extGStateCode}${shadingCode}>>\n/MediaBox [0 0 ${width} ${height}]${structAttrs} >>`;
+    )}\n>>\n${imageCode}${extGStateCode}${shadingCode}>>\n/MediaBox [0 0 ${width} ${height}]${structAttrs}${annotsCode} >>`;
 
     // Add page as new object; register its object number with the struct tree (for /Pg refs), then return it.
     const pageObjNum = objectManager.addObject(pageObject);
     if (structCtx) objectManager.struct.setPageObject(structCtx.structParents, pageObjNum);
+
+    // Bookmarks: an `Outline` IR node drew nothing; record it now that the page's object number is known.
+    // `node.y` is already Y-flipped to the page-space scroll target. PDFRenderer builds /Outlines at the end.
+    for (const node of flipped) {
+      if (node.type === "outline") {
+        objectManager.outline.add({
+          title: node.title,
+          level: node.level,
+          pageObjNum,
+          top: node.y,
+        });
+      }
+    }
     return pageObjNum;
   }
 }

--- a/src/lib/renderer/page-renderer.ts
+++ b/src/lib/renderer/page-renderer.ts
@@ -93,9 +93,14 @@ export class PageRenderer {
     for (const node of flipped) {
       if (node.type !== "link") continue;
       const rect = `[${num(node.x)} ${num(node.y)} ${num(node.x + node.width)} ${num(node.y + node.height)}]`;
-      const uri = PdfBackend.escapePdfString(node.href);
+      // Either an external URL (/URI) or an internal named destination (/GoTo, resolved via /Names /Dests).
+      // The Link IR guarantees exactly one is set; prefer `dest` when present.
+      const action =
+        node.dest !== undefined
+          ? `/A << /S /GoTo /D (${PdfBackend.escapePdfString(node.dest)}) >>`
+          : `/A << /S /URI /URI (${PdfBackend.escapePdfString(node.href ?? "")}) >>`;
       const annot = objectManager.addObject(
-        `<< /Type /Annot /Subtype /Link /Rect ${rect} /Border [0 0 0] /A << /S /URI /URI (${uri}) >> >>`,
+        `<< /Type /Annot /Subtype /Link /Rect ${rect} /Border [0 0 0] ${action} >>`,
       );
       annotRefs.push(`${annot} 0 R`);
     }
@@ -112,8 +117,9 @@ export class PageRenderer {
     const pageObjNum = objectManager.addObject(pageObject);
     if (structCtx) objectManager.struct.setPageObject(structCtx.structParents, pageObjNum);
 
-    // Bookmarks: an `Outline` IR node drew nothing; record it now that the page's object number is known.
-    // `node.y` is already Y-flipped to the page-space scroll target. PDFRenderer builds /Outlines at the end.
+    // Bookmarks + named destinations: an `Outline`/`Anchor` IR node drew nothing; record it now that the
+    // page's object number is known. `node.y` is already Y-flipped to the page-space scroll target.
+    // PDFRenderer builds /Outlines and /Names /Dests at the end.
     for (const node of flipped) {
       if (node.type === "outline") {
         objectManager.outline.add({
@@ -122,6 +128,8 @@ export class PageRenderer {
           pageObjNum,
           top: node.y,
         });
+      } else if (node.type === "anchor") {
+        objectManager.dests.add(node.name, { pageObjNum, top: node.y });
       }
     }
     return pageObjNum;

--- a/src/lib/renderer/pdf-backend.ts
+++ b/src/lib/renderer/pdf-backend.ts
@@ -72,6 +72,9 @@ export class PdfBackend {
         case "outline":
           // An outline anchor is a single point (the target's top); flip it like a text baseline.
           return { ...node, y: pageHeight - node.y };
+        case "anchor":
+          // A named-destination anchor is a single point (the target's top), flipped like a baseline.
+          return { ...node, y: pageHeight - node.y };
         default: {
           const unknown: never = node;
           return unknown;
@@ -96,6 +99,7 @@ export class PdfBackend {
           node.type === "clip-pop" ||
           node.type === "link" ||
           node.type === "outline" ||
+          node.type === "anchor" ||
           ops === ""
         )
           return ops;
@@ -294,6 +298,9 @@ export class PdfBackend {
         return "";
       case "outline":
         // An outline anchor draws nothing - it becomes a /Outlines entry (built in PageRenderer/PDFRenderer).
+        return "";
+      case "anchor":
+        // A named destination draws nothing - it becomes a /Names /Dests entry (built in PageRenderer/PDFRenderer).
         return "";
       default: {
         // Exhaustiveness guard: if a new IRNode variant is added, this fails to compile.

--- a/src/lib/renderer/pdf-backend.ts
+++ b/src/lib/renderer/pdf-backend.ts
@@ -66,6 +66,12 @@ export class PdfBackend {
               : { ...node.fill, y0: pageHeight - node.fill.y0, y1: pageHeight - node.fill.y1 };
           return { ...node, commands, fill };
         }
+        case "link":
+          // A link's clickable rect flips around its bottom edge, exactly like a rect.
+          return { ...node, y: pageHeight - node.y - node.height };
+        case "outline":
+          // An outline anchor is a single point (the target's top); flip it like a text baseline.
+          return { ...node, y: pageHeight - node.y };
         default: {
           const unknown: never = node;
           return unknown;
@@ -82,7 +88,16 @@ export class PdfBackend {
     return nodes
       .map((node) => {
         const ops = PdfBackend.serializeNode(node, om);
-        if (!struct || node.type === "clip-push" || node.type === "clip-pop" || ops === "")
+        // Graphics-state and side-channel nodes (clip push/pop, a link) carry no tag and never draw,
+        // so they pass through without a marked-content wrapper.
+        if (
+          !struct ||
+          node.type === "clip-push" ||
+          node.type === "clip-pop" ||
+          node.type === "link" ||
+          node.type === "outline" ||
+          ops === ""
+        )
           return ops;
         const { open, close } = struct.mark(node.tag);
         return open + ops + close;
@@ -274,6 +289,12 @@ export class PdfBackend {
       }
       case "clip-pop":
         return `Q\n`;
+      case "link":
+        // A link draws nothing in the content stream - it becomes a page /Annot (built in PageRenderer).
+        return "";
+      case "outline":
+        // An outline anchor draws nothing - it becomes a /Outlines entry (built in PageRenderer/PDFRenderer).
+        return "";
       default: {
         // Exhaustiveness guard: if a new IRNode variant is added, this fails to compile.
         const unknown: never = node;

--- a/src/lib/renderer/pdf-renderer.ts
+++ b/src/lib/renderer/pdf-renderer.ts
@@ -30,6 +30,10 @@ import { PositionedElement } from "../elements/layout/positioned-element.ts";
 import { PositionedRenderer } from "./positioned-renderer.ts";
 import { StructGroup } from "../elements/layout/struct-group.ts";
 import { StructGroupRenderer } from "./struct-group-renderer.ts";
+import { LinkElement } from "../elements/layout/link-element.ts";
+import { LinkRenderer } from "./link-renderer.ts";
+import { BookmarkElement } from "../elements/layout/bookmark-element.ts";
+import { BookmarkRenderer } from "./bookmark-renderer.ts";
 import { BoxConstraints } from "../layout/box-constraints.ts";
 import { collectImageElements } from "../layout/collect-images.ts";
 import { LayoutContext } from "../elements/pdf-element.ts";
@@ -54,6 +58,8 @@ export class PDFRenderer {
     RendererRegistry.register(DeferredElement, DeferredRenderer.render);
     RendererRegistry.register(PositionedElement, PositionedRenderer.render);
     RendererRegistry.register(StructGroup, StructGroupRenderer.render);
+    RendererRegistry.register(LinkElement, LinkRenderer.render);
+    RendererRegistry.register(BookmarkElement, BookmarkRenderer.render);
 
     let pdfContent = "";
 
@@ -111,6 +117,11 @@ export class PDFRenderer {
       // PDF/UA requires the viewer to show the document title (not the file name).
       catalogParts.push("/ViewerPreferences << /DisplayDocTitle true >>");
     }
+
+    // Document outline (bookmarks): emit the /Outlines tree collected during page rendering. Returns
+    // "" (no-op) when no Bookmark was placed, so a plain document's catalog is unchanged.
+    const outlineCatalog = objectManager.outline.finalize(objectManager);
+    if (outlineCatalog) catalogParts.push(outlineCatalog);
 
     const catalogObject = `<< ${catalogParts.join(" ")} >>`;
     objectManager.addObject(catalogObject);

--- a/src/lib/renderer/pdf-renderer.ts
+++ b/src/lib/renderer/pdf-renderer.ts
@@ -34,6 +34,8 @@ import { LinkElement } from "../elements/layout/link-element.ts";
 import { LinkRenderer } from "./link-renderer.ts";
 import { BookmarkElement } from "../elements/layout/bookmark-element.ts";
 import { BookmarkRenderer } from "./bookmark-renderer.ts";
+import { AnchorElement } from "../elements/layout/anchor-element.ts";
+import { AnchorRenderer } from "./anchor-renderer.ts";
 import { BoxConstraints } from "../layout/box-constraints.ts";
 import { collectImageElements } from "../layout/collect-images.ts";
 import { LayoutContext } from "../elements/pdf-element.ts";
@@ -60,6 +62,7 @@ export class PDFRenderer {
     RendererRegistry.register(StructGroup, StructGroupRenderer.render);
     RendererRegistry.register(LinkElement, LinkRenderer.render);
     RendererRegistry.register(BookmarkElement, BookmarkRenderer.render);
+    RendererRegistry.register(AnchorElement, AnchorRenderer.render);
 
     let pdfContent = "";
 
@@ -102,11 +105,16 @@ export class PDFRenderer {
       catalogParts.push(`/OutputIntents [${outputIntent} 0 R]`);
     }
 
+    // The catalog has exactly one /Names dict; embedded files and named destinations are two entries in
+    // it, so collect both and emit the /Names once (below).
+    const namesParts: string[] = [];
+
     const attachments = objectManager.getAttachments();
     if (attachments.length > 0) {
       const names = attachments.map((a) => `(${a.name}) ${a.filespec} 0 R`).join(" ");
       const af = attachments.map((a) => `${a.filespec} 0 R`).join(" ");
-      catalogParts.push(`/AF [${af}]`, `/Names << /EmbeddedFiles << /Names [${names}] >> >>`);
+      catalogParts.push(`/AF [${af}]`);
+      namesParts.push(`/EmbeddedFiles << /Names [${names}] >>`);
     }
 
     // Accessible tagging: finalize the structure tree (emits StructTreeRoot + StructElems + ParentTree) and
@@ -122,6 +130,13 @@ export class PDFRenderer {
     // "" (no-op) when no Bookmark was placed, so a plain document's catalog is unchanged.
     const outlineCatalog = objectManager.outline.finalize(objectManager);
     if (outlineCatalog) catalogParts.push(outlineCatalog);
+
+    // Named destinations (internal-link targets): a /Dests entry in the shared /Names dict.
+    const destsNames = objectManager.dests.finalize();
+    if (destsNames) namesParts.push(destsNames);
+
+    // Emit the single /Names dict if either embedded files or destinations contributed to it.
+    if (namesParts.length > 0) catalogParts.push(`/Names << ${namesParts.join(" ")} >>`);
 
     const catalogObject = `<< ${catalogParts.join(" ")} >>`;
     objectManager.addObject(catalogObject);

--- a/src/lib/renderer/text-renderer.ts
+++ b/src/lib/renderer/text-renderer.ts
@@ -10,7 +10,7 @@ import type {
   TTFParser,
   ColorGlyphLayer,
 } from "../utils/ttf-parser.ts";
-import { IRNode, TextRun, PathCommand, Gradient } from "../ir/display-list.ts";
+import { IRNode, TextRun, PathCommand, Gradient, Link } from "../ir/display-list.ts";
 import { isEmojiCodePoint } from "../text/emoji-codepoints.ts";
 import { emojiImageNode } from "./emoji-image.ts";
 import {
@@ -88,7 +88,7 @@ export class TextRenderer {
     // Component -> display list. Wrapping and positioning stay here; the backend
     // turns each run into BT/Tf/Td/Tj/ET. The wrapping algorithm is unchanged from
     // the original renderer - unifying it into the engine is Phase 3.
-    const runs = TextRenderer._buildRuns(
+    const { runs, links } = TextRenderer._buildRuns(
       content,
       fontSize,
       fontFamily,
@@ -115,9 +115,12 @@ export class TextRenderer {
 
     // Color fonts (COLR/CPAL): expand each run's emoji into filled vector layers (or fetched images
     // for an image emoji source); plain runs and monochrome fonts pass straight through unchanged.
-    return (
+    const drawn = (
       await Promise.all(runs.map((run) => TextRenderer._expandColorGlyphs(run, objectManager)))
     ).flat();
+    // Inline hyperlinks (href spans) ride along as /Link annotations - they draw nothing, so order
+    // vs the drawn runs does not matter; the page renderer peels them off into /Annots.
+    return links.length > 0 ? [...drawn, ...links] : drawn;
   }
 
   // Splits a text run into normal text sub-runs + filled `Path` layers for any COLR color glyphs,
@@ -325,8 +328,11 @@ export class TextRenderer {
     maxLines?: number,
     overflow?: TextOverflow,
     lineHeight = 1,
-  ): TextRun[] {
+  ): { runs: TextRun[]; links: Link[] } {
     const runs: TextRun[] = [];
+    // /Link annotation rects for any `href` spans, collected as we place segments. Empty for the
+    // common (no-href) case, so plain text keeps producing exactly the runs it did before.
+    const links: Link[] = [];
 
     // Horizontal offset of a line of the given width under the current alignment.
     const alignmentOffset = (lineWidth: number): number => {
@@ -382,7 +388,7 @@ export class TextRenderer {
           color,
         });
       });
-      return runs;
+      return { runs, links };
     }
 
     // --- Segments: break into lines (shared breaker), then emit one run per segment.
@@ -396,6 +402,7 @@ export class TextRenderer {
         const family = segment.fontFamily || fontFamily;
         const size = segment.fontSize || fontSize;
         const style = segment.fontStyle || fontStyle;
+        const advance = advanceNoKerning(segment.content, family, size, style);
         runs.push({
           type: "text",
           x,
@@ -406,7 +413,20 @@ export class TextRenderer {
           fontSize: size,
           color: segment.fontColor || color,
         });
-        x += advanceNoKerning(segment.content, family, size, style);
+        // An href span becomes a /Link annotation over exactly this run's glyph box. `lineY` is the
+        // baseline; the box spans from the ascent (BASELINE_RATIO above it) down by the full size, so
+        // ascent + descent are covered. A span wrapped across lines yields one rect per line.
+        if (segment.href) {
+          links.push({
+            type: "link",
+            x,
+            y: lineY - size * BASELINE_RATIO,
+            width: advance,
+            height: size,
+            href: segment.href,
+          });
+        }
+        x += advance;
       });
     };
 
@@ -435,6 +455,6 @@ export class TextRenderer {
       lineY += line.maxFontSize * lineHeight;
     }
 
-    return runs;
+    return { runs, links };
   }
 }

--- a/src/lib/renderer/text-renderer.ts
+++ b/src/lib/renderer/text-renderer.ts
@@ -413,10 +413,10 @@ export class TextRenderer {
           fontSize: size,
           color: segment.fontColor || color,
         });
-        // An href span becomes a /Link annotation over exactly this run's glyph box. `lineY` is the
+        // An href/to span becomes a /Link annotation over exactly this run's glyph box. `lineY` is the
         // baseline; the box spans from the ascent (BASELINE_RATIO above it) down by the full size, so
         // ascent + descent are covered. A span wrapped across lines yields one rect per line.
-        if (segment.href) {
+        if (segment.href !== undefined || segment.dest !== undefined) {
           links.push({
             type: "link",
             x,
@@ -424,6 +424,7 @@ export class TextRenderer {
             width: advance,
             height: size,
             href: segment.href,
+            dest: segment.dest,
           });
         }
         x += advance;

--- a/src/lib/utils/dest-registry.ts
+++ b/src/lib/utils/dest-registry.ts
@@ -1,0 +1,39 @@
+// A PDF literal string escape (backslash first, then the string delimiters).
+const esc = (s: string) => s.replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)");
+const num = (n: number) => (Number.isFinite(n) ? Number(n.toFixed(2)) : 0);
+
+// One named jump target: its page object number and page-space (already Y-flipped) top.
+interface Dest {
+  pageObjNum: number;
+  top: number;
+}
+
+/**
+ * Collects named destinations - the jump targets an internal `Link({ to })` points at, declared with
+ * `Anchor({ name })`. `finalize` emits the `/Dests` name-tree fragment for the catalog `/Names` dict, or
+ * "" when no anchor was placed. Names are strings the viewer resolves at click time, so a link can point
+ * at an anchor on a later (not-yet-rendered) page without any forward-reference bookkeeping.
+ */
+export class DestRegistry {
+  // Keyed by name so a duplicate name resolves to its last definition (last anchor wins).
+  private dests = new Map<string, Dest>();
+
+  add(name: string, dest: Dest): void {
+    this.dests.set(name, dest);
+  }
+
+  get isEmpty(): boolean {
+    return this.dests.size === 0;
+  }
+
+  /** The `/Dests << /Names [ ... ] >>` fragment for the catalog `/Names` dictionary (merged with any
+   *  `/EmbeddedFiles`). Returns "" when empty. Names are sorted lexically - a name tree requires it. */
+  finalize(): string {
+    if (this.dests.size === 0) return "";
+    const entries = [...this.dests.keys()].sort().map((name) => {
+      const d = this.dests.get(name)!;
+      return `(${esc(name)}) [${d.pageObjNum} 0 R /XYZ null ${num(d.top)} null]`;
+    });
+    return `/Dests << /Names [ ${entries.join(" ")} ] >>`;
+  }
+}

--- a/src/lib/utils/outline.ts
+++ b/src/lib/utils/outline.ts
@@ -1,0 +1,103 @@
+import type { PDFObjectManager } from "./pdf-object-manager.ts";
+
+// A PDF literal string escape (same rule as elsewhere): backslash first, then the string delimiters.
+const esc = (s: string) => s.replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)");
+const num = (n: number) => Number(n.toFixed(2));
+
+// One bookmark, collected in document (reading) order as pages render. `top` is the page-space
+// (already Y-flipped) y of the target, `pageObjNum` the page's indirect object it lives on.
+interface Entry {
+  title: string;
+  level: number;
+  pageObjNum: number;
+  top: number;
+}
+
+// One node of the built outline tree (an Entry plus its resolved position in the hierarchy).
+interface Node extends Entry {
+  children: Node[];
+}
+
+/**
+ * Builds the PDF document outline (`/Outlines`) - the viewer's bookmark panel. Entries are collected
+ * flat in reading order with a 1-based `level`; `finalize` nests each entry under the nearest preceding
+ * entry of a smaller level (so level 2s hang under the last level 1), emits the outline objects and
+ * returns the catalog addition `/Outlines N 0 R`. A no-op returning "" when nothing was added, so a
+ * document without bookmarks stays byte-identical.
+ */
+export class OutlineBuilder {
+  private entries: Entry[] = [];
+
+  add(entry: Entry): void {
+    this.entries.push(entry);
+  }
+
+  get isEmpty(): boolean {
+    return this.entries.length === 0;
+  }
+
+  finalize(om: PDFObjectManager): string {
+    if (this.entries.length === 0) return "";
+
+    // Nest by level: a stack where stack[i] is the last open node at level i+1. An entry at level L
+    // becomes a child of stack[L-2] (the enclosing smaller level), or a root when L is 1. Levels that
+    // skip a step (1 -> 3) are clamped to one deeper than the current stack so nothing is orphaned.
+    const roots: Node[] = [];
+    const stack: Node[] = [];
+    for (const e of this.entries) {
+      const level = Math.max(1, Math.min(e.level, stack.length + 1));
+      stack.length = level - 1; // pop back to this entry's parent depth
+      const node: Node = { ...e, children: [] };
+      if (level === 1) roots.push(node);
+      else stack[level - 2].children.push(node);
+      stack[level - 1] = node;
+    }
+
+    // Reserve an object number for every node up front - parent/child/prev/next all cross-reference.
+    const objOf = new Map<Node, number>();
+    const walk = (nodes: Node[]) => {
+      for (const n of nodes) {
+        objOf.set(n, om.addObject(""));
+        walk(n.children);
+      }
+    };
+    walk(roots);
+    const rootNum = om.addObject(""); // the /Outlines dictionary itself
+
+    // Count of all descendants of a node (used for the /Count of an open item, which shows them all).
+    const descendantCount = (n: Node): number =>
+      n.children.reduce((sum, c) => sum + 1 + descendantCount(c), 0);
+    const totalCount = roots.reduce((sum, r) => sum + 1 + descendantCount(r), 0);
+
+    // Emit each item dict, wired to its parent, siblings (prev/next) and first/last child.
+    const emit = (nodes: Node[], parentNum: number) => {
+      nodes.forEach((n, i) => {
+        const parts = [`/Title (${esc(n.title)})`, `/Parent ${parentNum} 0 R`];
+        if (i > 0) parts.push(`/Prev ${objOf.get(nodes[i - 1])!} 0 R`);
+        if (i < nodes.length - 1) parts.push(`/Next ${objOf.get(nodes[i + 1])!} 0 R`);
+        if (n.children.length > 0) {
+          parts.push(`/First ${objOf.get(n.children[0])!} 0 R`);
+          parts.push(`/Last ${objOf.get(n.children[n.children.length - 1])!} 0 R`);
+          parts.push(`/Count ${descendantCount(n)}`); // positive = shown open
+        }
+        // /Dest: jump to this page, scrolling the target's top into view; null left/zoom keep the
+        // viewer's current horizontal position and magnification. Guard the top: a non-finite value
+        // (e.g. a bookmark under a Spacer in an unbounded column) would emit invalid PDF, so fall back
+        // to the page top (0 flips to the page top edge).
+        const top = Number.isFinite(n.top) ? num(n.top) : 0;
+        parts.push(`/Dest [${n.pageObjNum} 0 R /XYZ null ${top} null]`);
+        om.replaceObject(objOf.get(n)!, `<< ${parts.join(" ")} >>`);
+        emit(n.children, objOf.get(n)!);
+      });
+    };
+    emit(roots, rootNum);
+
+    om.replaceObject(
+      rootNum,
+      `<< /Type /Outlines /First ${objOf.get(roots[0])!} 0 R ` +
+        `/Last ${objOf.get(roots[roots.length - 1])!} 0 R /Count ${totalCount} >>`,
+    );
+
+    return `/Outlines ${rootNum} 0 R`;
+  }
+}

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -13,6 +13,7 @@ import type { Gradient, GradientStop } from "../ir/display-list.ts";
 import { isEmojiCodePoint } from "../text/emoji-codepoints.ts";
 import { StructTree } from "./struct-tree.ts";
 import { OutlineBuilder } from "./outline.ts";
+import { DestRegistry } from "./dest-registry.ts";
 // Enums come from the leaf config module (never in a cycle); the config type is
 // erased at runtime so it can come from the cyclic module safely.
 import { ColorMode, Orientation } from "../renderer/pdf-config.ts";
@@ -234,6 +235,13 @@ export class PDFObjectManager implements FontMetrics {
   private _outline = new OutlineBuilder();
   get outline(): OutlineBuilder {
     return this._outline;
+  }
+
+  // Named destinations (internal-link jump targets). Empty unless an `Anchor` was placed; then it emits
+  // a /Names /Dests tree.
+  private _dests = new DestRegistry();
+  get dests(): DestRegistry {
+    return this._dests;
   }
 
   constructor();

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -12,6 +12,7 @@ import type { SecurityHandler } from "../crypto/security-handler.ts";
 import type { Gradient, GradientStop } from "../ir/display-list.ts";
 import { isEmojiCodePoint } from "../text/emoji-codepoints.ts";
 import { StructTree } from "./struct-tree.ts";
+import { OutlineBuilder } from "./outline.ts";
 // Enums come from the leaf config module (never in a cycle); the config type is
 // erased at runtime so it can come from the cyclic module safely.
 import { ColorMode, Orientation } from "../renderer/pdf-config.ts";
@@ -227,6 +228,12 @@ export class PDFObjectManager implements FontMetrics {
   private _struct = new StructTree();
   get struct(): StructTree {
     return this._struct;
+  }
+
+  // Document outline (bookmarks). Empty unless a `Bookmark` was placed; then finalize() emits /Outlines.
+  private _outline = new OutlineBuilder();
+  get outline(): OutlineBuilder {
+    return this._outline;
   }
 
   constructor();

--- a/tests/unit/renderer/anchor.test.ts
+++ b/tests/unit/renderer/anchor.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { Document, Page, Column, Text, span, Link, Anchor, renderPdf } from "../../../src/lib/api";
+
+const count = (haystack: string, needle: string): number => haystack.split(needle).length - 1;
+
+describe("internal links + named destinations (anchors)", () => {
+  it("adds no /Names /Dests to a document without anchors", async () => {
+    const pdf = await renderPdf(Document([Page([Text("plain")])]));
+    expect(pdf).not.toContain("/Dests");
+    expect(pdf).not.toContain("/GoTo");
+  });
+
+  it("wires an internal block Link to its Anchor via a named destination", async () => {
+    const doc = Document([
+      Page([Link({ to: "sec" }, Text("go to section"))]),
+      Page([Anchor({ name: "sec" }, Text("Section"))]),
+    ]);
+    const pdf = await renderPdf(doc);
+    expect(pdf).toContain("/Subtype /Link");
+    expect(pdf).toContain("/A << /S /GoTo /D (sec) >>");
+    expect(pdf).toContain("/Dests << /Names [ (sec) [");
+    expect(pdf).not.toContain("/URI"); // internal, not external
+  });
+
+  it("resolves an inline span({ to }) as an internal link", async () => {
+    const doc = Document([
+      Page([Text([span("jump "), span("here", { to: "x" }), span(" now")])]),
+      Page([Anchor({ name: "x" }, Text("target"))]),
+    ]);
+    const pdf = await renderPdf(doc);
+    expect(count(pdf, "/Subtype /Link")).toBe(1);
+    expect(pdf).toContain("/S /GoTo /D (x)");
+  });
+
+  it("points the destination at the page the anchor lives on", async () => {
+    const doc = Document([
+      Page([Link({ to: "sec" }, Text("toc"))]),
+      Page([Text("filler")]),
+      Page([Anchor({ name: "sec" }, Text("Section"))]),
+    ]);
+    const pdf = await renderPdf(doc);
+    // The dest's page ref should be the third page object, not the first.
+    const m = pdf.match(/\(sec\) \[(\d+) 0 R \/XYZ null [\d.]+ null\]/);
+    expect(m).not.toBeNull();
+  });
+
+  it("sorts destination names lexically (name-tree requirement)", async () => {
+    const doc = Document([
+      Page([
+        Column([
+          Anchor({ name: "zebra" }, Text("z")),
+          Anchor({ name: "alpha" }, Text("a")),
+          Anchor({ name: "mango" }, Text("m")),
+        ]),
+      ]),
+    ]);
+    const pdf = await renderPdf(doc);
+    const names = [...pdf.matchAll(/\((alpha|mango|zebra)\) \[/g)].map((m) => m[1]);
+    expect(names).toEqual(["alpha", "mango", "zebra"]);
+  });
+
+  it("merges embedded files and destinations into one /Names dict", async () => {
+    const doc = Document([Page([Anchor({ name: "top" }, Text("top"))])]);
+    const pdf = await renderPdf(doc, {
+      attachments: [{ name: "x.xml", data: Buffer.from("<x/>"), relationship: "Data" }],
+    });
+    // Exactly one /Names dictionary, holding BOTH keys.
+    expect(count(pdf, "/Names <<")).toBe(1);
+    expect(pdf).toContain("/EmbeddedFiles");
+    expect(pdf).toContain("/Dests");
+  });
+
+  it("rejects a Link with both href and to (or neither)", () => {
+    expect(() => Link({ href: "https://x.dev", to: "y" }, Text("x"))).toThrow(/exactly one/);
+    expect(() => Link({}, Text("x"))).toThrow(/exactly one/);
+  });
+});

--- a/tests/unit/renderer/bookmark.test.ts
+++ b/tests/unit/renderer/bookmark.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { Document, Page, Column, Text, Bookmark, renderPdf } from "../../../src/lib/api";
+
+const count = (haystack: string, needle: string): number => haystack.split(needle).length - 1;
+
+describe("document outline (bookmarks)", () => {
+  it("adds no /Outlines to a document without bookmarks", async () => {
+    const pdf = await renderPdf(Document([Page([Text("plain")])]));
+    expect(pdf).not.toContain("/Type /Outlines");
+    expect(pdf).not.toContain("/Dest");
+  });
+
+  it("emits an outline dict + one item per bookmark, wired to the catalog", async () => {
+    const doc = Document([
+      Page([
+        Column([
+          Bookmark({ title: "Intro" }, Text("Intro")),
+          Bookmark({ title: "Body" }, Text("Body")),
+        ]),
+      ]),
+    ]);
+    const pdf = await renderPdf(doc);
+    expect(pdf).toContain("/Type /Outlines");
+    expect(pdf).toContain("/Outlines "); // catalog reference
+    expect(pdf).toContain("/Title (Intro)");
+    expect(pdf).toContain("/Title (Body)");
+    expect(count(pdf, "/Dest [")).toBe(2);
+    // Two top-level siblings: the root spans both, they cross-link via Prev/Next.
+    expect(pdf).toContain("/Count 2");
+    expect(pdf).toContain("/Prev ");
+    expect(pdf).toContain("/Next ");
+  });
+
+  it("nests a level-2 bookmark under the preceding level-1 (a /First child + /Count)", async () => {
+    const doc = Document([
+      Page([
+        Column([
+          Bookmark({ title: "Chapter", level: 1 }, Text("Chapter")),
+          Bookmark({ title: "Section", level: 2 }, Text("Section")),
+        ]),
+      ]),
+    ]);
+    const pdf = await renderPdf(doc);
+    // The chapter is the only root; it has one child (the section).
+    expect(pdf).toContain("/Type /Outlines /First");
+    expect(pdf).toContain("/First "); // chapter -> section
+    expect(pdf).toMatch(/\/Title \(Chapter\)[^>]*\/First/);
+  });
+
+  it("points each bookmark's /Dest at the page object it lives on", async () => {
+    const doc = Document([
+      Page([Bookmark({ title: "One" }, Text("one"))]),
+      Page([Bookmark({ title: "Two" }, Text("two"))]),
+    ]);
+    const pdf = await renderPdf(doc);
+    const dests = [...pdf.matchAll(/\/Dest \[(\d+) 0 R \/XYZ null [\d.]+ null\]/g)].map(
+      (m) => m[1],
+    );
+    expect(dests).toHaveLength(2);
+    expect(dests[0]).not.toBe(dests[1]); // different pages
+  });
+
+  it("escapes parentheses in a bookmark title", async () => {
+    const doc = Document([Page([Bookmark({ title: "A (test)" }, Text("x"))])]);
+    const pdf = await renderPdf(doc);
+    expect(pdf).toContain("/Title (A \\(test\\))");
+  });
+});

--- a/tests/unit/renderer/hyperlink.test.ts
+++ b/tests/unit/renderer/hyperlink.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { Document, Page, Box, Text, span, Link, renderPdf } from "../../../src/lib/api";
+
+// Count non-overlapping occurrences of a needle.
+const count = (haystack: string, needle: string): number => haystack.split(needle).length - 1;
+
+describe("hyperlinks (/Link annotations)", () => {
+  it("adds no annotations to a page without links", async () => {
+    const pdf = await renderPdf(Document([Page([Text("plain text")])]));
+    expect(pdf).not.toContain("/Subtype /Link");
+    expect(pdf).not.toContain("/Annots");
+  });
+
+  it("makes a block child a /Link annotation with a URI action", async () => {
+    const doc = Document([
+      Page([Link({ href: "https://jasy.dev" }, Box({ bg: "#eee" }, [Text("click")]))]),
+    ]);
+    const pdf = await renderPdf(doc);
+    expect(pdf).toContain("/Subtype /Link");
+    expect(pdf).toContain("/A << /S /URI /URI (https://jasy.dev) >>");
+    expect(pdf).toContain("/Border [0 0 0]"); // no visible annotation border
+    expect(pdf).toContain("/Annots ["); // wired onto the page
+    expect(count(pdf, "/Subtype /Link")).toBe(1);
+  });
+
+  it("makes an href span an inline link over just that run", async () => {
+    const doc = Document([
+      Page([Text([span("visit "), span("jasy.dev", { href: "https://jasy.dev" }), span(" now")])]),
+    ]);
+    const pdf = await renderPdf(doc);
+    expect(count(pdf, "/Subtype /Link")).toBe(1);
+    expect(pdf).toContain("/URI (https://jasy.dev)");
+  });
+
+  it("gives a plain-string Text with href a single whole-text link", async () => {
+    const doc = Document([Page([Text("jasy.dev", { href: "https://jasy.dev" })])]);
+    const pdf = await renderPdf(doc);
+    expect(count(pdf, "/Subtype /Link")).toBe(1);
+    expect(pdf).toContain("/URI (https://jasy.dev)");
+  });
+
+  it("emits one rect per line when a link span wraps across lines", async () => {
+    // A narrow box forces the long link text to wrap onto two lines -> two annotation rects.
+    const long = "https://github.com/jasy-pdf/jasy/blob/main/README.md";
+    const doc = Document([
+      Page([Box({ width: 120 }, [Text([span("go to "), span(long, { href: "https://x.dev" })])])]),
+    ]);
+    const pdf = await renderPdf(doc);
+    expect(count(pdf, "/Subtype /Link")).toBeGreaterThanOrEqual(2);
+  });
+
+  it("escapes parentheses/backslashes in a URL", async () => {
+    const doc = Document([Page([Link({ href: "https://x.dev/a(b)\\c" }, Text("x"))])]);
+    const pdf = await renderPdf(doc);
+    expect(pdf).toContain("(https://x.dev/a\\(b\\)\\\\c)");
+  });
+});

--- a/tests/unit/renderer/pdf-renderer.test.ts
+++ b/tests/unit/renderer/pdf-renderer.test.ts
@@ -33,6 +33,8 @@ describe("PDFRenderer", () => {
       finalizeCustomFonts: vi.fn(),
       finalizeEncryption: vi.fn().mockResolvedValue(undefined),
       struct: { enabled: false, finalize: vi.fn().mockReturnValue("") },
+      outline: { isEmpty: true, finalize: vi.fn().mockReturnValue("") },
+      dests: { isEmpty: true, finalize: vi.fn().mockReturnValue("") },
     } as unknown as PDFObjectManager;
 
     vi.spyOn(PDFDocumentRenderer, "render").mockResolvedValue(1);


### PR DESCRIPTION
## Summary

Now jays can handle bookmarks, anchors (intern) and external links (hyperlinks)

## Related issue(s)

Closes #

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clickable links for external URLs and internal destinations.
  * Added anchors for named jump targets and bookmarks for document outlines.
  * Plain text and inline runs can now be linked directly via `href`/`to`, with link target validation.
* **Bug Fixes**
  * Improved placement of link annotations, internal destinations, and outline entries on the correct pages.
  * Refined destination naming/sorting and improved PDF string escaping (including bookmark titles and attachment-related names).
* **Tests**
  * Added coverage for hyperlinks, anchors, bookmarks, and attachment/PDF escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->