### PR TITLE
fix: infinity bug combined using spacer

### DIFF
--- a/src/lib/elements/container-element.ts
+++ b/src/lib/elements/container-element.ts
@@ -2,6 +2,7 @@ import { FlexLayoutHelper, VERTICAL_AXIS, MainAlign, CrossAlign } from "../utils
 import { BoxConstraints, Offset, Size, resolveExtent } from "../layout/box-constraints.ts";
 import { Fragmentable, FragmentResult, packChildren } from "../layout/fragmentation.ts";
 import {
+  FlexiblePDFElement,
   LayoutContext,
   PDFElement,
   SizedElement,
@@ -96,6 +97,16 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
 
   override relativeSizeFactor(horizontal: boolean): number | undefined {
     return horizontal ? this.requested.widthFactor : this.requested.heightFactor;
+  }
+
+  /** A Column stacks vertically, so it only needs a bounded HEIGHT, and only to hand leftover space to a
+   *  flex child. With an explicit height it already knows its extent; with no flex child there is nothing
+   *  to distribute and it keeps shrink-wrapping (which is what leaves old layouts untouched). */
+  override needsBoundedMain(horizontal: boolean): boolean {
+    if (horizontal) return false;
+    if (this.requested.height !== undefined || this.requested.heightFactor !== undefined)
+      return false;
+    return this.children.some((c) => c instanceof FlexiblePDFElement);
   }
 
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {

--- a/src/lib/elements/container-element.ts
+++ b/src/lib/elements/container-element.ts
@@ -99,14 +99,23 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
     return horizontal ? this.requested.widthFactor : this.requested.heightFactor;
   }
 
-  /** A Column stacks vertically, so it only needs a bounded HEIGHT, and only to hand leftover space to a
-   *  flex child. With an explicit height it already knows its extent; with no flex child there is nothing
-   *  to distribute and it keeps shrink-wrapping (which is what leaves old layouts untouched). */
+  /**
+   * A Column stacks vertically, so a flex child of its OWN only ever needs a bounded height. But the need
+   * also propagates: a `Spacer` two levels down is just as unable to resolve against an infinite axis, so
+   * we ask the children too - on both axes, since a nested Row's `Spacer` needs a bounded WIDTH and a
+   * Column nested in a Row is exactly where that width goes missing.
+   *
+   * An explicit extent on an axis short-circuits it: the element already knows how big it is there, and
+   * with no flex descendant nothing needs distributing, so it keeps shrink-wrapping. That is what leaves
+   * every existing layout untouched.
+   */
   override needsBoundedMain(horizontal: boolean): boolean {
-    if (horizontal) return false;
-    if (this.requested.height !== undefined || this.requested.heightFactor !== undefined)
-      return false;
-    return this.children.some((c) => c instanceof FlexiblePDFElement);
+    const requested = horizontal
+      ? [this.requested.width, this.requested.widthFactor]
+      : [this.requested.height, this.requested.heightFactor];
+    if (requested.some((v) => v !== undefined)) return false;
+    const ownFlexChild = !horizontal && this.children.some((c) => c instanceof FlexiblePDFElement);
+    return ownFlexChild || this.children.some((c) => c.needsBoundedMain(horizontal));
   }
 
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {

--- a/src/lib/elements/pdf-element.ts
+++ b/src/lib/elements/pdf-element.ts
@@ -87,6 +87,17 @@ export abstract class PDFElement {
   relativeSizeFactor(_horizontal: boolean): number | undefined {
     return undefined;
   }
+
+  /**
+   * Whether this element needs a BOUNDED extent on the given axis to lay itself out (`true` for a
+   * horizontal axis = width). A flex parent measures its fixed children with an unbounded main axis, so
+   * they keep their natural size; but a stack holding an `Expanded`/`Spacer` has no leftover space to
+   * distribute unless it is told how much main axis it may occupy. Such a stack answers `true` here and
+   * the parent hands it the line's bounded main extent instead of `Infinity`. Default: no.
+   */
+  needsBoundedMain(_horizontal: boolean): boolean {
+    return false;
+  }
 }
 
 export abstract class SizedPDFElement extends PDFElement {

--- a/src/lib/elements/rectangle-element.ts
+++ b/src/lib/elements/rectangle-element.ts
@@ -195,17 +195,26 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
       : undefined;
     const childCtx: LayoutContext = frame ? { ...ctx, frame } : ctx;
 
-    // Lay out children stacked inside the border (inset by the border width). Width is
-    // finalized here; height is left unbounded so each child sizes to its own content.
+    // Lay out children stacked inside the border (inset by the border width). Width is finalized here;
+    // height is left unbounded so each child sizes to its own content - EXCEPT for a child that cannot
+    // lay itself out without a bound (a stack holding an `Expanded`/`Spacer`). That one gets the height
+    // still free inside the box, so its flex child has real leftover space instead of an infinite one.
     const innerWidth = shrinkWrapWidth
       ? Infinity
       : Math.max(0, (this.width ?? 0) - 2 * this.borderWidth);
+    const innerHeight = shrinkWrapHeight
+      ? Infinity
+      : Math.max(0, (this.height ?? 0) - 2 * this.borderWidth);
     let contentWidth = 0;
     let contentHeight = 0;
     let yCursor = this.y + this.borderWidth;
     for (const child of this.children) {
+      const consumed = yCursor - (this.y + this.borderWidth);
+      const childHeight = child.needsBoundedMain(false)
+        ? Math.max(0, innerHeight - consumed) // Infinity - consumed stays Infinity, as it should
+        : Infinity;
       const childSize = child.calculateLayout(
-        BoxConstraints.loose(innerWidth, Infinity),
+        BoxConstraints.loose(innerWidth, childHeight),
         { x: this.x + this.borderWidth, y: yCursor },
         childCtx,
       );

--- a/src/lib/elements/rectangle-element.ts
+++ b/src/lib/elements/rectangle-element.ts
@@ -147,6 +147,17 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
     return horizontal ? this.sizeMemory.widthFactor : this.sizeMemory.heightFactor;
   }
 
+  /** A box has no flex children of its own, but it must not swallow the need of the stack inside it: a
+   *  `Spacer` in a box can only resolve if the box itself was given a bounded extent to pass down. With an
+   *  explicit size on an axis the box already knows its extent there and asks for nothing. */
+  override needsBoundedMain(horizontal: boolean): boolean {
+    const requested = horizontal
+      ? [this.sizeMemory.width, this.sizeMemory.widthFactor]
+      : [this.sizeMemory.height, this.sizeMemory.heightFactor];
+    if (requested.some((v) => v !== undefined)) return false;
+    return this.children.some((c) => c.needsBoundedMain(horizontal));
+  }
+
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
     // An explicit extent is a fixed point size or a fraction of the offered box (relative sizing);
     // the fraction only resolves in a bounded region. `undefined` = fill / shrink-wrap below.
@@ -210,7 +221,11 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
     let yCursor = this.y + this.borderWidth;
     for (const child of this.children) {
       const consumed = yCursor - (this.y + this.borderWidth);
-      const childHeight = child.needsBoundedMain(false)
+      // Same rule the flex helper applies: a child gets a finite main extent when it cannot lay itself
+      // out without one - a stack holding an `Expanded`/`Spacer`, or a child sized as a percentage of us.
+      const needsBound =
+        child.needsBoundedMain(false) || child.relativeSizeFactor(false) !== undefined;
+      const childHeight = needsBound
         ? Math.max(0, innerHeight - consumed) // Infinity - consumed stays Infinity, as it should
         : Infinity;
       const childSize = child.calculateLayout(

--- a/src/lib/elements/row-element.ts
+++ b/src/lib/elements/row-element.ts
@@ -1,6 +1,12 @@
 import { BoxConstraints, Offset, Size, resolveExtent } from "../layout/box-constraints.ts";
 import { FlexLayoutHelper, HORIZONTAL_AXIS, MainAlign, CrossAlign } from "../utils/flex-layout.ts";
-import { LayoutContext, PDFElement, SizedPDFElement, WithChildren } from "./pdf-element.ts";
+import {
+  FlexiblePDFElement,
+  LayoutContext,
+  PDFElement,
+  SizedPDFElement,
+  WithChildren,
+} from "./pdf-element.ts";
 
 interface RowElementParams extends WithChildren {
   /** Space inserted between children, in points. */
@@ -61,6 +67,15 @@ export class RowElement extends SizedPDFElement {
 
   override relativeSizeFactor(horizontal: boolean): number | undefined {
     return horizontal ? this.requested.widthFactor : this.requested.heightFactor;
+  }
+
+  /** A Row stacks horizontally, so the mirror of `ContainerElement`: it only needs a bounded WIDTH, and
+   *  only when a flex child is waiting for leftover space. */
+  override needsBoundedMain(horizontal: boolean): boolean {
+    if (!horizontal) return false;
+    if (this.requested.width !== undefined || this.requested.widthFactor !== undefined)
+      return false;
+    return this.children.some((c) => c instanceof FlexiblePDFElement);
   }
 
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {

--- a/src/lib/elements/row-element.ts
+++ b/src/lib/elements/row-element.ts
@@ -69,13 +69,15 @@ export class RowElement extends SizedPDFElement {
     return horizontal ? this.requested.widthFactor : this.requested.heightFactor;
   }
 
-  /** A Row stacks horizontally, so the mirror of `ContainerElement`: it only needs a bounded WIDTH, and
-   *  only when a flex child is waiting for leftover space. */
+  /** The mirror of `ContainerElement`: a Row's OWN flex child needs a bounded width, and the need of any
+   *  descendant propagates on both axes (see the Column for the reasoning). */
   override needsBoundedMain(horizontal: boolean): boolean {
-    if (!horizontal) return false;
-    if (this.requested.width !== undefined || this.requested.widthFactor !== undefined)
-      return false;
-    return this.children.some((c) => c instanceof FlexiblePDFElement);
+    const requested = horizontal
+      ? [this.requested.width, this.requested.widthFactor]
+      : [this.requested.height, this.requested.heightFactor];
+    if (requested.some((v) => v !== undefined)) return false;
+    const ownFlexChild = horizontal && this.children.some((c) => c instanceof FlexiblePDFElement);
+    return ownFlexChild || this.children.some((c) => c.needsBoundedMain(horizontal));
   }
 
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {

--- a/src/lib/renderer/pdf-backend.ts
+++ b/src/lib/renderer/pdf-backend.ts
@@ -107,9 +107,35 @@ export class PdfBackend {
    *  `PageStructContext` is given (accessible tagging on), each drawable node is wrapped in a marked-content
    *  sequence (`/Role <</MCID n>> BDC … EMC`, or `/Artifact` when untagged); graphics-state and empty nodes
    *  pass through untouched, so untagged output stays byte-identical. */
+  /**
+   * Every number reaching the backend must be finite. A non-finite coordinate is a layout bug, but
+   * silence turns it into a corrupt PDF: `Infinity` is written into the operator stream verbatim, and a
+   * viewer then discards everything from that point on - including the footer, which is drawn last. That
+   * failure is invisible until somebody opens the file, so we refuse instead.
+   *
+   * Checks the node's numbers, not the serialized text: a document containing the WORD "Infinity" is
+   * perfectly legal and must not trip this.
+   */
+  private static assertFinite(node: IRNode): void {
+    const finite = (value: unknown): boolean => {
+      if (typeof value === "number") return Number.isFinite(value);
+      if (Array.isArray(value)) return value.every(finite);
+      if (value !== null && typeof value === "object") return Object.values(value).every(finite);
+      return true;
+    };
+    if (!finite(node)) {
+      throw new Error(
+        `Layout produced a non-finite number on a "${node.type}" node, refusing to emit a corrupt ` +
+          `content stream. This is a bug in an element's calculateLayout (a size resolved to Infinity ` +
+          `or NaN), not in your document.`,
+      );
+    }
+  }
+
   static serialize(nodes: IRNode[], om: PDFObjectManager, struct?: PageStructContext): string {
     return nodes
       .map((node) => {
+        PdfBackend.assertFinite(node);
         const ops = PdfBackend.serializeNode(node, om);
         // Two kinds of node skip the marked-content wrapper, both because they carry no tag and never
         // draw: GRAPHICS-STATE nodes (clip / transform push+pop) only save/restore state around the

--- a/src/lib/utils/flex-layout.ts
+++ b/src/lib/utils/flex-layout.ts
@@ -102,12 +102,16 @@ export class FlexLayoutHelper {
     // gaps (the flexbox `width: 33%` + gap trap). Only finite when the line's main axis is bounded -
     // a fraction of an unbounded main axis has no meaning, so `%` children fall back to shrink-wrap.
     const percentBase = mainAvail !== Infinity ? Math.max(0, mainAvail - totalGap) : Infinity;
-    // The main cap to hand a child: `percentBase` for a percentage child (so its fraction resolves),
-    // unbounded for everyone else (they keep their natural / fixed size and never fill the line).
-    const mainCapFor = (child: PDFElement): number =>
-      percentBase !== Infinity && child.relativeSizeFactor(axis.mainHorizontal) !== undefined
-        ? percentBase
-        : Infinity;
+    // The main cap to hand a child: `percentBase` for a percentage child (so its fraction resolves) and
+    // for a child that cannot lay itself out without a bound (a nested stack holding an `Expanded`/
+    // `Spacer`); unbounded for everyone else, who keep their natural size and never fill the line.
+    const mainCapFor = (child: PDFElement): number => {
+      if (percentBase === Infinity) return Infinity;
+      const needsBound =
+        child.relativeSizeFactor(axis.mainHorizontal) !== undefined ||
+        child.needsBoundedMain(axis.mainHorizontal);
+      return needsBound ? percentBase : Infinity;
+    };
 
     // Pass 1: measure the fixed children (main extent + cross size) and total the flex.
     let fixedMain = 0;
@@ -130,7 +134,10 @@ export class FlexLayoutHelper {
     }
 
     const leftover = mainAvail - fixedMain - totalGap;
-    const remaining = Math.max(leftover, 0); // for flex children
+    // A flex child on an UNBOUNDED main axis has no leftover space to claim. It must collapse to zero,
+    // never to `Infinity`: an infinite extent would become the offset of every following sibling and get
+    // written into the content stream verbatim, silently corrupting the page from that point on.
+    const remaining = Number.isFinite(leftover) ? Math.max(leftover, 0) : 0;
 
     // Main-axis distribution only kicks in with no flex child and bounded, positive space.
     let leadingSpace = 0;

--- a/tests/unit/layout/spacer-bounds.test.ts
+++ b/tests/unit/layout/spacer-bounds.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { Document, Page, Column, Row, Box, Text, Spacer, renderPdf } from "../../../src/lib/api";
+import { PdfBackend } from "../../../src/lib/renderer/pdf-backend";
+import { IRNode } from "../../../src/lib/ir/display-list";
+
+// The y a `Td` operator places the given text at (uncompressed content stream, PDF bottom-left origin).
+const yOf = (pdf: string, text: string): number => {
+  const m = new RegExp(`([-\\d.]+|-?Infinity|NaN) Td \\(${text}\\)`).exec(pdf);
+  if (!m) throw new Error(`"${text}" was not drawn at all`);
+  return Number(m[1]);
+};
+
+const render = (doc: Parameters<typeof renderPdf>[0]) => renderPdf(doc, { compress: false });
+
+describe("Spacer / Expanded on an unbounded main axis (issue #10)", () => {
+  it("pushes a sibling to the bottom when the Spacer sits directly in the Page", async () => {
+    const pdf = await render(
+      Document([Page({ size: "A4", margin: 56 }, [Text("top"), Spacer(), Text("tail")])]),
+    );
+    expect(yOf(pdf, "tail")).toBeLessThan(70); // near the bottom margin, not under "top"
+  });
+
+  it("does the same from inside a nested Column (this used to emit -Infinity)", async () => {
+    const pdf = await render(
+      Document([Page({ size: "A4", margin: 56 }, [Column([Text("top"), Spacer(), Text("tail")])])]),
+    );
+    expect(pdf).not.toContain("Infinity");
+    expect(yOf(pdf, "tail")).toBeLessThan(70);
+  });
+
+  it("does the same from inside a Box with a resolved height", async () => {
+    const pdf = await render(
+      Document([
+        Page({ size: "A4", margin: 56 }, [
+          Box({ height: "100%" }, [Column([Text("top"), Spacer(), Text("tail")])]),
+        ]),
+      ]),
+    );
+    expect(yOf(pdf, "tail")).toBeLessThan(70);
+  });
+
+  it("collapses the Spacer to zero where no bound exists anywhere, and still draws the sibling", async () => {
+    // A shrink-wrapping Box in an unbounded region: nothing can tell the Spacer how much to take.
+    // It must take nothing - and above all it must not swallow what comes after it.
+    const pdf = await render(
+      Document([
+        Page([Column([Box({}, [Column([Text("top"), Spacer(), Text("tail")])]), Text("after")])]),
+      ]),
+    );
+    expect(pdf).not.toContain("Infinity");
+    expect(() => yOf(pdf, "tail")).not.toThrow();
+    expect(() => yOf(pdf, "after")).not.toThrow();
+    expect(yOf(pdf, "tail")).toBeLessThan(yOf(pdf, "top")); // stacked right below, no gap
+  });
+
+  it("keeps a Spacer in a Row working (horizontal main axis)", async () => {
+    const pdf = await render(
+      Document([Page({ size: "A4", margin: 56 }, [Row([Text("L"), Spacer(), Text("R")])])]),
+    );
+    expect(pdf).not.toContain("Infinity");
+    const x = /([\d.]+) [\d.]+ Td \(R\)/.exec(pdf);
+    expect(Number(x![1])).toBeGreaterThan(400); // pushed to the right edge
+  });
+
+  it("a Column without a flex child still shrink-wraps (old layouts untouched)", async () => {
+    const pdf = await render(
+      Document([Page({ size: "A4", margin: 56 }, [Column([Text("top"), Text("tail")])])]),
+    );
+    expect(yOf(pdf, "top") - yOf(pdf, "tail")).toBeLessThan(20); // stacked, not spread apart
+  });
+});
+
+describe("the backend refuses non-finite geometry", () => {
+  it("throws instead of writing Infinity into the content stream", () => {
+    const bad = [{ type: "rect", x: 10, y: Infinity, width: 5, height: 5 }] as unknown as IRNode[];
+    expect(() => PdfBackend.serialize(bad, {} as never)).toThrow(/non-finite/);
+  });
+
+  it("does not trip on a document that merely contains the word Infinity", async () => {
+    const pdf = await render(Document([Page([Text("Infinity and NaN are fine words")])]));
+    expect(pdf).toContain("(Infinity and NaN are fine words)");
+  });
+});

--- a/tests/unit/layout/spacer-bounds.test.ts
+++ b/tests/unit/layout/spacer-bounds.test.ts
@@ -62,6 +62,51 @@ describe("Spacer / Expanded on an unbounded main axis (issue #10)", () => {
     expect(Number(x![1])).toBeGreaterThan(400); // pushed to the right edge
   });
 
+  // The need for a bounded axis propagates: a Spacer two levels down cannot resolve against Infinity
+  // either, so every stack in between has to ask its own parent for a bound.
+  it("reaches a Spacer nested one Column deeper", async () => {
+    const pdf = await render(
+      Document([
+        Page({ size: "A4", margin: 56 }, [Column([Column([Text("top"), Spacer(), Text("tail")])])]),
+      ]),
+    );
+    expect(yOf(pdf, "tail")).toBeLessThan(70);
+  });
+
+  it("reaches a Spacer through a Box that has no size of its own", async () => {
+    const pdf = await render(
+      Document([
+        Page({ size: "A4", margin: 56 }, [
+          Column([Box({}, [Column([Text("top"), Spacer(), Text("tail")])])]),
+        ]),
+      ]),
+    );
+    expect(yOf(pdf, "tail")).toBeLessThan(70);
+  });
+
+  it("carries a horizontal need through a Column (a Column in a Row has no bounded width)", async () => {
+    const pdf = await render(
+      Document([
+        Page({ size: "A4", margin: 56 }, [Row([Column([Row([Text("L"), Spacer(), Text("R")])])])]),
+      ]),
+    );
+    const m = /([\d.]+) [\d.]+ Td \(R\)/.exec(pdf);
+    expect(Number(m![1])).toBeGreaterThan(400);
+  });
+
+  it("resolves a percentage height inside a sized Box", async () => {
+    const pdf = await render(
+      Document([
+        Page({ size: "A4", margin: 56 }, [
+          Box({ height: 300, bg: "#dddddd" }, [Box({ height: "50%", bg: "#ff0000" }, [Text("x")])]),
+        ]),
+      ]),
+    );
+    const heights = [...pdf.matchAll(/[\d.]+ [\d.]+ [\d.]+ ([\d.]+) re/g)].map((m) => Number(m[1]));
+    expect(heights).toContain(300); // the outer box
+    expect(heights).toContain(150); // 50% of it, not a shrink-wrapped 12pt line
+  });
+
   it("a Column without a flex child still shrink-wraps (old layouts untouched)", async () => {
     const pdf = await render(
       Document([Page({ size: "A4", margin: 56 }, [Column([Text("top"), Text("tail")])])]),


### PR DESCRIPTION
## Summary

Bad bug... spacer becomes `infinity` height "sometimes". this breaks the pages! Empty pages after spacer e.g. Now it is fixed.

## Related issue(s)

Closes #10 

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [ ] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved layout sizing and spacing across rows, containers, and rectangles, especially in nested and unbounded scenarios, so children better respect available space.
  - Fixed Spacer behavior on unbounded main axes to prevent incorrect offsets and ensure consistent collapsing/pushing logic.
  - PDF generation now fails fast when non-finite numeric geometry is detected, avoiding corrupt output streams.
- **Tests**
  - Added focused unit coverage for Spacer bounds and non-finite PDF backend handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->