### PR TITLE
fix: vertical text position in its line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,38 @@ WinAnsiEncoding (`utils/utf8-to-windows1252-encoder.ts`). **Custom TrueType font
 paths branch on the font name (`isCustomFont`), leaving the AFM/WinAnsi path byte-identical. `TTFParser`
 also parses `glyf`/`loca` outlines + COLR/CPAL color tables for color emoji (see the ✅ Color emoji entry).
 
+#### Font VERTICAL metrics — read this before touching a baseline
+
+Two different kinds of number live in a font, and mixing them up cost us ISSUE-5. **Read the right one.**
+
+- A **glyph metric** says how tall one letter is: AFM `Ascender 718` is the height of `b`/`d`/`h`;
+  `CapHeight 718`, `XHeight 523`. Useful for drawing (an underline, a strikethrough), useless for stacking
+  lines.
+- A **line metric** says how far a line must reach from its baseline so nothing collides: TrueType's
+  `hhea.ascent` / `hhea.descent` / `hhea.lineGap`. It is much taller than the letters, because it has to
+  clear an accented capital — Arial declares `ascent 0.905` where its capitals only reach `0.716`.
+
+**The standard-14 line metric is the `FontBBox`, not `Ascender`.** Helvetica: `-166 -225 1000 931` → ascent
+`0.931`, descent `0.225`, and no lineGap left to speak of. That is within a hair of a real Helvetica clone's
+`hhea`. `AFMParser.verticals()` returns exactly this; `PDFObjectManager.getFontVerticals(family, style)`
+answers from `hhea` for an embedded face and from the bbox for a standard-14 one (memoised per face).
+
+**Why a line box built this way looks right:** the surplus above the capitals (`0.931 − 0.718 = 0.213`) is
+about the same as the descent below the baseline (`0.225`). So an all-caps word lands optically centred in a
+box with equal padding. Seat the baseline at `Ascender` instead and every capital sits ~0.2 em too high —
+invisible on `Hxg` (the `g` hides it), glaring on `PAID` in a bordered box. **Always test with an all-caps
+word in a box with equal padding.** The reference is `google-chrome --headless --print-to-pdf` on the
+equivalent HTML (installed; scripts in `claude-data/out/lineheight/`), not react-pdf and certainly not
+reasoning from our own code.
+
+react-pdf hard-codes `ascent = 900` for every standard font, commented "based on empirical observation".
+That is a **rounded `FontBBox`**, not a guess. For embedded fonts it reads real `hhea` values, like we do.
+
+**Available and deliberately not parsed yet:** AFM gives `UnderlinePosition -100`, `UnderlineThickness 50`,
+`CapHeight`, `XHeight`. TrueType has the same in `post` and `OS/2` (`sxHeight`, `sCapHeight`) — `OS/2` is not
+parsed at all today. The planned `underline` / `strikethrough` / `letterSpacing` work needs these. Take them
+from the font. **Do not invent a constant** — that is exactly how `BASELINE_RATIO = 683/1000` happened.
+
 ### State threading — explicit, no singleton (since roadmap Phase 2)
 
 There is **no global object manager** (the old `@InjectObjectManager` / `reflect-metadata` decorator is
@@ -136,6 +168,12 @@ shared state.
 | `LineElement`           | `elements/line-element.ts`                   | `LineRenderer`        | stroke                                                                  |
 | `RectangleElement`      | `elements/rectangle-element.ts`              | `RectangleRenderer`   | fill + stroke                                                           |
 | `Color`                 | `common/color.ts`                            | —                     | RGB → PDF color string                                                  |
+| `LinkElement`           | `elements/layout/link-element.ts`            | `LinkRenderer`        | `href` (URL) or `dest` (an `Anchor`) → a /Link annotation               |
+| `AnchorElement`         | `elements/layout/anchor-element.ts`          | `AnchorRenderer`      | named jump target → catalog /Names /Dests                               |
+| `BookmarkElement`       | `elements/layout/bookmark-element.ts`        | `BookmarkRenderer`    | outline entry, nested by `level` → /Outlines                            |
+| `RotatedElement`        | `elements/layout/rotated-element.ts`         | `RotatedRenderer`     | paint-only spin at any angle (stamps)                                   |
+| `RotatedBoxElement`     | `elements/layout/rotated-box-element.ts`     | `RotatedRenderer`     | layout-aware quarter-turns (vertical labels)                            |
+| `PageBuilderElement`    | `elements/layout/page-builder-element.ts`    | `PageBuilderRenderer` | builds from `PageInfo` (pageNumber/pageCount/pageSize)                  |
 
 Every renderer's `render()` returns `Promise<IRNode[]>` (since roadmap Phase 1). Adding an element =
 new element + renderer that returns IR + (if it draws something new) a primitive in `ir/display-list.ts`
@@ -179,7 +217,7 @@ rendering. This is the standing visual check; prefer it over one-off `scripts/ru
 - `pnpm test` — Vitest (watch). `pnpm exec vitest run` for a one-shot CI-style run.
   `pnpm run test:coverage` for coverage. Unit tests live in **`tests/unit/`**, mirroring the `src/lib/`
   structure (`tests/unit/{common,elements,renderer,utils}/…`). `src/` is pure production code — the
-  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **~415 tests, green**
+  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **512 tests, green**
   in the core (plus the `@jasy/zugferd` suite).
 - `pnpm run build` — `tsc` → `dist/`.
 - `pnpm run lint` (oxlint) + `pnpm run fmt:check` (oxfmt `--check`); `pnpm run fmt` formats. **Run `pnpm run fmt`
@@ -221,6 +259,14 @@ The big refactors the roadmap set out are **done** (Phases 0-6, shipped as `@jas
   DURING fragmentation, not mutated onto shared instances — constraints down once, sizes up once.
 - ✅ **One shared line-breaker** (`text/line-breaker.ts`) feeds measure, draw AND fragmentation; the old
   duplicated-wrapping divergence is gone.
+- ✅ **One shared line-metrics module** (`text/line-metrics.ts`, 2026-07-10) — the VERTICAL counterpart:
+  `lineBoxFor(parts, lineHeight?) → { height, baseline }`. Measure/fragment/draw all call it, so a line's
+  height and its baseline are decided in exactly one place. Ascent/descent/lineGap come from the font via
+  `FontMetrics.getFontVerticals`: an embedded face answers from its `hhea`, a standard-14 face from its
+  **`FontBBox`** — NOT from the AFM's `Ascender`, which is a glyph metric (the height of `b`/`d`/`h`), not a
+  line metric. This is what makes an all-caps word sit optically centred, matching Chrome to a third of a
+  point. `lineHeight` unset = the font's natural line height (CSS `line-height: normal`); a number = a
+  multiplier of the font size. Half-leading splits the slack evenly, Flutter/CSS style.
 - ✅ **Singleton killed** → explicit `LayoutContext` threading (Phase 2); mixed-page-size bug fixed.
 - ✅ **Typed seams** — `BoxConstraints`/`Size`/`Offset` (Phase 4); `grep ': any' src/lib` empty.
 - ✅ **Custom fonts** — TTF parse → Type0/Identity-H + `/FontFile2`, full Unicode, subsetted
@@ -242,7 +288,7 @@ lineHeight, align, bold, italic }, …)` sets doc-wide text defaults; `DefaultTe
   choke-point (`streamPayload`) + a finalize pass (`finalizeEncryption`) writes `/Encrypt` + forces `/ID`;
   `EncryptMetadata false` keeps XMP plaintext. Mutually exclusive with PDF/A (ZUGFeRD throws). `recoverFileKey`
   (validates the password vs `/U`) is the groundwork for a future decrypt/edit path. Proven against poppler.
-- ✅ **Color emoji — COLR/CPAL v0 + v1** (2026-07, branch `feat/emoji`, not yet merged) — real color emoji
+- ✅ **Color emoji — COLR/CPAL v0 + v1** (2026-07, merged + shipped) — real color emoji
   rendered as **vector layers in pure TS, no browser, no CDN** (react-pdf only does CDN-fetched Twemoji PNGs).
   `TTFParser` grew a `glyf`+`loca` outline parser (`getGlyphPath` → M/L/Q, quads), COLR **v0** (flat solid
   layers) **and v1** (`getColorGlyph` walks the paint graph: PaintColrLayers/PaintGlyph/PaintColrGlyph, Solid,
@@ -272,7 +318,37 @@ lineHeight, align, bold, italic }, …)` sets doc-wide text defaults; `DefaultTe
   does (`canFragment` veto → rows move whole, never clipped). Backend wraps each node `/Role <</MCID>> BDC…EMC`
   (untagged → `/Artifact **BMC**`); catalog gets `/MarkInfo`, `/StructTreeRoot`, `/Lang`, `/ViewerPreferences
 /DisplayDocTitle`, pages `/Tabs /S`, TH `/Scope /Column`, XMP `pdfuaid:part 1` (`utils/ua-xmp.ts`). Off =
