### PR TITLE
feat: rotate element

### DIFF
--- a/src/lib/api/layout.ts
+++ b/src/lib/api/layout.ts
@@ -4,6 +4,8 @@ import { RectangleElement } from "../elements/rectangle-element.ts";
 import { ExpandedElement } from "../elements/layout/expanded-element.ts";
 import { PaddingElement } from "../elements/layout/padding-element.ts";
 import { PositionedElement, PositionedInsets } from "../elements/layout/positioned-element.ts";
+import { RotatedElement } from "../elements/layout/rotated-element.ts";
+import { RotatedBoxElement } from "../elements/layout/rotated-box-element.ts";
 import { PDFElement } from "../elements/pdf-element.ts";
 import { MainAlign, CrossAlign } from "../utils/flex-layout.ts";
 import { ColorInput, toColor } from "./color.ts";
@@ -174,6 +176,26 @@ export function Padding(padding: Insets, child: PDFElement): PaddingElement {
  */
 export function Positioned(opts: PositionedInsets, child: PDFElement): PositionedElement {
   return new PositionedElement({ child, ...opts });
+}
+
+/**
+ * Rotates `child` at PAINT time by `angle` degrees (clockwise), around its center - like CSS
+ * `transform: rotate()` / Flutter `Transform.rotate`. The child keeps its normal, unrotated layout box,
+ * so siblings do NOT reflow around the spun shape and the drawing may overflow its slot. Pair it with a
+ * `relative` Box + `Positioned` for a diagonal watermark or a "PAID" stamp laid over a document.
+ */
+export function Rotated(opts: { angle: number }, child: PDFElement): RotatedElement {
+  return new RotatedElement({ angle: opts.angle, child });
+}
+
+/**
+ * Rotates `child` by whole quarter-turns and, unlike `Rotated`, is LAYOUT-AWARE: a 90 / 270 turn swaps
+ * the box's width and height so siblings reflow around it (a tall label becomes a narrow, tall strip
+ * that reserves exactly that footprint). `turns` = clockwise 90-degree steps (1 = 90, 2 = 180, 3 = 270).
+ * Use it for a vertical label beside a table; use `Rotated` for a free-angle stamp / watermark.
+ */
+export function RotatedBox(opts: { turns: number }, child: PDFElement): RotatedBoxElement {
+  return new RotatedBoxElement({ turns: opts.turns, child });
 }
 
 /**

--- a/src/lib/elements/index.ts
+++ b/src/lib/elements/index.ts
@@ -8,5 +8,7 @@ export * from "./layout/expanded-element.ts";
 export * from "./layout/padding-element.ts";
 export * from "./layout/default-text-style-element.ts";
 export * from "./layout/positioned-element.ts";
+export * from "./layout/rotated-element.ts";
+export * from "./layout/rotated-box-element.ts";
 export * from "./line-element.ts";
 export * from "./row-element.ts";

--- a/src/lib/elements/layout/rotated-box-element.ts
+++ b/src/lib/elements/layout/rotated-box-element.ts
@@ -1,0 +1,72 @@
+import { PDFElement, LayoutContext } from "../pdf-element.ts";
+import { BoxConstraints, Offset, Size } from "../../layout/box-constraints.ts";
+
+/**
+ * Rotates its child by whole quarter-turns and, unlike `RotatedElement` (paint-only), makes the
+ * rotation LAYOUT-AWARE: for a 90 / 270 turn it SWAPS width and height, so the box reports the rotated
+ * footprint UP and siblings reflow around it. A tall text becomes a narrow vertical strip that actually
+ * reserves its narrow width and its long height - the "vertical label beside a table" case.
+ *
+ * `turns` is the number of 90-degree CLOCKWISE quarter-turns (like Flutter's `RotatedBox.quarterTurns`):
+ * 0 = none, 1 = 90, 2 = 180, 3 = 270. The child lays out with the box's constraints swapped, then it is
+ * placed centered on the box's center so a plain center-rotation (the shared renderer) maps it exactly
+ * onto the swapped box.
+ */
+export class RotatedBoxElement extends PDFElement {
+  private turns: number; // normalized 0..3, clockwise
+  private child: PDFElement;
+  private x = 0;
+  private y = 0;
+  private width = 0;
+  private height = 0;
+
+  constructor({ turns, child }: { turns: number; child: PDFElement }) {
+    super();
+    this.turns = ((Math.trunc(turns) % 4) + 4) % 4;
+    this.child = child;
+  }
+
+  calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
+    const quarter = this.turns % 2 === 1; // 90 or 270: axes swap
+    // A quarter-turned child experiences the box's constraints with the axes swapped.
+    const childConstraints = quarter
+      ? new BoxConstraints(
+          constraints.minHeight,
+          constraints.maxHeight,
+          constraints.minWidth,
+          constraints.maxWidth,
+        )
+      : constraints;
+
+    // Measure the child to learn its natural size, then take that size swapped as our own box.
+    const child = this.child.calculateLayout(childConstraints, offset, ctx);
+    this.width = quarter ? child.height : child.width;
+    this.height = quarter ? child.width : child.height;
+    this.x = offset.x;
+    this.y = offset.y;
+
+    // Re-place the child CENTERED on the box center: a rotation around that center then maps the
+    // child's (w x h) box exactly onto our (swapped) box - so the shared renderer needs no special case.
+    const cx = this.x + this.width / 2;
+    const cy = this.y + this.height / 2;
+    this.child.calculateLayout(
+      childConstraints,
+      { x: cx - child.width / 2, y: cy - child.height / 2 },
+      ctx,
+    );
+
+    return { width: this.width, height: this.height };
+  }
+
+  /** Same shape as `RotatedElement` (angle + box), so both share `RotatedRenderer`. */
+  override getProps() {
+    return {
+      angle: this.turns * 90,
+      child: this.child,
+      x: this.x,
+      y: this.y,
+      width: this.width,
+      height: this.height,
+    };
+  }
+}

