### PR TITLE
feat: add page number and count elements

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -7,6 +7,7 @@ export * from "./dimension.ts";
 export * from "./text.ts";
 export * from "./layout.ts";
 export * from "./content.ts";
+export * from "./page-builder.ts";
 export * from "./structure.ts";
 export * from "./table.ts";
 export * from "./descriptor.ts";

--- a/src/lib/api/page-builder.ts
+++ b/src/lib/api/page-builder.ts
@@ -24,7 +24,7 @@ export type { PageInfo };
  * SHRINK on later pages but must not GROW, because the body band was measured against the first build.
  */
 export function PageBuilder(build: (info: PageInfo) => PDFElement): PageBuilderElement {
-  return new PageBuilderElement(build);
+  return new PageBuilderElement({ build });
 }
 
 /** `Text` options plus an `offset` added to the number (e.g. `-1` to not count a cover page). */

--- a/src/lib/api/page-builder.ts
+++ b/src/lib/api/page-builder.ts
@@ -1,0 +1,43 @@
+import { PageBuilderElement } from "../elements/layout/page-builder-element.ts";
+import { PageInfo, PDFElement } from "../elements/pdf-element.ts";
+import { Text, TextOptions } from "./text.ts";
+
+export type { PageInfo };
+
+/**
+ * Builds content from the page it ends up on - this is how you show `pageNumber` / `pageCount`. Place it
+ * anywhere: in a `Page`'s `header`/`footer`, in the body, in a table cell, several times on one page.
+ * Because you write the closure, formatting and conditions are yours:
+ *
+ * ```ts
+ * PageBuilder(({ pageNumber, pageCount }) => Text(`Seite ${pageNumber} von ${pageCount}`))
+ * PageBuilder(({ pageNumber }) => (pageNumber === 1 ? Logo() : Text("Fortsetzung")))
+ * PageBuilder(({ pageNumber, pageCount }) => Text(`${pageNumber - 1} / ${pageCount - 1}`)) // cover page
+ * ```
+ *
+ * `pageNumber` is 1-based and counts PHYSICAL pages (an overflowing `Page` contributes several);
+ * `pageCount` is the document total; `pageSize` is the media box in points.
+ *
+ * The numbers themselves are always exact. Two sizing caveats, both from the same chicken-and-egg (the
+ * content decides the count that the content displays): in the flowing BODY the box is reserved before the
+ * total is known, so a much wider final string can paint slightly past it; and a conditional header may
+ * SHRINK on later pages but must not GROW, because the body band was measured against the first build.
+ */
+export function PageBuilder(build: (info: PageInfo) => PDFElement): PageBuilderElement {
+  return new PageBuilderElement(build);
+}
+
+/** `Text` options plus an `offset` added to the number (e.g. `-1` to not count a cover page). */
+export interface PageNumberOptions extends TextOptions {
+  offset?: number;
+}
+
+/** The current page number as text. Sugar for `PageBuilder` - same thing, one word. */
+export function PageNumber({ offset = 0, ...style }: PageNumberOptions = {}): PageBuilderElement {
+  return PageBuilder(({ pageNumber }) => Text(String(pageNumber + offset), style));
+}
+
+/** The document's total page count as text. Sugar for `PageBuilder`. */
+export function PageCount({ offset = 0, ...style }: PageNumberOptions = {}): PageBuilderElement {
+  return PageBuilder(({ pageCount }) => Text(String(pageCount + offset), style));
+}

--- a/src/lib/elements/index.ts
+++ b/src/lib/elements/index.ts
@@ -11,6 +11,7 @@ export * from "./layout/positioned-element.ts";
 export * from "./layout/link-element.ts";
 export * from "./layout/bookmark-element.ts";
 export * from "./layout/anchor-element.ts";
+export * from "./layout/page-builder-element.ts";
 export * from "./layout/rotated-element.ts";
 export * from "./layout/rotated-box-element.ts";
 export * from "./line-element.ts";

