### PR TITLE
feat: implement new elements to vue

### DIFF
--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -20,8 +20,18 @@ const textStyleProps = {
   italic: { type: Boolean, default: undefined },
   color: colorProp,
 };
+// A link target. Shared by `<Text>`/`<Paragraph>` (links the whole run) and `<Span>` (links just that
+// run). NOT part of `textStyleProps`: `<Document>` and `<DefaultTextStyle>` set defaults, they cannot link.
+// Exactly one of the two, mirroring the `Link` factory.
+const linkTargetProps = {
+  /** An external URL. */
+  href: String,
+  /** The `name` of an `<Anchor>` elsewhere in the document. */
+  to: String,
+};
 const textProps = {
   ...textStyleProps,
+  ...linkTargetProps,
   align: String as PropType<"left" | "center" | "right">,
   lineHeight: Number,
   maxLines: Number,
@@ -188,7 +198,7 @@ export const Paragraph = defineComponent({
 export const Span = defineComponent({
   name: "JasySpan",
   inheritAttrs: false,
-  props: textStyleProps,
+  props: { ...textStyleProps, ...linkTargetProps },
   setup: fwd("span"),
 });
 // `<Table :columns>` holds `<TableRow>`s (mark one `header` to repeat it per page) of `<TableCell>`s.
@@ -222,4 +232,64 @@ export const DefaultTextStyle = defineComponent({
   inheritAttrs: false,
   props: defaultTextStyleProps,
   setup: fwd("default-text-style"),
+});
+
+// --- Navigation -------------------------------------------------------------------------------------
+// Makes its child clickable. `href` opens a URL, `to` jumps to an `<Anchor>` in the same document.
+// For a link on part of a line put `href`/`to` on a `<Span>` instead.
+export const Link = defineComponent({
+  name: "JasyLink",
+  inheritAttrs: false,
+  props: linkTargetProps,
+  setup: fwd("link"),
+});
+// A named jump target for `<Link to="...">`. Layout-transparent: the child renders as it would alone.
+export const Anchor = defineComponent({
+  name: "JasyAnchor",
+  inheritAttrs: false,
+  props: { name: { type: String, required: true } },
+  setup: fwd("anchor"),
+});
+// An entry in the viewer's outline sidebar. `level` nests it under the nearest preceding smaller level.
+export const Bookmark = defineComponent({
+  name: "JasyBookmark",
+  inheritAttrs: false,
+  props: { title: { type: String, required: true }, level: Number },
+  setup: fwd("bookmark"),
+});
+
+// --- Transforms -------------------------------------------------------------------------------------
+// Spins its child at any angle around its center, at PAINT time: the layout box stays unrotated, so
+// siblings do not reflow. For a stamp or a watermark.
+export const Rotated = defineComponent({
+  name: "JasyRotated",
+  inheritAttrs: false,
+  props: { angle: { type: Number, required: true } },
+  setup: fwd("rotated"),
+});
+// Layout-aware quarter-turns: a 90/270 turn swaps width and height, so siblings reflow around a vertical
+// label. `turns` counts clockwise 90-degree steps.
+export const RotatedBox = defineComponent({
+  name: "JasyRotatedBox",
+  inheritAttrs: false,
+  props: { turns: { type: Number, required: true } },
+  setup: fwd("rotated-box"),
+});
+
+// --- Page numbers -----------------------------------------------------------------------------------
+// The current page / the document total, as text. Usable anywhere, not just in a `#footer`. `offset` is
+// added to the number - use `-1` when a cover page should not count.
+// (`PageBuilder` from the core is not exposed: it takes a closure, which a template cannot express.)
+const pageNumberProps = { ...textStyleProps, align: String, lineHeight: Number, offset: Number };
+export const PageNumber = defineComponent({
+  name: "JasyPageNumber",
+  inheritAttrs: false,
+  props: pageNumberProps,
+  setup: fwd("page-number"),
+});
+export const PageCount = defineComponent({
+  name: "JasyPageCount",
+  inheritAttrs: false,
+  props: pageNumberProps,
+  setup: fwd("page-count"),
 });

--- a/packages/vue/tests/navigation.test.ts
+++ b/packages/vue/tests/navigation.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { h, type Component } from "vue";
+import {
+  Document,
+  Page,
+  Column,
+  Text,
+  Paragraph,
+  Span,
+  Box,
+  Link,
+  Anchor,
+  Bookmark,
+  Rotated,
+  RotatedBox,
+  PageNumber,
+  PageCount,
+  renderToPdfString,
+} from "../src/index.ts";
+
+const comp = (render: () => any): Component => ({ render });
+const count = (s: string, needle: string) => s.split(needle).length - 1;
+
+// `compress: false` keeps the content stream greppable so we can assert on what was actually drawn.
+const render = (c: Component) => renderToPdfString(c, undefined, { compress: false });
+
+describe("navigation, transforms and page numbers as Vue components", () => {
+  it("turns <Link href> into an external /Link annotation", async () => {
+    const pdf = await render(
+      comp(() =>
+        h(Document, null, () =>
+          h(Page, null, () =>
+            h(Link, { href: "https://jasy.dev" }, () => h(Text, null, () => "go")),
+          ),
+        ),
+      ),
+    );
+    expect(pdf).toContain("/Subtype /Link");
+    expect(pdf).toContain("/A << /S /URI /URI (https://jasy.dev) >>");
+  });
+
+  it("wires <Link to> to <Anchor name> through a named destination", async () => {
+    const pdf = await render(
+      comp(() =>
+        h(Document, null, () => [
+          h(Page, null, () => h(Link, { to: "sec" }, () => h(Text, null, () => "jump"))),
+          h(Page, null, () => h(Anchor, { name: "sec" }, () => h(Text, null, () => "Section"))),
+        ]),
+      ),
+    );
+    expect(pdf).toContain("/S /GoTo /D (sec)");
+    expect(pdf).toContain("/Dests << /Names [ (sec) [");
+  });
+
+  it("puts a link on a single <Span> without linking the rest of the line", async () => {
+    const pdf = await render(
+      comp(() =>
+        h(Document, null, () =>
+          h(Page, null, () =>
+            h(Paragraph, null, () => [
+              h(Span, null, () => "visit "),
+              h(Span, { href: "https://jasy.dev" }, () => "jasy.dev"),
+              h(Span, null, () => " now"),
+            ]),
+          ),
+        ),
+      ),
+    );
+    expect(count(pdf, "/Subtype /Link")).toBe(1);
+    expect(pdf).toContain("/URI (https://jasy.dev)");
+  });
+
+  it("builds a nested outline from <Bookmark>", async () => {
+    const pdf = await render(
+      comp(() =>
+        h(Document, null, () =>
+          h(Page, null, () =>
+            h(Column, null, () => [
+              h(Bookmark, { title: "Chapter", level: 1 }, () => h(Text, null, () => "Chapter")),
+              h(Bookmark, { title: "Section", level: 2 }, () => h(Text, null, () => "Section")),
+            ]),
+          ),
+        ),
+      ),
+    );
+    expect(pdf).toContain("/Type /Outlines");
+    expect(pdf).toContain("/Title (Chapter)");
+    expect(pdf).toContain("/Title (Section)");
+  });
+
+  it("rotates with <Rotated> and <RotatedBox>", async () => {
+    const pdf = await render(
+      comp(() =>
+        h(Document, null, () =>
+          h(Page, null, () =>
+            h(Column, null, () => [
+              h(Rotated, { angle: 20 }, () =>
+                h(Box, { bg: "#eeeeee" }, () => h(Text, null, () => "stamp")),
+              ),
+              h(RotatedBox, { turns: 3 }, () => h(Text, null, () => "label")),
+            ]),
+          ),
+        ),
+      ),
+    );
+    expect(count(pdf, " cm")).toBeGreaterThanOrEqual(2); // one transform matrix per rotation
+    expect(pdf).toContain("(stamp)");
+    expect(pdf).toContain("(label)");
+  });
+
+  it("prints the running page number and the document total", async () => {
+    const filler = () =>
+      Array.from({ length: 14 }, () => h(Paragraph, null, () => "x ".repeat(300)));
+    const pdf = await render(
+      comp(() =>
+        h(Document, null, () =>
+          h(Page, null, {
+            footer: () => [h(Text, null, () => "p"), h(PageNumber, null), h(PageCount, null)],
+            default: () => h(Column, null, filler),
+          }),
+        ),
+      ),
+    );
+    expect(pdf).toContain("/Count 2"); // the body flowed onto a second physical page
+    // Page 1 prints "1" then the total "2"; page 2 prints "2" twice. So both digits must be drawn.
+    const digits = [...pdf.matchAll(/\((\d+)\) Tj/g)].map((m) => m[1]);
+    expect(digits).toEqual(["1", "2", "2", "2"]);
+  });
+
+  it("applies `offset` so a cover page does not count", async () => {
+    const pdf = await render(
+      comp(() => h(Document, null, () => h(Page, null, () => h(PageNumber, { offset: -1 })))),
+    );
+    expect(pdf).toContain("(0)"); // 1 + (-1)
+  });
+});

--- a/src/lib/api/descriptor.ts
+++ b/src/lib/api/descriptor.ts
@@ -3,9 +3,23 @@ import { PDFDocumentElement } from "../elements/pdf-document-element.ts";
 import { PageElement } from "../elements/page-element.ts";
 import { TextSegment } from "../elements/text-element.ts";
 import { Text, Paragraph, span } from "./text.ts";
-import { Column, Row, Box, Padding, Spacer, Expanded, Positioned } from "./layout.ts";
+import {
+  Column,
+  Row,
+  Box,
+  Padding,
+  Spacer,
+  Expanded,
+  Positioned,
+  Link,
+  Anchor,
+  Bookmark,
+  Rotated,
+  RotatedBox,
+} from "./layout.ts";
 import { Divider, Image } from "./content.ts";
 import { Page, Document, DefaultTextStyle } from "./structure.ts";
+import { PageNumber, PageCount } from "./page-builder.ts";
 import { Table, Cell } from "./table.ts";
 
 /**
@@ -70,6 +84,14 @@ function slotElement(node: Descriptor): PDFElement {
   return els.length === 1 ? els[0] : Column(els);
 }
 
+// The single child a wrapper takes (`Link`, `Anchor`, `Bookmark`, `Rotated`, ...). Several children are
+// stacked in a Column, so `<JasyLink><Text/><Text/></JasyLink>` behaves like the factory would.
+function wrappedChild(children: DescriptorChild[]): PDFElement {
+  const els = children.map((c) => (typeof c === "string" ? Text(c) : build(c)));
+  if (els.length === 0) throw new Error("A wrapper element needs exactly one child");
+  return els.length === 1 ? els[0] : Column(els);
+}
+
 const REGISTRY: Record<string, ElementFactory> = {
   document: (props, children) => {
     const doc = Document(props, elementChildren(children) as PageElement[]);
@@ -115,6 +137,21 @@ const REGISTRY: Record<string, ElementFactory> = {
   },
   positioned: (props, children) => Positioned(props, elementChildren(children)[0]),
   "default-text-style": (props, children) => DefaultTextStyle(props, elementChildren(children)),
+
+  // Navigation. `Link` takes exactly one of `href` (a URL) or `to` (an `Anchor` name) - the factory
+  // enforces that, so a template typo surfaces as an error instead of a dead link.
+  link: (props, children) => Link(props, wrappedChild(children)),
+  anchor: (props, children) => Anchor(props, wrappedChild(children)),
+  bookmark: (props, children) => Bookmark(props, wrappedChild(children)),
+
+  // Transforms.
+  rotated: (props, children) => Rotated(props, wrappedChild(children)),
+  "rotated-box": (props, children) => RotatedBox(props, wrappedChild(children)),
+
+  // Page numbers. `PageBuilder` itself is deliberately NOT exposed: it takes a closure, which a template
+  // cannot express. These two cover what the closure exists for.
+  "page-number": (props) => PageNumber(props),
+  "page-count": (props) => PageCount(props),
 };
 
 /**


### PR DESCRIPTION
## Summary

Implement new rotation, bookmark, anchor elements to VUE - speed optimization and bug fixes

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for links, anchors, bookmarks, rotated content, and page numbers in Vue PDF components.
  * Link targets can now be applied to text, paragraphs, and inline spans.
  * Added page numbering and total page count components, including offset support for excluding cover pages.
* **Bug Fixes**
  * Improved handling of wrapper content so nested content renders more reliably, including single or multiple child elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->