--- a/src/lib/elements/layout/rotated-element.ts
+++ b/src/lib/elements/layout/rotated-element.ts
@@ -1,0 +1,48 @@
+import { PDFElement, LayoutContext } from "../pdf-element.ts";
+import { BoxConstraints, Offset, Size } from "../../layout/box-constraints.ts";
+
+/**
+ * Rotates its single child at PAINT time only (like Flutter's `Transform.rotate`): the child lays out
+ * in its normal, axis-aligned box and the element reports that same box UP, so siblings never reflow
+ * around the rotated shape. Only the drawing is rotated, around the box's center, by the renderer.
+ *
+ * Layout-transparent: it delegates `calculateLayout` to the child and just records the resulting box,
+ * which the renderer needs as the pivot. Not `Fragmentable` on purpose - a rotated subtree is atomic
+ * w.r.t. pagination (it moves whole to the next page rather than splitting mid-rotation).
+ */
+export class RotatedElement extends PDFElement {
+  private angle: number; // degrees, clockwise as seen on the page
+  private child: PDFElement;
+  private x = 0;
+  private y = 0;
+  private width = 0;
+  private height = 0;
+
+  constructor({ angle, child }: { angle: number; child: PDFElement }) {
+    super();
+    this.angle = angle;
+    this.child = child;
+  }
+
+  calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
+    // Delegate entirely to the child, then record its box (position + size) as our own - the
+    // rotation does not change what space we take, only how the child is painted.
+    const size = this.child.calculateLayout(constraints, offset, ctx);
+    this.x = offset.x;
+    this.y = offset.y;
+    this.width = size.width;
+    this.height = size.height;
+    return size;
+  }
+
+  override getProps() {
+    return {
+      angle: this.angle,
+      child: this.child,
+      x: this.x,
+      y: this.y,
+      width: this.width,
+      height: this.height,
+    };
+  }
+}