-  byte-identical. Full conformance needs embedded fonts + a title (same as PDF/A). **~415 tests.**
+  byte-identical. Full conformance needs embedded fonts + a title (same as PDF/A).
+- ✅ **Rotate** (2026-07-08) — `Rotated({ angle })` spins a subtree at any angle at PAINT time (stamps,
+  watermarks; layout-neutral, siblings do not reflow); `RotatedBox({ turns })` does layout-aware quarter-turns
+  (a 90/270 turn swaps w/h, so a vertical label reserves its strip). One IR pair `TransformPush{matrix}` /
+  `TransformPop` → `q … cm … Q`; `flipY` conjugates the matrix (`M_pdf = F·M·F`) so producers stay
+  coordinate-blind. Known gap: an annotation inside a transform does NOT rotate (see gap 6 below).
+- ✅ **Navigation** (2026-07-09, `@jasy/pdf@alpha.6`) — `Link({ href })` (external URL) or `Link({ to })`
+  (internal jump); `href`/`to` on a `span` links just that run (one /Rect per wrapped line); `Anchor({ name })`
+  is the jump target, resolved through the catalog `/Names /Dests` name tree, so a link may point at a page
+  that has not been rendered yet. `Bookmark({ title, level })` builds the nested `/Outlines` sidebar tree.
+  All three are layout-transparent wrappers emitting side-channel IR nodes that draw NOTHING (`serializeNode`
+  returns `""`); `PageRenderer` peels them into `/Annots`, `PDFRenderer` into the catalog. `/EmbeddedFiles`
+  (ZUGFeRD) and `/Dests` share ONE `/Names` dict. Off = byte-identical.
+- ✅ **Page numbers** (2026-07-09) — the page driver now PAGINATES the whole document, THEN draws, so the
+  total exists before page 1 is painted. `PageBuilder(({ pageNumber, pageCount, pageSize }) => element)` is the
+  primitive and works ANYWHERE (header, footer, body, a table cell); `PageNumber({ offset })` / `PageCount()`
+  are one-line sugar. Caveats, both from the same chicken-and-egg: dynamic BODY content reserves its box from a
+  provisional "1 of 1" build, and a conditional header may SHRINK on later pages but never GROW.
+- ✅ **The `Spacer` bug** (2026-07-09, GitHub #10) — a flex child on an UNBOUNDED main axis resolved to
+  `Infinity`, which became the offset of every following sibling and was written into the content stream
+  verbatim (`56.000 -Infinity Td`). Viewers discard the stream from there, so siblings AND the footer silently
+  vanished. Now: flex collapses to `0` on an unbounded axis; `PdfBackend.assertFinite` REFUSES to serialize a
+  non-finite number (it checks numbers, not text, so `Text("Infinity")` still renders); and a stack holding a
+  flex child ASKS its parent for a bounded main axis (`PDFElement.needsBoundedMain`, propagated recursively
+  through `Column`/`Row`/`Box`). So `Spacer()` finally pushes to the bottom in a nested `Column` and in a sized
+  `Box` — it never worked there before.
+- ✅ **Performance, ~4.8x** (2026-07-09, GitHub #12) — the hot path built STRING KEYS inside per-character
+  lookups. `resolveCustomStyle` early-outs when no custom font is registered; `customFonts` became
+  `Map<family, Map<style, TTFParser>>` (one map walk, not three key builds); `AFMParser.kerningPairs` is nested
+  too. Standard-14: 590 → 124 ms. Custom TTF: 778 → 119 ms (react-pdf 4.5.1: 181 ms on the same document).
+  Output byte-identical throughout, veraPDF still PDF/A-3b compliant. Harness: `node claude-data/bench.mjs`.
 
 Genuine remaining gaps / deferred:
 
@@ -297,10 +373,19 @@ Genuine remaining gaps / deferred:
 4. `manual-test` has hard-coded machine-specific paths.
 5. Font gaps: no TrueType kerning; only TTF / TrueType-flavoured OTF parsed (OTF/CFF, WOFF2 not yet).
    Bold/italic resolve via registered family variants with a clean fallback to `normal` (no faux styles).
-   Color-emoji deferred (all on `feat/emoji`, none blocking): COLR v1 **rotate/skew** transforms (24-31 —
+   Color-emoji deferred (none blocking): COLR v1 **rotate/skew** transforms (24-31 —
    Noto doesn't use them; not built without a test font), variable-font paint variants, **sweep** gradient,
    gradient `repeat`/`reflect` extend (drawn as `pad`), and **CFF** / **sbix**+**CBDT** bitmap color fonts
    (so Apple Color Emoji and the bitmap Noto build are unsupported — only glyf-outline COLR fonts render).
+6. **A transform does not carry its side channels** (`todo.md` ISSUE-2, priority LOW). Everything a `Rotated`
+   subtree DRAWS rotates — text, custom fonts, colour-emoji `Path`s, images, rects, borders, the
+   `overflow: hidden` clip, a whole `Table` (all measured). What does NOT rotate is `Link`, `Anchor` and
+   `Outline`: they are page `/Annots` and catalog entries, and never see the content-stream `cm` matrix. A
+   rotated _clickable_ link therefore keeps an axis-aligned hit area at its un-rotated position. **react-pdf is
+   not better here** — it transforms only the rect's two diagonal corners, so its hit area lands in the WRONG
+   place (measured: 152.3 × 96.8 pt where the true AABB is 155.56 × 155.56), and it emits no `/QuadPoints` at
+   all. The fix (a matrix stack at the `flipY` seam → `/QuadPoints` + a correct AABB `/Rect`) would make us the
+   only one who gets it right; it is a corner case, hence LOW.
 
 ## Roadmap
 
@@ -309,12 +394,12 @@ starting work. Working agreement: **phase by phase, Flo approves each gate, Clau
 unprompted, comments English + sensible, don't break the font math.**
 
 Status: **LAUNCHED 2026-06-27**, still shipping alpha increments (no beta/rc/stable until the feature set is
-complete — see `todo.md`). All five packages live on npm; **current (2026-07-02): `@jasy/pdf`@alpha.5,
-`@jasy/zugferd`@alpha.2, `@jasy/cli`@alpha.4, `@jasy/vue`@alpha.5, `@jasy/nuxt`@alpha.4** (the alpha.5 cascade =
-color emoji + PDF/UA). Repo public + locked, full CI + changelog +
+complete — see `todo.md`). All five packages live on npm; **current (2026-07-09): `@jasy/pdf`@alpha.6,
+`@jasy/zugferd`@alpha.3, `@jasy/cli`@alpha.5, `@jasy/vue`@alpha.6, `@jasy/nuxt`@alpha.5** (the alpha.6 cascade =
+rotate + navigation + page numbers + the Spacer fix + a 4.8x speed-up). Repo public + locked, full CI + changelog +
 bots in place (see Repo facts). The engine is **feature-complete for the alpha** — inheritance, `onOverflow`,
-custom formats, the line-breaker fixes; **~415 tests green**. The **landing**
-(`~/projects/jasy-landing` → **jasy.dev**) is built: showroom (9 cards), validator, docs, a home-page
+custom formats, the line-breaker fixes; **512 tests green**. The **landing**
+(`~/projects/jasy-landing` → **jasy.dev**) is built: showroom (12 cards), validator, docs, a home-page
 roadmap section, and a full **SEO + AI-discoverability layer** (OG image, JSON-LD, `robots.txt`,
 `llms.txt`, `sitemap.xml`).
 
@@ -333,8 +418,8 @@ media queries are meaningless for a fixed-size PDF). **✅ Relative/percentage s
 `width`/`height` as `"50%"`/pt on Box/Column/Row/Image, image aspect auto-size, and `%` children in flex
 containers resolved against `line − gaps` (so N columns at (100/N)%+gaps fit exactly - better than
 react-pdf/CSS). One shared `resolveExtent` (`layout/box-constraints.ts`); the core is untouched. Still
-**wanted-additive**: **paint-only rotate** + the small relative-sizing follow-ups (`aspectRatio` on any Box,
-`min/max` w/h, `%` on padding/margin/Positioned) — all 1.x minors. Plus the 🔮 wish-list (read/edit existing PDFs, forms, security + signatures,
+**wanted-additive**: the small relative-sizing follow-ups (`aspectRatio` on any Box, `min/max` w/h, `%` on
+padding/margin/Positioned) + page-break control (keep-together, orphans/widows) — all 1.x minors. Plus the 🔮 wish-list (read/edit existing PDFs, forms, security + signatures,
 more e-invoice profiles, framework bindings). See `todo.md` "⭐ Active" + "🔮 Layout & styling".
 
 ## Repo facts

--- a/src/lib/api/text.ts
+++ b/src/lib/api/text.ts
@@ -31,8 +31,9 @@ export interface TextOptions extends TextStyle {
   maxLines?: number;
   /** What happens past `maxLines`: `"clip"` (default) cuts hard, `"ellipsis"` ends with "…". */
   overflow?: TextOverflow;
-  /** Line-height multiplier (default `1`). `1.4` gives roomier body copy; each line is
-   *  `size * lineHeight` tall. */
+  /** Line-height multiplier: each line is `size * lineHeight` tall. Unset means the font's own
+   *  natural line height (`ascent + descent + lineGap`), like CSS `line-height: normal` - which is
+   *  what you want for body copy. `1` gives exactly one em, which most faces overflow slightly. */
   lineHeight?: number;
   /** Accessibility role for the tagged structure tree (only when rendered with `accessible`): a heading
    *  level `"h1"`..`"h6"` or `"p"` (default). Purely semantic - it does not change the visual style. */

--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -15,6 +15,7 @@ import {
   segmentLinesToSegments,
   TextOverflow,
 } from "../text/line-breaker.ts";
+import { lineBoxForSegmentLine, lineBoxForString } from "../text/line-metrics.ts";
 import { HorizontalAlignment, LayoutContext, SizedPDFElement } from "./pdf-element.ts";
 export interface TextSegment {
   content: string;
@@ -44,7 +45,8 @@ interface TextElementParams {
   maxLines?: number;
   /** What to do past `maxLines`: `"clip"` (default) drops them, `"ellipsis"` ends with "…". */
   overflow?: TextOverflow;
-  /** Line-height multiplier: each line is `fontSize * lineHeight` tall (default `1`). */
+  /** Line-height multiplier: each line is `fontSize * lineHeight` tall. Unset means the font's
+   *  natural line height (`ascent + descent + lineGap`), like CSS `line-height: normal`. */
   lineHeight?: number;
   /** Accessibility role for the tagged structure tree (heading level or paragraph; default `"p"`). */
   role?: TextRole;
@@ -67,7 +69,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
   private fontStyle!: FontStyle;
   private color!: Color;
   private textAlignment!: HorizontalAlignment;
-  private lineHeight!: number;
+  private lineHeight?: number; // undefined = the font's natural line height
 
   private content: string | TextSegment[];
   private maxLines?: number;
@@ -128,8 +130,8 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       : this.fragmentSegments(this.content, maxHeight, width, ctx);
   }
 
-  // Plain string: every wrapped line is `fontSize` tall (matches calculateTextHeight),
-  // so `floor(maxHeight / fontSize)` lines fit.
+  // Plain string: every wrapped line gets the same box (the same one calculateTextHeight uses),
+  // so `floor(maxHeight / lineBox)` lines fit.
   private fragmentString(
     content: string,
     maxHeight: number,
@@ -147,7 +149,14 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       this.overflow,
     );
 
-    const fittedLineCount = Math.floor(maxHeight / (this.fontSize * this.lineHeight));
+    const box = lineBoxForString(
+      ctx.metrics,
+      this.fontFamily,
+      this.fontStyle,
+      this.fontSize,
+      this.lineHeight,
+    );
+    const fittedLineCount = Math.floor(maxHeight / box.height);
     if (fittedLineCount <= 0) return { fitted: null, remainder: this };
     if (fittedLineCount >= lines.length) return { fitted: this, remainder: null };
 
@@ -157,21 +166,22 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     };
   }
 
-  // Styled segments: each line's height is its tallest font (maxFontSize), so pack lines
-  // by cumulative leading. Rebuild the fitted/remainder halves back into TextSegment[].
+  // Styled segments: each line's height comes from the fonts on it, so pack lines by cumulative
+  // box height. Rebuild the fitted/remainder halves back into TextSegment[].
   private fragmentSegments(
     content: TextSegment[],
     maxHeight: number,
     width: number,
     ctx: LayoutContext,
   ): FragmentResult {
+    const defaults = {
+      fontFamily: this.fontFamily,
+      fontSize: this.fontSize,
+      fontStyle: this.fontStyle,
+    };
     const lines = breakSegmentsIntoLines(
       content,
-      {
-        fontFamily: this.fontFamily,
-        fontSize: this.fontSize,
-        fontStyle: this.fontStyle,
-      },
+      defaults,
       width,
       ctx.metrics,
       this.maxLines,
@@ -181,7 +191,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     let used = 0;
     let fittedLineCount = 0;
     for (const line of lines) {
-      const lineBox = line.maxFontSize * this.lineHeight;
+      const lineBox = lineBoxForSegmentLine(line, defaults, ctx.metrics, this.lineHeight).height;
       if (used + lineBox > maxHeight) break;
       used += lineBox;
       fittedLineCount++;

--- a/src/lib/renderer/text-renderer.ts
+++ b/src/lib/renderer/text-renderer.ts
@@ -19,10 +19,7 @@ import {
   SegmentLine,
   TextOverflow,
 } from "../text/line-breaker.ts";
-
-// Distance from the top of a line down to its baseline, as a fraction of the font
-// size. ~0.683 is the standard-14 ascent ratio used to seat the first baseline.
-const BASELINE_RATIO = 683 / 1000;
+import { lineBoxForSegmentLine, lineBoxForString } from "../text/line-metrics.ts";
 
 export class TextRenderer {
   // Measuring only needs metrics, not the full object manager. (The render pass below
@@ -36,9 +33,9 @@ export class TextRenderer {
     maxWidth: number,
     maxLines?: number,
     overflow?: TextOverflow,
-    lineHeight = 1,
+    lineHeight?: number,
   ): number {
-    // Plain string: one line box (fontSize * lineHeight) per wrapped line.
+    // Plain string: every wrapped line gets the same box.
     if (typeof content === "string") {
       const lines = wrapStringIntoLines(
         content,
@@ -50,19 +47,25 @@ export class TextRenderer {
         maxLines,
         overflow,
       );
-      return lines.length * fontSize * lineHeight;
+      const box = lineBoxForString(objectManager, fontFamily, fontStyle, fontSize, lineHeight);
+      return lines.length * box.height;
     }
 
-    // Segments: each line contributes its own (tallest-on-line) leading, scaled by lineHeight.
+    // Segments: each line's box comes from the fonts actually on it.
+    const defaults = { fontFamily, fontSize, fontStyle };
     const lines = breakSegmentsIntoLines(
       content,
-      { fontFamily, fontSize, fontStyle },
+      defaults,
       maxWidth,
       objectManager,
       maxLines,
       overflow,
     );
-    return lines.reduce((total, line) => total + line.maxFontSize * lineHeight, 0);
+    return lines.reduce(
+      (total, line) =>
+        total + lineBoxForSegmentLine(line, defaults, objectManager, lineHeight).height,
+      0,
+    );
   }
 
   static async render(
@@ -327,7 +330,7 @@ export class TextRenderer {
     yPosition: number,
     maxLines?: number,
     overflow?: TextOverflow,
-    lineHeight = 1,
+    lineHeight?: number,
   ): { runs: TextRun[]; links: Link[] } {
     const runs: TextRun[] = [];
     // /Link annotation rects for any `href` spans, collected as we place segments. Empty for the
@@ -369,18 +372,15 @@ export class TextRenderer {
         maxLines,
         overflow,
       );
-      // yPosition is the top of the text box (top-left); seat line 0's baseline below it, then step
-      // DOWN by one line box (fontSize * lineHeight) per line. The lineHeight EXTRA leading is split
-      // half above / half below (CSS/Flutter "half-leading"), so the text sits centered in its line
-      // box instead of clinging to the top. At lineHeight 1 the half-leading is 0 -> byte-identical.
-      const halfLeading = (fontSize * (lineHeight - 1)) / 2;
-      const baseline = yPosition + halfLeading + fontSize * BASELINE_RATIO;
+      // yPosition is the top of the text box (top-left). The line box seats its own baseline; lines
+      // then stack by that box's height. Same numbers as calculateTextHeight, by construction.
+      const box = lineBoxForString(objectManager, fontFamily, fontStyle, fontSize, lineHeight);
       lines.forEach((line, index) => {
         const lineWidth = objectManager.getStringWidth(line, fontFamily, fontSize, fontStyle);
         runs.push({
           type: "text",
           x: initialX + alignmentOffset(lineWidth),
-          y: baseline + fontSize * lineHeight * index,
+          y: yPosition + box.baseline + box.height * index,
           text: line,
           fontFamily,
           fontStyle,
@@ -413,16 +413,17 @@ export class TextRenderer {
           fontSize: size,
           color: segment.fontColor || color,
         });
-        // An href/to span becomes a /Link annotation over exactly this run's glyph box. `lineY` is the
-        // baseline; the box spans from the ascent (BASELINE_RATIO above it) down by the full size, so
-        // ascent + descent are covered. A span wrapped across lines yields one rect per line.
+        // An href/to span becomes a /Link annotation over exactly this run's glyph box: from its own
+        // ascent above the baseline down to its own descender. A span wrapped across lines yields
+        // one rect per line.
         if (segment.href !== undefined || segment.dest !== undefined) {
+          const v = objectManager.getFontVerticals(family, style);
           links.push({
             type: "link",
             x,
-            y: lineY - size * BASELINE_RATIO,
+            y: lineY - v.ascent * size,
             width: advance,
-            height: size,
+            height: (v.ascent + v.descent) * size,
             href: segment.href,
             dest: segment.dest,
           });
@@ -431,29 +432,22 @@ export class TextRenderer {
       });
     };
 
-    // The overall tallest font seats the first baseline; each line then steps DOWN by
-    // its own leading. yPosition is the top of the text box (top-left); the seam flips
-    // the whole thing to PDF space.
-    let overallMaxFont = fontSize;
-    for (const segment of content) {
-      const size = segment.fontSize || fontSize;
-      if (size > overallMaxFont) overallMaxFont = size;
-    }
-
-    let lineY = yPosition + overallMaxFont * BASELINE_RATIO;
+    // yPosition is the top of the text box (top-left). Each line seats its own baseline inside its
+    // own box (tallest ascent / deepest descent ON THAT LINE), then the next line starts below it.
+    // The seam flips the whole thing to PDF space.
+    const defaults = { fontFamily, fontSize, fontStyle };
+    let top = yPosition;
     for (const line of breakSegmentsIntoLines(
       content,
-      { fontFamily, fontSize, fontStyle },
+      defaults,
       maxWidth,
       objectManager,
       maxLines,
       overflow,
     )) {
-      // Half-leading: shift this line's baseline down by half its own extra leading, so the line
-      // sits centered in its box (CSS/Flutter). At lineHeight 1 the shift is 0 -> byte-identical.
-      const halfLeading = (line.maxFontSize * (lineHeight - 1)) / 2;
-      pushLine(line, lineY + halfLeading);
-      lineY += line.maxFontSize * lineHeight;
+      const box = lineBoxForSegmentLine(line, defaults, objectManager, lineHeight);
+      pushLine(line, top + box.baseline);
+      top += box.height;
     }
 
     return { runs, links };

--- a/src/lib/text/line-breaker.ts
+++ b/src/lib/text/line-breaker.ts
@@ -17,12 +17,11 @@ export type TextOverflow = "clip" | "ellipsis";
  *  (WinAnsi) and any embedded TTF - whereas U+2026 needs a glyph the font may not carry. */
 const ELLIPSIS = "...";
 
-/** One laid-out line of segments. `maxFontSize` is the tallest font ON THIS LINE - its
- *  leading - matching how real engines (and this lib's plain-string path) space lines. */
+/** One laid-out line of segments. How TALL it is does not live here: the breaker owns the horizontal
+ *  half, `text/line-metrics.ts` owns the vertical one and derives the box from the fonts on the line. */
 export interface SegmentLine {
   segments: TextSegment[];
   width: number; // sum of word widths incl. spaces, used for alignment
-  maxFontSize: number;
 }
 
 /**
@@ -78,10 +77,10 @@ export function wrapStringIntoLines(
 }
 
 /**
- * Break styled segments into lines that fit within `maxWidth`. Same greedy
- * word-splitting as the string breaker, but each line records the tallest font on
- * THAT line as its leading (per-line, not a paragraph-global maximum). Single source
- * of truth: both height measurement and rendering call this.
+ * Break styled segments into lines that fit within `maxWidth`. Same greedy word-splitting as the
+ * string breaker; each line keeps the segments that landed on it, which is what `line-metrics.ts`
+ * later derives the line's height from. Single source of truth: both height measurement and
+ * rendering call this.
  */
 export function breakSegmentsIntoLines(
   segments: TextSegment[],
@@ -93,7 +92,6 @@ export function breakSegmentsIntoLines(
 ): SegmentLine[] {
   const lines: SegmentLine[] = [];
   let width = 0;
-  let maxFontSize = 0; // per line: starts at 0, grows to the tallest font on the line
   let lineSegments: TextSegment[] = [];
   let combined = "";
 
@@ -109,7 +107,6 @@ export function breakSegmentsIntoLines(
     // its whole text into the line that just closed.)
     lineSegments.push({ ...segment, fontFamily: family, content: "" });
     combined = "";
-    if (maxFontSize < size) maxFontSize = size;
 
     words.forEach((word, wordIndex) => {
       const wordWidth = metrics.getStringWidth(word, family, size, style);
@@ -117,10 +114,8 @@ export function breakSegmentsIntoLines(
       // Same guard as the string path: don't open a phantom empty line for an over-wide first word -
       // place it (overflowing) on the current empty line instead.
       if (width + wordWidth > maxWidth && width > 0) {
-        lines.push({ segments: lineSegments, width, maxFontSize });
-        // Start the next line; its leading resets to the wrapping segment's size.
+        lines.push({ segments: lineSegments, width });
         width = 0;
-        maxFontSize = size;
         lineSegments = [];
         combined = word;
         width += wordWidth + spaceWidth;
@@ -137,7 +132,7 @@ export function breakSegmentsIntoLines(
   });
 
   if (lineSegments.length > 0) {
-    lines.push({ segments: lineSegments, width, maxFontSize });
+    lines.push({ segments: lineSegments, width });
   }
 
   // Open-end by default; cap only when maxLines is set.

--- a/src/lib/text/line-metrics.ts
+++ b/src/lib/text/line-metrics.ts
@@ -1,0 +1,109 @@
+/**
+ * The vertical half of text layout: how tall a line box is, and where its baseline sits.
+ *
+ * One canonical answer, like `line-breaker.ts` is the one canonical answer for the horizontal
+ * half. Measuring (`calculateTextHeight`), fragmenting (`TextElement.fragment`) and drawing
+ * (`TextRenderer._buildRuns`) all call in here, so they can never disagree about a line's height
+ * again - the divergence that produced ISSUE-5.
+ */
+
+import type { FontStyle } from "../utils/pdf-object-manager.ts";
+import type { FontMetrics } from "../utils/font-metrics.ts";
+import type { SegmentDefaults, SegmentLine } from "./line-breaker.ts";
+
+/** A font's vertical metrics, as fractions of the em (so they scale by multiplying with fontSize). */
+export interface FontVerticals {
+  /** Distance from the baseline up to the ascender. Positive. */
+  ascent: number;
+  /** Distance from the baseline down to the descender. Positive (unlike the AFM/hhea sign). */
+  descent: number;
+  /** Extra leading the font asks for between two lines. Often 0 for a TrueType face. */
+  lineGap: number;
+}
+
+/** One font used on a line: its metrics and the size it is set at. */
+export interface LinePart {
+  verticals: FontVerticals;
+  fontSize: number;
+}
+
+/** A laid-out line box, in points, relative to the top of the box. */
+export interface LineBox {
+  /** Total height of the line box. Lines stack by this. */
+  height: number;
+  /** Distance from the top of the line box down to the baseline. */
+  baseline: number;
+}
+
+/**
+ * The line box for a set of fonts sharing one line.
+ *
+ * `lineHeight` is a multiplier of the font size, like CSS. Leave it `undefined` for the font's
+ * NATURAL line height (`ascent + descent + lineGap`), which is what CSS calls `line-height: normal`.
+ *
+ * Whatever is left over between the box and the font's content is split evenly above and below
+ * ("half-leading", as CSS and Flutter do), so the glyphs sit centred in their own box. An explicit
+ * `lineHeight` smaller than the content makes the leading negative and the glyphs overflow - again
+ * exactly like CSS, and the author asked for it.
+ */
+export function lineBoxFor(parts: LinePart[], lineHeight?: number): LineBox {
+  if (parts.length === 0) return { height: 0, baseline: 0 };
+
+  let ascent = 0;
+  let descent = 0;
+  let gap = 0;
+  let maxFontSize = 0;
+  for (const { verticals, fontSize } of parts) {
+    ascent = Math.max(ascent, verticals.ascent * fontSize);
+    descent = Math.max(descent, verticals.descent * fontSize);
+    gap = Math.max(gap, verticals.lineGap * fontSize);
+    maxFontSize = Math.max(maxFontSize, fontSize);
+  }
+
+  const content = ascent + descent;
+  const height = lineHeight === undefined ? content + gap : maxFontSize * lineHeight;
+  return { height, baseline: (height - content) / 2 + ascent };
+}
+
+/** The line box of a single-font line (the plain-string path). */
+export function lineBoxForString(
+  metrics: FontMetrics,
+  fontFamily: string,
+  fontStyle: FontStyle,
+  fontSize: number,
+  lineHeight?: number,
+): LineBox {
+  return lineBoxFor(
+    [{ verticals: metrics.getFontVerticals(fontFamily, fontStyle), fontSize }],
+    lineHeight,
+  );
+}
+
+/** The line box of a mixed-font line: the tallest ascent and the deepest descent on it win, so a
+ *  big or a deep-descending span pushes the whole line apart rather than colliding with it. */
+export function lineBoxForSegmentLine(
+  line: SegmentLine,
+  defaults: SegmentDefaults,
+  metrics: FontMetrics,
+  lineHeight?: number,
+): LineBox {
+  const parts: LinePart[] = line.segments.map((segment) => {
+    const fontFamily = segment.fontFamily ?? defaults.fontFamily;
+    const fontStyle = segment.fontStyle ?? defaults.fontStyle;
+    return {
+      verticals: metrics.getFontVerticals(fontFamily, fontStyle),
+      fontSize: segment.fontSize ?? defaults.fontSize,
+    };
+  });
+  // A line with no segments still occupies its default font's box (an empty paragraph keeps height).
+  if (parts.length === 0) {
+    return lineBoxForString(
+      metrics,
+      defaults.fontFamily,
+      defaults.fontStyle,
+      defaults.fontSize,
+      lineHeight,
+    );
+  }
+  return lineBoxFor(parts, lineHeight);
+}

--- a/src/lib/text/text-style.ts
+++ b/src/lib/text/text-style.ts
@@ -14,13 +14,14 @@ export interface ResolvedTextStyle {
   fontStyle: FontStyle;
   color: Color;
   textAlignment: HorizontalAlignment;
-  lineHeight: number;
+  /** Multiplier of the font size. `undefined` means the font's natural line height
+   *  (`ascent + descent + lineGap`), i.e. CSS `line-height: normal`. */
+  lineHeight?: number;
 }
 
 /**
  * The root of the cascade: what a `Text` falls back to when neither it nor any ancestor sets a
- * property. These MUST match the historical `Text` defaults so a document that sets nothing renders
- * byte-for-byte as before.
+ * property.
  */
 export const DEFAULT_TEXT_STYLE: ResolvedTextStyle = {
   fontSize: 12,
@@ -28,7 +29,7 @@ export const DEFAULT_TEXT_STYLE: ResolvedTextStyle = {
   fontStyle: FontStyle.Normal,
   color: new Color(0, 0, 0),
   textAlignment: HorizontalAlignment.left,
-  lineHeight: 1,
+  lineHeight: undefined,
 };
 
 /** Layers a partial override onto a complete style; an unset (undefined) field keeps the base. */

--- a/src/lib/utils/afm-parser.ts
+++ b/src/lib/utils/afm-parser.ts
@@ -1,9 +1,15 @@
 import { AGL } from "../assets/font-data.ts";
+import type { FontVerticals } from "../text/line-metrics.ts";
 
 export class AFMParser {
   private advanceWidths: Record<string, number> = {};
   private kerningPairs: Record<string, Record<string, number>> = {};
   private glyphMap: Record<string, string> = {};
+
+  // The font's bounding box in glyph space (1000 units / em), from the AFM header. This - not the
+  // `Ascender` line - is what a line box is built from; see `verticals()`.
+  private bbox: [number, number, number, number] = [0, 0, 0, 0];
+  private cachedVerticals?: FontVerticals; // never changes for a face; asked once per line
 
   constructor(afmData: string) {
     this.parseAFMData(afmData);
@@ -57,6 +63,11 @@ export class AFMParser {
         }
       }
 
+      if (line.startsWith("FontBBox ")) {
+        const [x0, y0, x1, y1] = line.slice(9).trim().split(/\s+/).map(parseFloat);
+        this.bbox = [x0, y0, x1, y1];
+      }
+
       if (line.startsWith("KPX")) {
         const parts = line.split(/\s+/);
         const firstChar = parts[1];
@@ -91,6 +102,29 @@ export class AFMParser {
     }
 
     return null;
+  }
+
+  /**
+   * The font's LINE metrics, as fractions of the em: how far a line box must reach above and below
+   * the baseline. Taken from the `FontBBox`.
+   *
+   * Not from the AFM's `Ascender` / `Descender` lines, and that distinction is the whole point.
+   * `Ascender 718` is a GLYPH metric - the height of `b`, `d`, `h` - and for Helvetica it happens to
+   * equal the cap height. The line-metric equivalent is TrueType's `hhea.ascent`, which is much
+   * taller because it has to clear the accented capitals: Arial declares 0.905 where its caps reach
+   * 0.716. That surplus above the caps (0.189) is about as large as the descent below the baseline
+   * (0.212), which is exactly why capitals look vertically centred in a browser.
+   *
+   * Helvetica's `FontBBox` is `-166 -225 1000 931`: 0.931 up, 0.225 down - within a hair of Arial's
+   * hhea numbers. So the bbox IS the standard-14 line metric, and there is no leftover slack to
+   * call a lineGap. (Seating the baseline at `Ascender` instead put every capital too high; see
+   * ISSUE-5.)
+   */
+  verticals(): FontVerticals {
+    if (this.cachedVerticals) return this.cachedVerticals;
+    const [, yMin, , yMax] = this.bbox;
+    this.cachedVerticals = { ascent: yMax / 1000, descent: -yMin / 1000, lineGap: 0 };
+    return this.cachedVerticals;
   }
 
   getAdvanceWidth(charName: string): number {

--- a/src/lib/utils/font-metrics.ts
+++ b/src/lib/utils/font-metrics.ts
@@ -1,4 +1,5 @@
 import type { FontStyle } from "./pdf-object-manager.ts";
+import type { FontVerticals } from "../text/line-metrics.ts";
 
 /**
  * Read-only font measurement - the slice of the object manager that the layout pass
@@ -17,4 +18,8 @@ export interface FontMetrics {
     fontName?: string,
     fontStyle?: FontStyle,
   ): number;
+
+  /** Ascent / descent / lineGap of a face, in em fractions - the vertical counterpart of the widths
+   *  above. Drives the line box and the baseline (see `text/line-metrics.ts`). */
+  getFontVerticals(fontFamily: string, fontStyle: FontStyle): FontVerticals;
 }

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -11,6 +11,7 @@ import { getArrayBuffer } from "./utf8-to-windows1252-encoder.ts";
 import type { SecurityHandler } from "../crypto/security-handler.ts";
 import type { Gradient, GradientStop } from "../ir/display-list.ts";
 import { isEmojiCodePoint } from "../text/emoji-codepoints.ts";
+import type { FontVerticals } from "../text/line-metrics.ts";
 import { StructTree } from "./struct-tree.ts";
 import { OutlineBuilder } from "./outline.ts";
 import { DestRegistry } from "./dest-registry.ts";
@@ -188,6 +189,8 @@ export class PDFObjectManager implements FontMetrics {
   // every lookup, and the lookups happen once per character - the string allocation alone was a third
   // of a custom-font render. `customFontEmit` below keeps the flat key: it is touched once per face.
   private customFonts = new Map<string, Map<FontStyle, TTFParser>>();
+  // Memoised getFontVerticals answers, family -> style -> metrics. Cleared when a font registers.
+  private verticalsCache = new Map<string, Map<FontStyle, FontVerticals>>();
   // Per-registered face: the reserved font-object numbers + the glyph ids actually used. The font
   // program is subsetted and the objects filled in by finalizeCustomFonts(), after the render pass.
   private customFontEmit = new Map<
@@ -609,6 +612,7 @@ endstream`;
     if (this.fonts.hasFont(fontName, fontStyle)) {
       return this.fonts.getFont(fontName, fontStyle)!; // Already exists? Return it!
     }
+    this.verticalsCache.delete(fontName);
 
     const data = STANDARD_AFM[fullName];
     if (data !== undefined) {
@@ -646,6 +650,7 @@ endstream`;
     }
     if (byStyle.has(style)) return;
     byStyle.set(style, new TTFParser(data));
+    this.verticalsCache.delete(name); // this family now answers from the .ttf, not from an AFM
     // Emission (the PDF font objects + page resource) is DEFERRED to first use via ensureEmitted(),
     // so a registered-but-never-rendered face - e.g. a bundled family the document doesn't touch -
     // costs nothing in the output. The metrics above are still available for layout immediately.
@@ -871,6 +876,35 @@ endstream`;
       `<< /Type /Font /Subtype /Type0 /BaseFont /${pdfName(name)} /Encoding /Identity-H ` +
       `/DescendantFonts [${cidFont} 0 R] /ToUnicode ${toUnicode} 0 R >>`
     );
+  }
+
+  // The vertical metrics of a face, in em fractions - what seats the baseline and sizes the line
+  // box (see text/line-metrics.ts). An embedded font answers from its own `hhea`; a standard-14
+  // font from its AFM header. Nothing here is guessed: both numbers come out of the font data.
+  //
+  // Asked once per LINE (not per character), but a long document has a lot of lines and the
+  // standard-14 lookup below is a linear scan, so the answer is memoised per face. Registering a
+  // font clears the cache - a name can go from standard-14 to embedded.
+  getFontVerticals(fontFamily: string, fontStyle: FontStyle): FontVerticals {
+    let byStyle = this.verticalsCache.get(fontFamily);
+    const hit = byStyle?.get(fontStyle);
+    if (hit) return hit;
+
+    const ttf = this.getCustomFont(fontFamily, fontStyle);
+    const verticals = ttf
+      ? {
+          ascent: ttf.ascent / 1000,
+          descent: -ttf.descent / 1000, // hhea writes the descent negative
+          lineGap: ttf.lineGap / 1000,
+        }
+      : this.getAVMParserByFont(undefined, fontFamily, fontStyle).parser.verticals();
+
+    if (!byStyle) {
+      byStyle = new Map();
+      this.verticalsCache.set(fontFamily, byStyle);
+    }
+    byStyle.set(fontStyle, verticals);
+    return verticals;
   }
 
   // Returns the current width of a text, included kernings

--- a/src/lib/utils/ttf-parser.ts
+++ b/src/lib/utils/ttf-parser.ts
@@ -119,6 +119,8 @@ export class TTFParser {
   // FontDescriptor metrics, in PDF glyph space (1000 units / em).
   ascent = 0;
   descent = 0;
+  // Extra leading the font asks for between two lines (hhea), same glyph space. Often 0.
+  lineGap = 0;
   bbox: [number, number, number, number] = [0, 0, 0, 0];
   private numGlyphs = 0;
   private numHMetrics = 0;
@@ -151,6 +153,7 @@ export class TTFParser {
     const hhea = this.table("hhea").offset;
     this.ascent = this.toGlyphSpace(i16(this.data, hhea + 4));
     this.descent = this.toGlyphSpace(i16(this.data, hhea + 6));
+    this.lineGap = this.toGlyphSpace(i16(this.data, hhea + 8));
     this.indexToLocFormat = i16(this.data, head + 50);
     this.readHmtx();
     this.readCmap();

--- a/tests/unit/elements/positioned-element.test.ts
+++ b/tests/unit/elements/positioned-element.test.ts
@@ -10,10 +10,12 @@ import { Orientation } from "../../../src/lib/renderer/pdf-config";
 import { PageSize } from "../../../src/lib/constants/page-sizes";
 import type { FontMetrics } from "../../../src/lib/utils/font-metrics";
 import type { PDFObjectManager } from "../../../src/lib/utils/pdf-object-manager";
+import { unitVerticals } from "../support/metrics";
 
 const metrics: FontMetrics = {
   getStringWidth: (text) => text.length * 10,
   getCharWidth: () => 0,
+  getFontVerticals: unitVerticals,
 };
 const ctx = { metrics } as LayoutContext;
 

--- a/tests/unit/elements/row-element.test.ts
+++ b/tests/unit/elements/row-element.test.ts
@@ -6,6 +6,7 @@ import { TextElement } from "../../../src/lib/elements/text-element";
 import { BoxConstraints } from "../../../src/lib/layout/box-constraints";
 import { LayoutContext } from "../../../src/lib/elements/pdf-element";
 import { FontMetrics } from "../../../src/lib/utils/font-metrics";
+import { unitVerticals } from "../support/metrics";
 
 const box = (width: number, height: number) =>
   new RectangleElement({ x: 0, y: 0, children: [], width, height, borderWidth: 0 });
@@ -33,6 +34,7 @@ describe("RowElement", () => {
     const metrics = {
       getStringWidth: (t: string) => t.length * 6,
       getCharWidth: () => 6,
+      getFontVerticals: unitVerticals,
     } as unknown as FontMetrics;
     const ctx = { metrics, pageConfig: {} } as LayoutContext;
 
@@ -55,6 +57,7 @@ describe("RowElement", () => {
     const metrics = {
       getStringWidth: (t: string) => t.length * 6 - 10, // per word; kerning pulls it IN
       getCharWidth: () => 6, // the space advance
+      getFontVerticals: unitVerticals,
     } as unknown as FontMetrics;
     const ctx = { metrics, pageConfig: {} } as LayoutContext;
 

--- a/tests/unit/layout/box-fragment.test.ts
+++ b/tests/unit/layout/box-fragment.test.ts
@@ -7,11 +7,13 @@ import { LayoutContext, PDFElement } from "../../../src/lib/elements/pdf-element
 import { BoxConstraints, Offset, Size } from "../../../src/lib/layout/box-constraints";
 import { packChildren } from "../../../src/lib/layout/fragmentation";
 import type { FontMetrics } from "../../../src/lib/utils/font-metrics";
+import { unitVerticals } from "../support/metrics";
 
 // Each glyph 10 wide, spaces 0: "aa bb cc dd ee ff" wraps to 3 lines of 10pt at width 50.
 const metrics: FontMetrics = {
   getStringWidth: (text) => text.length * 10,
   getCharWidth: () => 0,
+  getFontVerticals: unitVerticals,
 };
 const ctx = { metrics } as LayoutContext;
 

--- a/tests/unit/renderer/text-renderer.test.ts
+++ b/tests/unit/renderer/text-renderer.test.ts
@@ -5,12 +5,14 @@ import { describe, it, vi, expect } from "vitest";
 import { TextElement } from "../../../src/lib/elements";
 import { HorizontalAlignment } from "../../../src/lib/elements/pdf-element";
 import { Color } from "../../../src/lib/common/color";
+import { unitVerticals } from "../support/metrics";
 
 describe("TextRenderer - calculateTextHeight", () => {
   it("should calculate the correct text height for a simple string", () => {
     const mockObjectManager = {
       getStringWidth: vi.fn().mockReturnValue(10), // String width is used for each word = 20
       getCharWidth: vi.fn().mockReturnValue(5), // Used for empty spaces = 5
+      getFontVerticals: unitVerticals,
       struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
@@ -30,6 +32,7 @@ describe("TextRenderer - calculateTextHeight", () => {
     const mockObjectManager = {
       getStringWidth: vi.fn().mockReturnValue(10), // String width is used for each word = 60
       getCharWidth: vi.fn().mockReturnValue(5), // Used for empty spaces = 25
+      getFontVerticals: unitVerticals,
       struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
@@ -49,6 +52,7 @@ describe("TextRenderer - calculateTextHeight", () => {
     const mockObjectManager = {
       getStringWidth: vi.fn().mockReturnValue(10),
       getCharWidth: vi.fn().mockReturnValue(5),
+      getFontVerticals: unitVerticals,
       struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
@@ -92,6 +96,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getEmojiImageSource: vi.fn().mockReturnValue(undefined),
       getStringWidth: vi.fn().mockReturnValue(10),
       getCharWidth: vi.fn().mockReturnValue(5),
+      getFontVerticals: unitVerticals,
       struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
@@ -132,6 +137,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getEmojiImageSource: vi.fn().mockReturnValue(undefined),
       getStringWidth: vi.fn().mockReturnValue(10),
       getCharWidth: vi.fn().mockReturnValue(5),
+      getFontVerticals: unitVerticals,
       struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
@@ -169,6 +175,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getEmojiImageSource: vi.fn().mockReturnValue(undefined),
       getStringWidth: vi.fn().mockReturnValue(25), // Here we get the widht of the "complete" string, because the renderer renders each "line", not only the words/segments: 25
       getCharWidth: vi.fn().mockReturnValue(0), // For empty spaces: 0
+      getFontVerticals: unitVerticals,
       struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
@@ -178,9 +185,11 @@ describe("TextRenderer - calculateTextHeight", () => {
     );
 
     expect(result).toContain("/F1 12 Tf");
-    // x: 10 + (200 - 25) / 2 = 97.5. y: top 20 + baseline 12*0.683 = 28.196
+    // x: 10 + (200 - 25) / 2 = 97.5.
+    // y: the test font is 0.75 up / 0.25 down, so its natural box is 1 em = 12 with no leading to
+    // split; the baseline sits at its ascent, 12*0.75 = 9, below the top: 20 + 9 = 29.
     // (top-left baseline; the seam flips to PDF coordinates later).
-    expect(result).toContain("97.500 28.196 Td");
+    expect(result).toContain("97.500 29.000 Td");
     expect(result).toContain("(Hello World) Tj");
   });
 
@@ -207,6 +216,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getEmojiImageSource: vi.fn().mockReturnValue(undefined),
       getStringWidth: vi.fn().mockReturnValue(25), // Here we get the widht of the "complete" string, because the renderer renders each "line", not only the words/segments: 25
       getCharWidth: vi.fn().mockReturnValue(0),
+      getFontVerticals: unitVerticals,
       struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
@@ -216,8 +226,8 @@ describe("TextRenderer - calculateTextHeight", () => {
     );
 
     expect(result).toContain("/F1 12 Tf");
-    // x: 10 + 200 - 25 = 185. y: top 20 + baseline 12*0.683 = 28.196.
-    expect(result).toContain("185.000 28.196 Td");
+    // x: 10 + 200 - 25 = 185. y: top 20 + ascent 12*0.75 = 29.
+    expect(result).toContain("185.000 29.000 Td");
     expect(result).toContain("(Hello World) Tj");
   });
 
@@ -244,6 +254,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getEmojiImageSource: vi.fn().mockReturnValue(undefined),
       getStringWidth: vi.fn().mockReturnValue(0),
       getCharWidth: vi.fn().mockReturnValue(0),
+      getFontVerticals: unitVerticals,
       struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
@@ -300,6 +311,7 @@ describe("TextRenderer - calculateTextHeight", () => {
         return content.length * fontSize; // Einfacher Algorithmus zur Rückgabe der Breite
       }),
       getCharWidth: vi.fn().mockReturnValue(10),
+      getFontVerticals: unitVerticals,
       struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
@@ -355,6 +367,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getEmojiImageSource: vi.fn().mockReturnValue(undefined),
       getStringWidth: vi.fn().mockReturnValue(25), // Here we get the widht of each segment: 50
       getCharWidth: vi.fn().mockReturnValue(0), // For empty spaces: 0
+      getFontVerticals: unitVerticals,
       struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
@@ -367,7 +380,9 @@ describe("TextRenderer - calculateTextHeight", () => {
     expect(result).toContain("/F1 12 Tf");
     expect(result).toContain("/F2 14 Tf");
 
-    // x: 10 + (200 - 50) / 2 = 85. y: top 20 + baseline (tallest font 14)*0.683 = 29.562.
-    expect(result).toContain("85.000 29.562 Td");
+    // x: 10 + (200 - 50) / 2 = 85.
+    // y: the line mixes 12pt and 14pt, so the tallest ascent (14*0.75 = 10.5) and the deepest
+    // descent (14*0.25 = 3.5) size the box: content 14, no leading, baseline at 10.5. 20 + 10.5.
+    expect(result).toContain("85.000 30.500 Td");
   });
 });

--- a/tests/unit/support/metrics.ts
+++ b/tests/unit/support/metrics.ts
@@ -1,0 +1,11 @@
+import type { FontVerticals } from "../../../src/lib/text/line-metrics";
+
+/**
+ * Vertical metrics for the deterministic test fonts: 3/4 em above the baseline, 1/4 em below, no
+ * lineGap. The natural line box is then exactly 1 em, so a test can keep doing arithmetic in whole
+ * font sizes - and both fractions are exact in binary, so `ascent + descent` is 1.0 and not
+ * 1.0000000000000002. A real font's numbers come from its AFM/hhea (see `getFontVerticals`).
+ */
+export const UNIT_VERTICALS: FontVerticals = { ascent: 0.75, descent: 0.25, lineGap: 0 };
+
+export const unitVerticals = (): FontVerticals => UNIT_VERTICALS;

--- a/tests/unit/text/line-breaker.test.ts
+++ b/tests/unit/text/line-breaker.test.ts
@@ -2,12 +2,15 @@ import { describe, it, expect } from "vitest";
 import { breakSegmentsIntoLines, wrapStringIntoLines } from "../../../src/lib/text/line-breaker";
 import { FontStyle } from "../../../src/lib/utils/pdf-object-manager";
 import type { FontMetrics } from "../../../src/lib/utils/font-metrics";
+import { unitVerticals } from "../support/metrics";
+import { lineBoxForSegmentLine } from "../../../src/lib/text/line-metrics";
 
 // Deterministic metrics: every glyph is 10 wide, spaces are 0. Expected line breaks
 // are computed by hand from these, so the test is an oracle, not a snapshot.
 const metrics: FontMetrics = {
   getStringWidth: (text) => text.length * 10,
   getCharWidth: () => 0,
+  getFontVerticals: unitVerticals,
 };
 
 const defaults = {
@@ -42,13 +45,19 @@ describe("line-breaker", () => {
       metrics,
     );
 
-    // Line 0 carries the 24pt word, so its leading is 24; the wrapped 11pt lines are 11.
-    expect(lines[0].maxFontSize).toBe(24);
-    expect(lines.slice(1).every((line) => line.maxFontSize === 11)).toBe(true);
+    // The breaker only decides WHICH segments land on which line; the height comes from those
+    // segments (line-metrics.ts). Line 0 carries the 24pt word, the wrapped lines carry only 11pt.
+    const sizeOf = (line: (typeof lines)[number]): number =>
+      Math.max(...line.segments.map((s) => s.fontSize ?? defaults.fontSize));
+    expect(sizeOf(lines[0])).toBe(24);
+    expect(lines.slice(1).every((line) => sizeOf(line) === 11)).toBe(true);
 
-    // Measured height = sum of per-line leadings (NOT lineCount * globalMax).
-    const height = lines.reduce((h, l) => h + l.maxFontSize, 0);
-    expect(height).toBe(24 + 11 * (lines.length - 1));
+    // Each line is sized on its own, NOT on a paragraph-global maximum.
+    const box = (line: (typeof lines)[number]): number =>
+      lineBoxForSegmentLine(line, defaults, metrics).height;
+    expect(box(lines[0])).toBeGreaterThan(box(lines[1]));
+    const height = lines.reduce((h, l) => h + box(l), 0);
+    expect(height).toBeCloseTo(24 + 11 * (lines.length - 1)); // unitVerticals: 1 em per line
   });
 
   it("keeps a single over-wide word on one line (no phantom empty leading line)", () => {

--- a/tests/unit/text/line-height.test.ts
+++ b/tests/unit/text/line-height.test.ts
@@ -4,11 +4,13 @@ import { BoxConstraints } from "../../../src/lib/layout/box-constraints";
 import { LayoutContext } from "../../../src/lib/elements/pdf-element";
 import { FontMetrics } from "../../../src/lib/utils/font-metrics";
 import { Text } from "../../../src/lib/api";
+import { unitVerticals } from "../support/metrics";
 
 // Every glyph (and the space) is 10pt wide -> "alfa" = 40pt; at width 50 each word lands on its line.
 const metrics = {
   getStringWidth: (t: string) => t.length * 10,
   getCharWidth: () => 10,
+  getFontVerticals: unitVerticals,
 } as unknown as FontMetrics;
 
 const CONTENT = "alfa bram char dent emil"; // wraps to 5 lines at width 50
@@ -25,8 +27,30 @@ describe("lineHeight", () => {
     expect(roomy.getProps().height).toBe(75); // 5 lines x 10 x 1.5
   });
 
-  it("defaults to 1 and flows through the factory", () => {
-    expect(Text("hi").getProps().lineHeight).toBe(1);
+  it("is unset by default (the font's natural line height) and flows through the factory", () => {
+    // Unset does NOT mean 1: it means `ascent + descent + lineGap`, resolved per font at layout
+    // time. Only an explicit value is a multiplier of the font size.
+    expect(Text("hi").getProps().lineHeight).toBeUndefined();
     expect(Text("hi", { lineHeight: 1.4 }).getProps().lineHeight).toBe(1.4);
+  });
+
+  it("unset falls back to the font's own metrics, not to 1", () => {
+    // A face that asks for 0.9 up, 0.3 down and 0.1 of lineGap wants a 1.3 em line box. A 1 em box
+    // would be tighter than the font itself declares - which is exactly what the old hard-coded
+    // baseline constant did to every embedded font.
+    const tall = {
+      getStringWidth: (t: string) => t.length * 10,
+      getCharWidth: () => 10,
+      getFontVerticals: () => ({ ascent: 0.9, descent: 0.3, lineGap: 0.1 }),
+    } as unknown as FontMetrics;
+    const ctx = { metrics: tall, pageConfig: {} } as LayoutContext;
+
+    const natural = new TextElement({ fontSize: 10, content: CONTENT });
+    natural.calculateLayout(BoxConstraints.loose(50, Infinity), { x: 0, y: 0 }, ctx);
+    expect(natural.getProps().height).toBeCloseTo(65); // 5 lines x 10 x 1.3
+
+    const explicit = new TextElement({ fontSize: 10, content: CONTENT, lineHeight: 1 });
+    explicit.calculateLayout(BoxConstraints.loose(50, Infinity), { x: 0, y: 0 }, ctx);
+    expect(explicit.getProps().height).toBe(50); // an explicit 1 still means exactly 1 em
   });
 });

--- a/tests/unit/text/line-metrics.test.ts
+++ b/tests/unit/text/line-metrics.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { lineBoxFor } from "../../../src/lib/text/line-metrics";
+import { PDFObjectManager, FontStyle } from "../../../src/lib/utils/pdf-object-manager";
+
+// ISSUE-5: the baseline used to be a hard-coded 683/1000 - Times-Roman's `Ascender`, applied to
+// every face - and the line box was assumed to be 1 em tall while a font's content is
+// `ascent + descent`. Both numbers now come out of the font itself.
+//
+// And `Ascender` was the wrong LINE metric to reach for even for Times: it is the height of the
+// ascender LETTERS (b, d, h), not how far a line must reach to clear an accented capital. The
+// standard-14 line metric is the `FontBBox`, which is what TrueType's `hhea.ascent` corresponds to.
+// Using it puts capitals optically centred, matching a browser to within a third of a point.
+
+const om = () => {
+  const m = new PDFObjectManager();
+  m.registerFont("Helvetica", FontStyle.Normal, "Helvetica");
+  m.registerFont("Times-Roman", FontStyle.Normal, "Times-Roman");
+  m.registerFont("Courier", FontStyle.Normal, "Courier");
+  return m;
+};
+
+describe("font verticals come from the font, not from a constant", () => {
+  it("takes each standard-14 face's line metric from its FontBBox", () => {
+    const m = om();
+    // Helvetica AFM: FontBBox -166 -225 1000 931. (Its `Ascender 718` is the height of b/d/h.)
+    const helv = m.getFontVerticals("Helvetica", FontStyle.Normal);
+    expect(helv.ascent).toBeCloseTo(0.931);
+    expect(helv.descent).toBeCloseTo(0.225);
+    expect(helv.lineGap).toBe(0); // the bbox already IS the full extent
+
+    // Times-Roman: FontBBox -168 -218 1000 898. Courier: -23 -250 715 805.
+    expect(m.getFontVerticals("Times-Roman", FontStyle.Normal).ascent).toBeCloseTo(0.898);
+    expect(m.getFontVerticals("Courier", FontStyle.Normal).ascent).toBeCloseTo(0.805);
+  });
+
+  it("no longer seats every face at Times-Roman's 0.683 ascender", () => {
+    const m = om();
+    for (const family of ["Helvetica", "Times-Roman", "Courier"]) {
+      expect(m.getFontVerticals(family, FontStyle.Normal).ascent).not.toBeCloseTo(0.683);
+    }
+  });
+
+  it("leaves room above the capitals, about as much as the descent below", () => {
+    // This is what makes an all-caps word sit optically centred (Chrome and react-pdf agree).
+    const m = om();
+    const CAP_HEIGHT = 0.718; // Helvetica's capitals
+    const { ascent, descent } = m.getFontVerticals("Helvetica", FontStyle.Normal);
+    const aboveCaps = ascent - CAP_HEIGHT;
+    expect(aboveCaps).toBeGreaterThan(0);
+    expect(Math.abs(aboveCaps - descent)).toBeLessThan(0.04); // 0.213 vs 0.225
+  });
+});
+
+describe("lineBoxFor", () => {
+  // Helvetica's FontBBox, as `getFontVerticals` reports it.
+  const helvetica = { ascent: 0.931, descent: 0.225, lineGap: 0 };
+
+  it("centres the content in its box: the air above equals the air below", () => {
+    const { height, baseline } = lineBoxFor([{ verticals: helvetica, fontSize: 60 }]);
+    const airAbove = baseline - helvetica.ascent * 60;
+    const airBelow = height - baseline - helvetica.descent * 60;
+    expect(airAbove).toBeCloseTo(airBelow);
+  });
+
+  it("an unset lineHeight is the font's natural line height", () => {
+    const { height } = lineBoxFor([{ verticals: helvetica, fontSize: 100 }]);
+    expect(height).toBeCloseTo(115.6); // 931 + 225
+  });
+
+  it("seats the baseline at the ascent when the box has no leading to split", () => {
+    const { baseline } = lineBoxFor([{ verticals: helvetica, fontSize: 100 }]);
+    expect(baseline).toBeCloseTo(93.1); // NOT 68.3, which is what the old constant gave
+  });
+
+  it("an explicit lineHeight is a multiplier of the font size, and still half-leads", () => {
+    const { height, baseline } = lineBoxFor([{ verticals: helvetica, fontSize: 10 }], 1.8);
+    expect(height).toBeCloseTo(18);
+    // half-leading against the REAL content height (1.156 em), not against 1 em:
+    // (18 - 11.56) / 2 + 9.31 = 12.53
+    expect(baseline).toBeCloseTo(12.53);
+  });
+
+  it("a box tighter than the content overflows evenly, as CSS does", () => {
+    const { height, baseline } = lineBoxFor([{ verticals: helvetica, fontSize: 10 }], 0.5);
+    expect(height).toBe(5);
+    const airAbove = baseline - 9.31;
+    const airBelow = height - baseline - 2.25;
+    expect(airAbove).toBeCloseTo(airBelow); // both negative, symmetric
+    expect(airAbove).toBeLessThan(0);
+  });
+
+  it("a mixed-font line takes the tallest ascent and the deepest descent on it", () => {
+    const small = { ascent: 0.7, descent: 0.2, lineGap: 0 };
+    const deep = { ascent: 0.5, descent: 0.6, lineGap: 0 };
+    const { height, baseline } = lineBoxFor([
+      { verticals: small, fontSize: 10 },
+      { verticals: deep, fontSize: 10 },
+    ]);
+    expect(baseline).toBeCloseTo(7); // the tallest ascent seats the baseline
+    expect(height).toBeCloseTo(13); // 7 up + 6 down: the deep descender still fits
+  });
+});

--- a/tests/unit/text/text-fragment.test.ts
+++ b/tests/unit/text/text-fragment.test.ts
@@ -4,12 +4,14 @@ import { TextSegment } from "../../../src/lib/elements/text-element";
 import { LayoutContext } from "../../../src/lib/elements/pdf-element";
 import { BoxConstraints } from "../../../src/lib/layout/box-constraints";
 import type { FontMetrics } from "../../../src/lib/utils/font-metrics";
+import { unitVerticals } from "../support/metrics";
 
 // Deterministic metrics: each glyph is 10 wide, spaces are 0. With six 2-char words and
 // maxWidth 50 the greedy breaker yields three lines of two words each.
 const metrics: FontMetrics = {
   getStringWidth: (text) => text.length * 10,
   getCharWidth: () => 0,
+  getFontVerticals: unitVerticals,
 };
 const ctx = { metrics } as LayoutContext;
 

--- a/tests/unit/text/text-truncation.test.ts
+++ b/tests/unit/text/text-truncation.test.ts
@@ -6,11 +6,13 @@ import { LayoutContext } from "../../../src/lib/elements/pdf-element";
 import { FontStyle } from "../../../src/lib/utils/pdf-object-manager";
 import { FontMetrics } from "../../../src/lib/utils/font-metrics";
 import { Text } from "../../../src/lib/api";
+import { unitVerticals } from "../support/metrics";
 
 // Every glyph (and the space) is 10pt wide, no kerning -> "alfa" = 40pt. Deterministic wrapping.
 const metrics = {
   getStringWidth: (t: string) => t.length * 10,
   getCharWidth: () => 10,
+  getFontVerticals: unitVerticals,
 } as unknown as FontMetrics;
 
 const wrap = (text: string, maxWidth: number, maxLines?: number, overflow?: "clip" | "ellipsis") =>


### PR DESCRIPTION
## Summary

The text was wrong calculated and sits a bit too high in its line. The Hxg (what we using to calc this) was wrong. Now it is fixed and "all" fonts, including defaults, are now calculated correctly

## Related issue(s)

Closes #16 

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [ ] Docs updated if needed