--- a/src/lib/elements/layout/page-builder-element.ts
+++ b/src/lib/elements/layout/page-builder-element.ts
@@ -1,0 +1,51 @@
+import { BoxConstraints, Offset, Size } from "../../layout/box-constraints.ts";
+import { LayoutContext, PageInfo, PDFElement } from "../pdf-element.ts";
+import { resolvePageSize } from "../page-element.ts";
+
+/**
+ * Builds its subtree from the page it lands on, so a header, a footer or plain body content can show
+ * `pageNumber` / `pageCount`. The closure runs on EVERY layout, because the numbers differ between the
+ * two driver passes: pagination has to size the element before the page total exists, so it builds
+ * against a provisional "1 of 1"; the render pass then rebuilds it with the real `PageInfo`.
+ *
+ * Two consequences, and neither is magic - both come from the same chicken-and-egg: the content decides
+ * the page count that the content displays.
+ *
+ * 1. In the flowing BODY the box is reserved by the provisional build, so a much wider final string
+ *    (`"9 of 10"` vs `"1 of 1"`) can paint slightly past it. Keep dynamic body content roughly constant
+ *    in width.
+ * 2. A header/footer is re-laid out per page, so its real height is honoured - but the BODY band was
+ *    already sized against the provisional build. A later page whose header is SHORTER simply gains
+ *    room (harmless). A later page whose header is TALLER shrinks the band its body was measured for,
+ *    and that body can overflow. So: a conditional header may shrink on later pages, never grow.
+ */
+export class PageBuilderElement extends PDFElement {
+  private composed?: PDFElement;
+
+  constructor(private build: (info: PageInfo) => PDFElement) {
+    super();
+  }
+
+  /** The real page info during the render pass; a provisional "1 of 1" while paginating. */
+  private infoFrom(ctx: LayoutContext): PageInfo {
+    return (
+      ctx.pageInfo ?? {
+        pageNumber: 1,
+        pageCount: 1,
+        pageSize: resolvePageSize(ctx.pageConfig),
+      }
+    );
+  }
+
+  calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
+    this.composed = this.build(this.infoFrom(ctx));
+    return this.composed.calculateLayout(constraints, offset, ctx);
+  }
+
+  // Named `composed` (not `child`) like DeferredElement: the pre-layout image walk keys on `child`, and
+  // this subtree does not exist yet when it runs. So an Image inside a PageBuilder skips aspect-ratio
+  // pre-resolution - give it both width and height, exactly as inside a Deferred/Table subtree.
+  override getProps() {
+    return { composed: this.composed };
+  }
+}