--- a/src/lib/ir/display-list.ts
+++ b/src/lib/ir/display-list.ts
@@ -108,6 +108,25 @@ export interface ClipPop {
 }
 
 /**
+ * Pushes an affine transform (a `q` + `cm` in the content stream): everything between this and the
+ * matching `TransformPop` is painted through `matrix`. This is what `Rotated` wraps its child's nodes
+ * in, so a subtree draws rotated (or scaled/translated) around a pivot without touching its layout.
+ *
+ * `matrix` is `[a, b, c, d, e, f]` in the engine's TOP-LEFT coordinates - the same space every other IR
+ * node uses. The Y-flip at the IR -> backend seam converts it to PDF's bottom-left once per page, so
+ * producers stay coordinate-system-blind (they never see a flipped matrix).
+ */
+export interface TransformPush {
+  type: "transform-push";
+  matrix: [number, number, number, number, number, number];
+}
+
+/** Closes the most recent `TransformPush` (restores the graphics state). */
+export interface TransformPop {
+  type: "transform-pop";
+}
+
+/**
  * One drawing command of a `Path`, in absolute page coordinates. Curves are CUBIC because PDF
  * content streams have no quadratic operator - a producer converts TrueType quads to cubics before
  * emitting. `z` closes the current subpath (a glyph contour).
@@ -164,4 +183,13 @@ export interface Path {
 }
 
 /** The closed set of primitives the PDF backend knows how to draw. */
-export type IRNode = TextRun | Rect | Line | Image | ClipPush | ClipPop | Path;
+export type IRNode =
+  | TextRun
+  | Rect
+  | Line
+  | Image
+  | ClipPush
+  | ClipPop
+  | Path
+  | TransformPush
+  | TransformPop;

--- a/src/lib/renderer/pdf-backend.ts
+++ b/src/lib/renderer/pdf-backend.ts
@@ -66,6 +66,26 @@ export class PdfBackend {
               : { ...node.fill, y0: pageHeight - node.fill.y0, y1: pageHeight - node.fill.y1 };
           return { ...node, commands, fill };
         }
+        case "transform-push": {
+          // The child nodes are flipped from top-left to bottom-left by F = [1,0,0,-1,0,H] (F is its
+          // own inverse). For a matrix authored in top-left space to act correctly on them, conjugate
+          // it by that flip: M_pdf = F · M · F. Worked out for [a,b,c,d,e,f] with H = pageHeight:
+          const [a, b, c, d, e, f] = node.matrix;
+          const H = pageHeight;
+          return {
+            ...node,
+            matrix: [a, -b, -c, d, H * c + e, H - H * d - f] as [
+              number,
+              number,
+              number,
+              number,
+              number,
+              number,
+            ],
+          };
+        }
+        case "transform-pop":
+          return node; // no coordinates to flip
         default: {
           const unknown: never = node;
           return unknown;
@@ -82,7 +102,16 @@ export class PdfBackend {
     return nodes
       .map((node) => {
         const ops = PdfBackend.serializeNode(node, om);
-        if (!struct || node.type === "clip-push" || node.type === "clip-pop" || ops === "")
+        // Graphics-state nodes (clip / transform push+pop) carry no tag and must not be wrapped in a
+        // marked-content sequence - they only save/restore state around the drawables they enclose.
+        if (
+          !struct ||
+          node.type === "clip-push" ||
+          node.type === "clip-pop" ||
+          node.type === "transform-push" ||
+          node.type === "transform-pop" ||
+          ops === ""
+        )
           return ops;
         const { open, close } = struct.mark(node.tag);
         return open + ops + close;
@@ -273,6 +302,13 @@ export class PdfBackend {
         return gs ? `q\n${gs}${body}Q\n` : body;
       }
       case "clip-pop":
+        return `Q\n`;
+      case "transform-push": {
+        // Save the graphics state, then apply the affine; everything until transform-pop paints through it.
+        const f = (n: number) => n.toFixed(3);
+        return `q\n${node.matrix.map(f).join(" ")} cm\n`;
+      }
+      case "transform-pop":
         return `Q\n`;
       default: {
         // Exhaustiveness guard: if a new IRNode variant is added, this fails to compile.

--- a/src/lib/renderer/pdf-renderer.ts
+++ b/src/lib/renderer/pdf-renderer.ts
@@ -30,6 +30,9 @@ import { PositionedElement } from "../elements/layout/positioned-element.ts";
 import { PositionedRenderer } from "./positioned-renderer.ts";
 import { StructGroup } from "../elements/layout/struct-group.ts";
 import { StructGroupRenderer } from "./struct-group-renderer.ts";
+import { RotatedElement } from "../elements/layout/rotated-element.ts";
+import { RotatedBoxElement } from "../elements/layout/rotated-box-element.ts";
+import { RotatedRenderer } from "./rotated-renderer.ts";
 import { BoxConstraints } from "../layout/box-constraints.ts";
 import { collectImageElements } from "../layout/collect-images.ts";
 import { LayoutContext } from "../elements/pdf-element.ts";
@@ -54,6 +57,8 @@ export class PDFRenderer {
     RendererRegistry.register(DeferredElement, DeferredRenderer.render);
     RendererRegistry.register(PositionedElement, PositionedRenderer.render);
     RendererRegistry.register(StructGroup, StructGroupRenderer.render);
+    RendererRegistry.register(RotatedElement, RotatedRenderer.render);
+    RendererRegistry.register(RotatedBoxElement, RotatedRenderer.render);
 
     let pdfContent = "";
 

--- a/src/lib/renderer/rotated-renderer.ts
+++ b/src/lib/renderer/rotated-renderer.ts
@@ -1,0 +1,40 @@
+import { PDFObjectManager } from "../utils/pdf-object-manager.ts";
+import { RotatedElement } from "../elements/layout/rotated-element.ts";
+import { RotatedBoxElement } from "../elements/layout/rotated-box-element.ts";
+import { RendererRegistry } from "../utils/renderer-registry.ts";
+import { IRNode } from "../ir/display-list.ts";
+
+export class RotatedRenderer {
+  // Both `Rotated` (paint-only) and `RotatedBox` (layout-aware quarter-turns) expose the same
+  // `{ angle, child, x, y, width, height }` and rotate the child around the box center - shared here.
+  static async render(
+    element: RotatedElement | RotatedBoxElement,
+    objectManager: PDFObjectManager,
+  ): Promise<IRNode[]> {
+    const { angle, child, x, y, width, height } = element.getProps();
+
+    // Rotate around the box CENTER, in the engine's top-left coordinates (the IR->backend seam flips
+    // the matrix to PDF space per page). A positive angle reads clockwise on the page.
+    const cx = x + width / 2;
+    const cy = y + height / 2;
+    const theta = (angle * Math.PI) / 180;
+    const cos = Math.cos(theta);
+    const sin = Math.sin(theta);
+    // M = T(cx,cy) · R(theta) · T(-cx,-cy) as a PDF cm [a,b,c,d,e,f]: the linear part is the rotation,
+    // the translation keeps the center fixed.
+    const matrix: [number, number, number, number, number, number] = [
+      cos,
+      sin,
+      -sin,
+      cos,
+      cx - cos * cx + sin * cy,
+      cy - sin * cx - cos * cy,
+    ];
+
+    const renderer = RendererRegistry.getRenderer(child);
+    const childNodes = renderer ? await renderer(child, objectManager) : [];
+
+    // Wrap the child's drawing between a push (apply the matrix) and a pop (restore).
+    return [{ type: "transform-push", matrix }, ...childNodes, { type: "transform-pop" }];
+  }
+}

--- a/tests/unit/elements/rotated-box-element.test.ts
+++ b/tests/unit/elements/rotated-box-element.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { RotatedBoxElement } from "../../../src/lib/elements/layout/rotated-box-element";
+import { RotatedBox } from "../../../src/lib/api/layout";
+import { RectangleElement } from "../../../src/lib/elements/rectangle-element";
+import { BoxConstraints } from "../../../src/lib/layout/box-constraints";
+import { LayoutContext } from "../../../src/lib/elements/pdf-element";
+
+const ctx = {} as LayoutContext;
+const box = (w: number, h: number) =>
+  new RectangleElement({ x: 0, y: 0, children: [], width: w, height: h, borderWidth: 0 });
+const layout = (turns: number, child: RectangleElement) =>
+  new RotatedBoxElement({ turns, child }).calculateLayout(
+    BoxConstraints.loose(400, 400),
+    { x: 0, y: 0 },
+    ctx,
+  );
+
+describe("RotatedBoxElement (layout-aware quarter-turns)", () => {
+  it("a 90-turn swaps width and height (100x20 -> 20x100)", () => {
+    expect(layout(1, box(100, 20))).toEqual({ width: 20, height: 100 });
+  });
+
+  it("a 270-turn also swaps the axes", () => {
+    expect(layout(3, box(100, 20))).toEqual({ width: 20, height: 100 });
+  });
+
+  it("a 180-turn (and 0) keeps width and height", () => {
+    expect(layout(2, box(100, 20))).toEqual({ width: 100, height: 20 });
+    expect(layout(0, box(100, 20))).toEqual({ width: 100, height: 20 });
+  });
+
+  it("normalizes the turn count and exposes turns*90 as the angle", () => {
+    expect(new RotatedBoxElement({ turns: 5, child: box(10, 10) }).getProps().angle).toBe(90); // 5 -> 1
+    expect(new RotatedBoxElement({ turns: -1, child: box(10, 10) }).getProps().angle).toBe(270); // -1 -> 3
+  });
+
+  it("places the child centered on the box center, so a center-rotation maps it onto the box", () => {
+    // box is 20x100 at (0,0) -> center (10,50); the 100x20 child centered -> offset (10-50, 50-10).
+    const child = box(100, 20);
+    layout(1, child);
+    expect({ x: child.getProps().x, y: child.getProps().y }).toEqual({ x: -40, y: 40 });
+  });
+
+  it("the RotatedBox factory wraps the child in a RotatedBoxElement", () => {
+    expect(RotatedBox({ turns: 1 }, box(10, 10))).toBeInstanceOf(RotatedBoxElement);
+  });
+});

--- a/tests/unit/elements/rotated-element.test.ts
+++ b/tests/unit/elements/rotated-element.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { RotatedElement } from "../../../src/lib/elements/layout/rotated-element";
+import { Rotated } from "../../../src/lib/api/layout";
+import { RectangleElement } from "../../../src/lib/elements/rectangle-element";
+import { BoxConstraints } from "../../../src/lib/layout/box-constraints";
+import { LayoutContext } from "../../../src/lib/elements/pdf-element";
+
+const ctx = {} as LayoutContext;
+const box = (w: number, h: number) =>
+  new RectangleElement({ x: 0, y: 0, children: [], width: w, height: h, borderWidth: 0 });
+
+describe("RotatedElement (paint-only, layout-transparent)", () => {
+  it("reports the child's box unchanged (no reflow around the rotated shape)", () => {
+    const child = box(100, 50);
+    const size = new RotatedElement({ angle: 45, child }).calculateLayout(
+      BoxConstraints.loose(200, Infinity),
+      { x: 10, y: 20 },
+      ctx,
+    );
+    expect(size).toEqual({ width: 100, height: 50 }); // same as the child, rotation is paint-only
+  });
+
+  it("lays the child out at the given offset and records the box + angle for the renderer", () => {
+    const child = box(100, 50);
+    const rot = new RotatedElement({ angle: 30, child });
+    rot.calculateLayout(BoxConstraints.loose(200, Infinity), { x: 10, y: 20 }, ctx);
+    const props = rot.getProps();
+    expect(props.angle).toBe(30);
+    expect({ x: props.x, y: props.y, width: props.width, height: props.height }).toEqual({
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 50,
+    });
+    expect(child.getProps().x).toBe(10); // child was actually placed at the offset
+  });
+
+  it("the Rotated factory wraps the child in a RotatedElement carrying the angle", () => {
+    const r = Rotated({ angle: 45 }, box(10, 10));
+    expect(r).toBeInstanceOf(RotatedElement);
+    r.calculateLayout(BoxConstraints.loose(100, Infinity), { x: 0, y: 0 }, ctx);
+    expect(r.getProps().angle).toBe(45);
+  });
+});

--- a/tests/unit/renderer/pdf-backend.test.ts
+++ b/tests/unit/renderer/pdf-backend.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { PdfBackend } from "../../../src/lib/renderer/pdf-backend";
 import { PDFObjectManager, FontStyle } from "../../../src/lib/utils/pdf-object-manager";
-import { TextRun, Path } from "../../../src/lib/ir/display-list";
+import { TextRun, Path, TransformPush, TransformPop } from "../../../src/lib/ir/display-list";
 import { Color } from "../../../src/lib/common/color";
 
 describe("PdfBackend.escapePdfString", () => {
@@ -39,6 +39,39 @@ describe("PdfBackend text serialization", () => {
     expect(out).toContain("(can't split \\(yet\\)) Tj");
     // No bare ")" that would terminate the string early before " Tj".
     expect(out).not.toContain("(yet)) Tj");
+  });
+});
+
+describe("PdfBackend transform serialization + flipY", () => {
+  const om = new PDFObjectManager();
+
+  it("transform-push saves state and emits the matrix as a cm; transform-pop restores it", () => {
+    const push: TransformPush = { type: "transform-push", matrix: [1, 0, 0, 1, 10, 20] };
+    const pop: TransformPop = { type: "transform-pop" };
+    expect(PdfBackend.serializeNode(push, om)).toBe(
+      "q\n1.000 0.000 0.000 1.000 10.000 20.000 cm\n",
+    );
+    expect(PdfBackend.serializeNode(pop, om)).toBe("Q\n");
+  });
+
+  it("flipY leaves identity as identity", () => {
+    const push: TransformPush = { type: "transform-push", matrix: [1, 0, 0, 1, 0, 0] };
+    const [flipped] = PdfBackend.flipY([push], 1000) as [TransformPush];
+    // `+ 0` normalizes -0 to 0 (a negated 0); harmless in the stream ((-0).toFixed(3) === "0.000").
+    expect(flipped.matrix.map((n) => n + 0)).toEqual([1, 0, 0, 1, 0, 0]);
+  });
+
+  it("flipY turns a top-left translation into its bottom-left equivalent (y negates)", () => {
+    const push: TransformPush = { type: "transform-push", matrix: [1, 0, 0, 1, 5, 7] };
+    const [flipped] = PdfBackend.flipY([push], 1000) as [TransformPush];
+    expect(flipped.matrix.map((n) => n + 0)).toEqual([1, 0, 0, 1, 5, -7]);
+  });
+
+  it("flipY conjugates a rotation by the page flip (90deg around the origin)", () => {
+    // [cos,sin,-sin,cos] at 90deg = [0,1,-1,0]; F·M·F with H=1000 -> [0,-1,1,0,-1000,1000].
+    const push: TransformPush = { type: "transform-push", matrix: [0, 1, -1, 0, 0, 0] };
+    const [flipped] = PdfBackend.flipY([push], 1000) as [TransformPush];
+    expect(flipped.matrix).toEqual([0, -1, 1, 0, -1000, 1000]);
   });
 });
 


### PR DESCRIPTION
## Summary

Now jasy can rotate "text" elements with each angle, also in absolute positioned elements

## Related issue(s)

Closes #

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rotation support for layout elements, including free-angle rotation and quarter-turn box rotation.
  * Introduced transform handling in rendering so rotated content is drawn correctly.
* **Bug Fixes**
  * Improved coordinate handling so rotated content keeps the expected position and size.
  * Ensured transform state is saved and restored properly during rendering.
* **Tests**
  * Added coverage for rotated layout behavior and transform serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->