--- a/src/lib/elements/layout/page-builder-element.ts
+++ b/src/lib/elements/layout/page-builder-element.ts
@@ -21,9 +21,11 @@ import { resolvePageSize } from "../page-element.ts";
  */
 export class PageBuilderElement extends PDFElement {
   private composed?: PDFElement;
+  private readonly build: (info: PageInfo) => PDFElement;
 
-  constructor(private build: (info: PageInfo) => PDFElement) {
+  constructor({ build }: { build: (info: PageInfo) => PDFElement }) {
     super();
+    this.build = build;
   }
 
   /** The real page info during the render pass; a provisional "1 of 1" while paginating. */

--- a/src/lib/elements/page-element.ts
+++ b/src/lib/elements/page-element.ts
@@ -24,6 +24,18 @@ interface PDFPageParams extends WithChildren {
 }
 
 /**
+ * The full page (media box) size in points, orientation applied. This is what a `PageBuilder` sees as
+ * `pageSize`; `resolvePageContentBox` below then subtracts the margins.
+ */
+export function resolvePageSize(config: PDFPageConfig): { width: number; height: number } {
+  // Defaults to A4 when the config is not fully resolved, matching what PageRenderer does for the MediaBox.
+  const [pageW, pageH] = config.customSize ?? pageFormats[config.pageSize ?? PageSize.A4];
+  return config.orientation === Orientation.landscape
+    ? { width: pageH, height: pageW }
+    : { width: pageW, height: pageH };
+}
+
+/**
  * The content box of a page (inside the margins, orientation applied) for a fully
  * resolved config. Single source of truth, shared by `PageElement` layout and the page
  * driver so they can never drift.
@@ -125,6 +137,7 @@ export class PageElement extends PDFElement {
       pageConfig: this.config,
       textStyle: ctx.textStyle,
       onOverflow: ctx.onOverflow,
+      pageInfo: ctx.pageInfo, // the render pass supplies it; absent during pagination
     };
 
     // Place the header/footer bands; the body gets the region left in between (the whole

--- a/src/lib/elements/pdf-element.ts
+++ b/src/lib/elements/pdf-element.ts
@@ -22,9 +22,23 @@ export interface PositioningFrame {
   place: Array<(frame: { origin: Offset; size: Size }, ctx: LayoutContext) => void>;
 }
 
+/**
+ * What a `PageBuilder` learns about the page it landed on. `pageNumber` is 1-based and counts PHYSICAL
+ * pages across the whole document (a logical `Page` that overflows contributes several); `pageCount` is
+ * the document's final physical page total. `pageSize` is the media box in points, orientation applied.
+ */
+export interface PageInfo {
+  pageNumber: number;
+  pageCount: number;
+  pageSize: { width: number; height: number };
+}
+
 export interface LayoutContext {
   metrics: FontMetrics;
   pageConfig: PDFPageConfig;
+  /** The page a `PageBuilder` is being laid out on. Only the render pass knows the real numbers, so
+   *  during pagination this is absent and a `PageBuilder` builds against a provisional "1 of 1". */
+  pageInfo?: PageInfo;
   /** The nearest enclosing positioning frame, if any (set by a `relative` Box). */
   frame?: PositioningFrame;
   /** The cascaded text style descendants inherit (CSS/Flutter-style). Seeded at the document root

--- a/src/lib/renderer/page-builder-renderer.ts
+++ b/src/lib/renderer/page-builder-renderer.ts
@@ -1,0 +1,18 @@
+import { PDFObjectManager } from "../utils/pdf-object-manager.ts";
+import { PageBuilderElement } from "../elements/layout/page-builder-element.ts";
+import { RendererRegistry } from "../utils/renderer-registry.ts";
+import { IRNode } from "../ir/display-list.ts";
+
+export class PageBuilderRenderer {
+  static async render(
+    element: PageBuilderElement,
+    objectManager: PDFObjectManager,
+  ): Promise<IRNode[]> {
+    // `composed` is whatever the closure built for THIS page during the render pass's layout.
+    const { composed } = element.getProps();
+    if (!composed) return [];
+
+    const renderer = RendererRegistry.getRenderer(composed);
+    return renderer ? renderer(composed, objectManager) : [];
+  }
+}

--- a/src/lib/renderer/pdf-document-renderer.ts
+++ b/src/lib/renderer/pdf-document-renderer.ts
@@ -77,11 +77,17 @@ export class PDFDocumentRenderer {
     return pagesObjectNumber;
   }
 
-  /** The page geometry a physical page will use. Pass 1 already merged the document defaults into every
-   *  `PageElement.config`; a page that never carried its own config falls back to the document's. */
+  /**
+   * The page geometry a physical page will use. `PageElement.calculateLayout` has already folded the
+   * document defaults into every page's config by the time we get here (`PDFRenderer` lays the document
+   * out before it calls us, and it is our only caller). Merging again is therefore a no-op today - it is
+   * here so this stays correct BY CONSTRUCTION rather than by call order: were that order ever changed,
+   * an unmerged config would otherwise make `resolvePageSize` fall back to A4 and quietly report the
+   * wrong page size.
+   */
   private static configOf(physical: PhysicalPage, ctx: LayoutContext): PDFPageConfig {
     const config = physical.kind === "whole" ? physical.page.getProps().config : physical.config;
-    return config ?? ctx.pageConfig;
+    return { ...ctx.pageConfig, ...config };
   }
 
   /**

--- a/src/lib/renderer/pdf-document-renderer.ts
+++ b/src/lib/renderer/pdf-document-renderer.ts
@@ -124,7 +124,9 @@ export class PDFDocumentRenderer {
         break;
       }
 
-      const { fitted, remainder } = region.fragment(height, width, ctx);
+      // pageCtx, not the document ctx: a descendant that reads `pageConfig` while being measured (a
+      // `PageBuilder` sizing its provisional build) must see THIS page's geometry, not the document default.
+      const { fitted, remainder } = region.fragment(height, width, pageCtx);
 
       // Everything fits on one page: keep the ORIGINAL page so output is unchanged. Measuring inside
       // fragment() left its children at the measuring origin; pass B lays the page out again, which

--- a/src/lib/renderer/pdf-document-renderer.ts
+++ b/src/lib/renderer/pdf-document-renderer.ts
@@ -1,10 +1,30 @@
 import { PDFDocumentElement } from "../elements/pdf-document-element.ts";
-import { layoutPageBands, PageElement, PDFPageConfig } from "../elements/page-element.ts";
+import {
+  layoutPageBands,
+  PageElement,
+  PDFPageConfig,
+  resolvePageSize,
+} from "../elements/page-element.ts";
 import { LayoutContext, PDFElement } from "../elements/pdf-element.ts";
 import { BoxConstraints } from "../layout/box-constraints.ts";
 import { isFragmentable } from "../layout/fragmentation.ts";
 import { PDFObjectManager } from "../utils/pdf-object-manager.ts";
 import { PageRenderer } from "./page-renderer.ts";
+
+/**
+ * One physical PDF page, decided during pagination and rendered afterwards. `whole` = the logical page
+ * fits as-is; `fragment` = one slice of an overflowing page, placed on a fresh page of the same geometry.
+ * Both are laid out again in pass B, which is what lets a `PageBuilder` see its final page number.
+ */
+type PhysicalPage =
+  | { kind: "whole"; page: PageElement }
+  | {
+      kind: "fragment";
+      config: PDFPageConfig | undefined;
+      content: PDFElement;
+      header: PDFElement | undefined;
+      footer: PDFElement | undefined;
+    };
 
 export class PDFDocumentRenderer {
   static async render(
@@ -12,8 +32,6 @@ export class PDFDocumentRenderer {
     objectManager: PDFObjectManager,
     ctx: LayoutContext,
   ): Promise<number> {
-    const pageNumbers: number[] = [];
-
     // Add the pages object first... we need its object number (resources). The count is
     // a placeholder; it is replaced below with the real (post-pagination) page count.
     const pagesObject = `<< /Type /Pages /Kids [] /Count ${document.getProps().children.length} >>`;
@@ -22,11 +40,30 @@ export class PDFDocumentRenderer {
     // Now set the given object number all its childs
     objectManager.setParentObjectNumber(pagesObjectNumber);
 
-    // The page driver: each logical PageElement may produce SEVERAL physical PDF pages
-    // when its content overflows (Slice 0: whole children reflow to the next page).
-    for (let page of document.getProps().children) {
-      const numbers = await PDFDocumentRenderer.renderLogicalPage(page, objectManager, ctx);
-      pageNumbers.push(...numbers);
+    // Pass A - paginate the whole document WITHOUT drawing anything. Fragmentation is synchronous and
+    // pure (`{ fitted, remainder }`), so the full list of physical pages can be settled up front. Only
+    // then is the total page count known, which is what page numbers in a header/footer need.
+    const physicalPages: PhysicalPage[] = [];
+    for (const page of document.getProps().children) {
+      physicalPages.push(...PDFDocumentRenderer.paginateLogicalPage(page, ctx));
+    }
+
+    // Pass B - draw them, in order, so the emitted page objects keep their previous numbering. Each page
+    // is laid out again with its own PageInfo, which is how a `PageBuilder` anywhere in the tree (header,
+    // footer or body) learns its final page number and the now-known document total.
+    const pageNumbers: number[] = [];
+    for (const [index, physical] of physicalPages.entries()) {
+      const pageInfo = {
+        pageNumber: index + 1,
+        pageCount: physicalPages.length,
+        pageSize: resolvePageSize(PDFDocumentRenderer.configOf(physical, ctx)),
+      };
+      pageNumbers.push(
+        await PDFDocumentRenderer.renderPhysicalPage(physical, objectManager, {
+          ...ctx,
+          pageInfo,
+        }),
+      );
     }
 
     // We must update the pages object with the real physical page numbers and count.
@@ -40,22 +77,25 @@ export class PDFDocumentRenderer {
     return pagesObjectNumber;
   }
 
+  /** The page geometry a physical page will use. Pass 1 already merged the document defaults into every
+   *  `PageElement.config`; a page that never carried its own config falls back to the document's. */
+  private static configOf(physical: PhysicalPage, ctx: LayoutContext): PDFPageConfig {
+    const config = physical.kind === "whole" ? physical.page.getProps().config : physical.config;
+    return config ?? ctx.pageConfig;
+  }
+
   /**
-   * Renders one logical page, paginating it into one or more physical pages.
+   * Splits one logical page into the physical pages it will occupy, without rendering.
    *
-   * Slice 0 only auto-paginates the common shape - a page whose single child is a
-   * fragmentation context (a Container). Anything else renders as a single page on the
-   * unchanged path, so non-overflowing documents stay byte-identical to pre-Slice-0.
+   * Only the common shape auto-paginates - a page whose single child is a fragmentation context
+   * (a Container). Anything else stays a single page on the unchanged path, so non-overflowing
+   * documents keep producing byte-identical output.
    */
-  private static async renderLogicalPage(
-    page: PageElement,
-    objectManager: PDFObjectManager,
-    ctx: LayoutContext,
-  ): Promise<number[]> {
+  private static paginateLogicalPage(page: PageElement, ctx: LayoutContext): PhysicalPage[] {
     const { children, config, header, footer } = page.getProps();
 
     if (children.length !== 1 || !isFragmentable(children[0])) {
-      return [await PageRenderer.render(page, objectManager)];
+      return [{ kind: "whole", page }];
     }
 
     // Header/footer repeat on every physical page, so the body only ever flows into the
@@ -72,76 +112,60 @@ export class PDFDocumentRenderer {
       footer,
       pageCtx,
     );
-    const numbers: number[] = [];
+
+    const pages: PhysicalPage[] = [];
     let region: PDFElement | null = children[0];
     let isFirstRegion = true;
 
     while (region) {
       if (!isFragmentable(region)) {
         // A non-fragmentable remainder is placed whole on its own page.
-        numbers.push(
-          await PDFDocumentRenderer.renderPhysicalPage(
-            config,
-            region,
-            header,
-            footer,
-            objectManager,
-            ctx,
-          ),
-        );
+        pages.push({ kind: "fragment", config, content: region, header, footer });
         break;
       }
 
       const { fitted, remainder } = region.fragment(height, width, ctx);
 
-      // Everything fits on one page: render the ORIGINAL page so output is unchanged.
-      // Measuring inside fragment() laid the children out at the origin to size them, so
-      // re-run the page layout first to restore their real positions (deterministic).
+      // Everything fits on one page: keep the ORIGINAL page so output is unchanged. Measuring inside
+      // fragment() left its children at the measuring origin; pass B lays the page out again, which
+      // restores their real positions (layout is deterministic).
       if (isFirstRegion && remainder === null) {
-        page.calculateLayout(new BoxConstraints(), { x: 0, y: 0 }, ctx);
-        numbers.push(await PageRenderer.render(page, objectManager));
+        pages.push({ kind: "whole", page });
         break;
       }
 
       if (fitted) {
-        numbers.push(
-          await PDFDocumentRenderer.renderPhysicalPage(
-            config,
-            fitted,
-            header,
-            footer,
-            objectManager,
-            ctx,
-          ),
-        );
+        pages.push({ kind: "fragment", config, content: fitted, header, footer });
       }
       region = remainder;
       isFirstRegion = false;
     }
 
-    return numbers;
+    return pages;
   }
 
   /**
-   * Lays out one fragment on a fresh page of the same geometry and renders it. The
-   * header/footer are attached to every physical page so they repeat; `PageElement`
+   * Lays out one physical page and renders it. A fragment gets a fresh `PageElement` of the same
+   * geometry; the header/footer are attached to every physical page so they repeat, and `PageElement`
    * re-places them and the body in the band between.
    */
   private static async renderPhysicalPage(
-    config: PDFPageConfig | undefined,
-    content: PDFElement,
-    header: PDFElement | undefined,
-    footer: PDFElement | undefined,
+    physical: PhysicalPage,
     objectManager: PDFObjectManager,
     ctx: LayoutContext,
   ): Promise<number> {
-    const physicalPage = new PageElement({
-      config,
-      header,
-      footer,
-      children: [content],
+    if (physical.kind === "whole") {
+      physical.page.calculateLayout(new BoxConstraints(), { x: 0, y: 0 }, ctx);
+      return PageRenderer.render(physical.page, objectManager);
+    }
+
+    const page = new PageElement({
+      config: physical.config,
+      header: physical.header,
+      footer: physical.footer,
+      children: [physical.content],
     });
-    physicalPage.calculateLayout(new BoxConstraints(), { x: 0, y: 0 }, ctx);
-    return PageRenderer.render(physicalPage, objectManager);
+    page.calculateLayout(new BoxConstraints(), { x: 0, y: 0 }, ctx);
+    return PageRenderer.render(page, objectManager);
   }
 }

--- a/src/lib/renderer/pdf-renderer.ts
+++ b/src/lib/renderer/pdf-renderer.ts
@@ -36,6 +36,8 @@ import { BookmarkElement } from "../elements/layout/bookmark-element.ts";
 import { BookmarkRenderer } from "./bookmark-renderer.ts";
 import { AnchorElement } from "../elements/layout/anchor-element.ts";
 import { AnchorRenderer } from "./anchor-renderer.ts";
+import { PageBuilderElement } from "../elements/layout/page-builder-element.ts";
+import { PageBuilderRenderer } from "./page-builder-renderer.ts";
 import { RotatedElement } from "../elements/layout/rotated-element.ts";
 import { RotatedBoxElement } from "../elements/layout/rotated-box-element.ts";
 import { RotatedRenderer } from "./rotated-renderer.ts";
@@ -67,6 +69,7 @@ export class PDFRenderer {
     RendererRegistry.register(LinkElement, LinkRenderer.render);
     RendererRegistry.register(BookmarkElement, BookmarkRenderer.render);
     RendererRegistry.register(AnchorElement, AnchorRenderer.render);
+    RendererRegistry.register(PageBuilderElement, PageBuilderRenderer.render);
     RendererRegistry.register(RotatedElement, RotatedRenderer.render);
     RendererRegistry.register(RotatedBoxElement, RotatedRenderer.render);
 

--- a/tests/unit/api/page-builder.test.ts
+++ b/tests/unit/api/page-builder.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  Document,
+  Page,
+  Column,
+  Paragraph,
+  Text,
+  PageBuilder,
+  PageNumber,
+  PageCount,
+  renderPdf,
+} from "../../../src/lib/api";
+
+// Enough body to flow across three physical pages.
+const filler = () =>
+  Array.from({ length: 14 }, () => Paragraph("Lorem ipsum dolor sit amet. ".repeat(30)));
+
+// `compress: false` keeps the content stream greppable, so we can assert on the drawn text itself.
+const drawn = (doc: Parameters<typeof renderPdf>[0]) => renderPdf(doc, { compress: false });
+
+describe("PageBuilder / PageNumber / PageCount", () => {
+  it("gives a footer the running page number and the final total", async () => {
+    const doc = Document([
+      Page(
+        {
+          footer: PageBuilder(({ pageNumber, pageCount }) => Text(`P${pageNumber}of${pageCount}`)),
+        },
+        [Column(filler())],
+      ),
+    ]);
+    const pdf = await drawn(doc);
+
+    // Three pages were produced, and each footer shows its own number with the same total.
+    expect(pdf).toContain("(P1of3)");
+    expect(pdf).toContain("(P2of3)");
+    expect(pdf).toContain("(P3of3)");
+    expect(pdf).toContain("/Count 3");
+  });
+
+  it("lets the closure branch on the page number", async () => {
+    const doc = Document([
+      Page(
+        {
+          header: PageBuilder(({ pageNumber }) =>
+            pageNumber === 1 ? Text("FIRST") : Text("CONT"),
+          ),
+        },
+        [Column(filler())],
+      ),
+    ]);
+    const pdf = await drawn(doc);
+    expect(pdf).toContain("(FIRST)");
+    expect(pdf).toContain("(CONT)");
+  });
+
+  it("works in the body, not just header/footer", async () => {
+    const doc = Document([Page([Column([Text("x"), PageNumber(), PageCount()])])]);
+    const pdf = await drawn(doc);
+    expect(pdf).toContain("(1)"); // single page: number and count are both 1
+  });
+
+  it("applies `offset` (a cover page that does not count)", async () => {
+    const doc = Document([Page([Column([PageNumber({ offset: -1 }), PageCount({ offset: 10 })])])]);
+    const pdf = await drawn(doc);
+    expect(pdf).toContain("(0)"); // 1 + (-1)
+    expect(pdf).toContain("(11)"); // 1 + 10
+  });
+
+  it("hands the closure the page size in points (A4 portrait)", async () => {
+    const doc = Document([
+      Page({ size: "A4" }, [
+        Column([PageBuilder(({ pageSize }) => Text(`${pageSize.width}x${pageSize.height}`))]),
+      ]),
+    ]);
+    const pdf = await drawn(doc);
+    expect(pdf).toContain("(595.28x841.89)");
+  });
+
+  it("counts physical pages across several logical Pages", async () => {
+    const doc = Document([
+      Page({ footer: PageNumber() }, [Column([Text("a")])]),
+      Page({ footer: PageCount() }, [Column([Text("b")])]),
+    ]);
+    const pdf = await drawn(doc);
+    expect(pdf).toContain("(1)"); // first page's number
+    expect(pdf).toContain("(2)"); // second page shows the total, which is 2
+  });
+
+  it("adds nothing when no PageBuilder is used (unchanged output path)", async () => {
+    const pdf = await drawn(Document([Page([Text("plain")])]));
+    expect(pdf).toContain("/Count 1");
+  });
+});

--- a/tests/unit/api/page-builder.test.ts
+++ b/tests/unit/api/page-builder.test.ts
@@ -86,6 +86,22 @@ describe("PageBuilder / PageNumber / PageCount", () => {
     expect(pdf).toContain("(2)"); // second page shows the total, which is 2
   });
 
+  it("sees THIS page's geometry while it is being measured, not the document default", async () => {
+    // The page is A5 (419.53 wide); the document default is A4 (595.28). Every build - including the
+    // provisional one during pagination - must be handed the page's own size, never the document's.
+    const seen = new Set<number>();
+    const probe = () =>
+      PageBuilder(({ pageSize }) => {
+        seen.add(Math.round(pageSize.width));
+        return Text("probe");
+      });
+    const doc = Document([
+      Page({ size: "A5" }, [Column([probe(), ...filler()])]), // long enough to fragment
+    ]);
+    await drawn(doc);
+    expect([...seen]).toEqual([420]); // A5 portrait, never 595 (A4)
+  });
+
   it("adds nothing when no PageBuilder is used (unchanged output path)", async () => {
     const pdf = await drawn(Document([Page([Text("plain")])]));
     expect(pdf).toContain("/Count 1");

--- a/tests/unit/renderer/pdf-document-renderer.test.ts
+++ b/tests/unit/renderer/pdf-document-renderer.test.ts
@@ -10,8 +10,13 @@ vi.spyOn(PageRenderer, "render").mockImplementation(async () => 1);
 
 const ctx = {} as LayoutContext; // not used on the unchanged (non-fragmenting) path
 
-// A page that takes the unchanged path: not the single-fragmentable-child shape.
-const plainPage = () => ({ getProps: () => ({ children: [], config: {} }) });
+// A page that takes the unchanged path: not the single-fragmentable-child shape. The render pass lays
+// every physical page out again (that is what gives a PageBuilder its final page number), so the fake
+// needs calculateLayout too.
+const plainPage = () => ({
+  getProps: () => ({ children: [], config: {} }),
+  calculateLayout: vi.fn(),
+});
 
 describe("PDFDocumentRenderer", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Now we have page-number and page-count elements. They can placed everywhere, not only in header/footer.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added page-aware building blocks that provide the current page number, total page count, and page size to your PDF content.
  * Introduced `PageBuilder`, plus `PageNumber` and `PageCount` helpers (with `offset` support), for composing dynamic headers/footers.
* **Bug Fixes**
  * Improved pagination/rendering for long documents so totals and repeated header/footer content stay correct across multiple physical pages.
* **Tests**
  * Added and updated unit tests covering numbering, totals, offsets, page-size awareness, and multi-page rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->