### PR TITLE
fix: positioned element position in header/footer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,6 +356,12 @@ Genuine remaining gaps / deferred:
    positioning frame (the page is one too); `Positioned({ top,left,right,bottom }, child)` is out-of-flow
    and anchors to the nearest frame (negative offsets poke out); `Box({ overflow: "hidden" })` crops its
    children to the rounded box (an image in one is round-cropped for free). Tests + gallery `10-positioning`.
+   The page's frame is its **content box** — built in `PageElement.calculateLayout` BEFORE `layoutPageBands`
+   and threaded into header, footer and body alike (`pageFrame(config)`), so `Positioned` means the same
+   thing in all three and `bottom: 0` is the foot of the page, not the top of the footer. That is what makes
+   **watermarks / draft stamps** work: a `Positioned` in a band repeats on every page and takes no space in
+   it (gallery `18-watermark`; this is react-pdf's `fixed`). With no frame at all a `Positioned` now THROWS
+   — it used to leave its child at (0,0) and silently draw it in the page corner (ISSUE-4).
    Remaining: **`z-index`** (Stage 3, paint order within a frame) and a public `measure()` helper. See
    `todo.md` "Absolute-positioning layer".
 2. **`slice` border mode** (a split box left open at the break) — `clone` is the default; needs per-side

--- a/src/lib/api/layout.ts
+++ b/src/lib/api/layout.ts
@@ -171,11 +171,16 @@ export function Padding(padding: Insets, child: PDFElement): PaddingElement {
 }
 
 /**
- * Places a child OUT OF FLOW, relative to the nearest enclosing `relative` Box. Two ways, pick per
- * axis: pin to EDGES - `Positioned({ top, left, right, bottom }, child)`, where a negative value
- * pokes into / out of the corner (a badge, a tab, a ribbon) and pinning both sides stretches; or
- * ANCHOR + nudge - `Positioned({ h: "center", v: "end", x: -10, y: -8 }, child)`, i.e. centered /
- * end-aligned with a pixel offset. An edge wins over an anchor on the same axis.
+ * Places a child OUT OF FLOW, relative to the nearest enclosing `relative` Box - or, with none, to
+ * the page's content box. Two ways, pick per axis: pin to EDGES - `Positioned({ top, left, right,
+ * bottom }, child)`, where a negative value pokes into / out of the corner (a badge, a tab, a
+ * ribbon) and pinning both sides stretches; or ANCHOR + nudge - `Positioned({ h: "center", v: "end",
+ * x: -10, y: -8 }, child)`, i.e. centered / end-aligned with a pixel offset. An edge wins over an
+ * anchor on the same axis.
+ *
+ * A `Positioned` in a `Page`'s `header` or `footer` repeats on EVERY page and takes no space in the
+ * band, which is how you draw a watermark, a draft stamp or a corner ribbon across a document. It
+ * anchors to the page, not to the band, so `bottom: 0` is the foot of the page.
  */
 export function Positioned(opts: PositionedInsets, child: PDFElement): PositionedElement {
   return new PositionedElement({ child, ...opts });

--- a/src/lib/elements/layout/positioned-element.ts
+++ b/src/lib/elements/layout/positioned-element.ts
@@ -78,7 +78,12 @@ export class PositionedElement extends PDFElement {
     const constraints = BoxConstraints.loose(width, height);
 
     // Measure first (so end/center anchors and right/bottom edges resolve against the child's size).
-    const measured = this.child.calculateLayout(constraints, { x: 0, y: 0 }, ctx);
+    // The measuring pass gets a throwaway `place` list: this subtree is laid out twice, and a nested
+    // out-of-flow child would otherwise register its placement on both passes.
+    const measureCtx: LayoutContext = ctx.frame
+      ? { ...ctx, frame: { ...ctx.frame, place: [] } }
+      : ctx;
+    const measured = this.child.calculateLayout(constraints, { x: 0, y: 0 }, measureCtx);
 
     // Resolve one axis: a near-edge pins to origin, a far-edge pins to the far side; otherwise the
     // anchor (default `start`) positions the child and the nudge shifts it from there.

--- a/src/lib/elements/layout/positioned-element.ts
+++ b/src/lib/elements/layout/positioned-element.ts
@@ -26,14 +26,17 @@ export interface PositionedInsets {
 interface PositionedElementParams extends WithChild, PositionedInsets {}
 
 /**
- * An out-of-flow child, placed relative to the nearest enclosing positioning frame (a `relative`
- * Box). It takes ZERO space in the normal flow - `calculateLayout` returns `Size(0,0)` and instead
- * registers a placement closure on the frame. The frame runs that closure once it knows its own
- * size, so `right`/`bottom` resolve against the final box and the child can overflow it (a negative
- * `top`/`left` makes it poke into / out of the corner, e.g. a badge or tab).
+ * An out-of-flow child, placed relative to the nearest enclosing positioning frame: a `relative`
+ * Box, or failing that the page's content box. It takes ZERO space in the normal flow -
+ * `calculateLayout` returns `Size(0,0)` and instead registers a placement closure on the frame. The
+ * frame runs that closure once it knows its own size, so `right`/`bottom` resolve against the final
+ * box and the child can overflow it (a negative `top`/`left` makes it poke into / out of the
+ * corner, e.g. a badge or tab).
  *
- * With no frame in scope the element is a no-op (nothing is drawn) - `Positioned` only makes sense
- * inside a `relative` Box.
+ * Every page supplies a frame - header, footer and body alike - so within a document there is
+ * always one. Outside of one we REFUSE rather than draw: the element used to fall through to its
+ * child's default (0, 0), which is how a header watermark landed silently in the page corner
+ * (ISSUE-4). Content that lands somewhere unasked is worse than content that does not render.
  */
 export class PositionedElement extends PDFElement {
   private child: PDFElement;
@@ -46,8 +49,14 @@ export class PositionedElement extends PDFElement {
   }
 
   calculateLayout(_constraints: BoxConstraints, _offset: Offset, ctx: LayoutContext): Size {
+    if (!ctx.frame) {
+      throw new Error(
+        "Positioned found no positioning frame. It must sit inside a Page (header, footer or body) " +
+          "or inside a Box({ relative: true }).",
+      );
+    }
     // Defer to the frame: it calls back once it has sized itself. Out of flow either way.
-    ctx.frame?.place.push((frame, frameCtx) => this.placeInFrame(frame, frameCtx));
+    ctx.frame.place.push((frame, frameCtx) => this.placeInFrame(frame, frameCtx));
     return { width: 0, height: 0 };
   }
 

--- a/src/lib/elements/page-element.ts
+++ b/src/lib/elements/page-element.ts
@@ -72,6 +72,20 @@ export interface PageBands {
  * no header/footer the bands are zero and the body equals the full content box - identical
  * to a page without them.
  */
+/**
+ * The page's positioning frame: its CONTENT box (paper minus margins). Header, footer and body all
+ * resolve a `Positioned` against this same box, so `top`/`bottom` mean the same thing in each.
+ *
+ * `layoutPageBands` lays the bands out, so its caller must hand it a context carrying this frame -
+ * otherwise a `Positioned` in a band has nothing to resolve against (ISSUE-4). A caller that only
+ * wants the band HEIGHTS may throw the frame away without draining it: an out-of-flow child
+ * contributes no height.
+ */
+export function pageFrame(config: PDFPageConfig): PositioningFrame {
+  const { origin, width, height } = resolvePageContentBox(config);
+  return { origin, size: { width, height }, place: [] };
+}
+
 export function layoutPageBands(
   config: PDFPageConfig,
   header: PDFElement | undefined,
@@ -140,27 +154,32 @@ export class PageElement extends PDFElement {
       pageInfo: ctx.pageInfo, // the render pass supplies it; absent during pagination
     };
 
+    // The PAGE is a positioning frame, and the frame is the content box - not the body region left
+    // over between the bands. So `Positioned` means the same thing in the header, in the footer and
+    // in the body, `bottom: 0` is the foot of the page rather than the top of the footer, and adding
+    // a header no longer shifts a page-level `Positioned` that nobody touched. A `relative` Box
+    // still overrides it for its own subtree.
+    //
+    // Built BEFORE the bands are laid out: they need to see it, and their heights are not known yet
+    // anyway. (That is the whole of ISSUE-4 - a `Positioned` in a band had no frame to resolve
+    // against, so it silently stayed at the page's top-left corner.)
+    const frame = pageFrame(this.config);
+    const frameCtx: LayoutContext = { ...pageCtx, frame };
+
     // Place the header/footer bands; the body gets the region left in between (the whole
     // content box when there is neither - byte-identical to a plain page).
-    const bands = layoutPageBands(this.config, this.header, this.footer, pageCtx);
+    const bands = layoutPageBands(this.config, this.header, this.footer, frameCtx);
     const childConstraints = BoxConstraints.loose(bands.bodyWidth, bands.bodyHeight);
 
-    // The page body is itself a positioning frame: a `Positioned` with no `relative` ancestor
-    // resolves against the content box (a `relative` Box overrides it for its own subtree). Drained
-    // after the body is laid out, so a page-level Positioned isn't a silent no-op.
-    const frame: PositioningFrame = {
-      origin: bands.bodyOrigin,
-      size: { width: bands.bodyWidth, height: bands.bodyHeight },
-      place: [],
-    };
-    const bodyCtx: LayoutContext = { ...pageCtx, frame };
     this.children.forEach((child) =>
-      child.calculateLayout(childConstraints, bands.bodyOrigin, bodyCtx),
+      child.calculateLayout(childConstraints, bands.bodyOrigin, frameCtx),
     );
+
+    // Drained last, once every band and the body have registered: an out-of-flow child is placed
+    // against the final frame box and paints on top of the flow content.
     for (const place of frame.place) place(frame, pageCtx);
 
-    const { width, height } = resolvePageContentBox(this.config);
-    return { width, height };
+    return { width: frame.size.width, height: frame.size.height };
   }
 
   override getProps(): PDFPageParams {

--- a/src/lib/elements/page-element.ts
+++ b/src/lib/elements/page-element.ts
@@ -105,11 +105,16 @@ export function layoutPageBands(
 
   let footerHeight = 0;
   if (footer) {
-    // Measure first to learn its height, then place it flush against the bottom edge.
+    // Measure first to learn its height, then place it flush against the bottom edge. The MEASURING
+    // pass gets a throwaway `place` list: an out-of-flow child registers a placement every time it is
+    // laid out, and this subtree is laid out twice. Only the second, real pass may register.
+    const measureCtx: LayoutContext = ctx.frame
+      ? { ...ctx, frame: { ...ctx.frame, place: [] } }
+      : ctx;
     footerHeight = footer.calculateLayout(
       BoxConstraints.loose(width, Infinity),
       origin,
-      ctx,
+      measureCtx,
     ).height;
     footer.calculateLayout(
       BoxConstraints.loose(width, Infinity),
@@ -177,7 +182,11 @@ export class PageElement extends PDFElement {
 
     // Drained last, once every band and the body have registered: an out-of-flow child is placed
     // against the final frame box and paints on top of the flow content.
-    for (const place of frame.place) place(frame, pageCtx);
+    //
+    // The callback gets `frameCtx`, not `pageCtx`: a `Positioned` NESTED inside an out-of-flow child
+    // must still see a frame. It appends to `frame.place` while we walk it, and a `for..of` over an
+    // array visits what was appended, so nested placements drain in the same loop.
+    for (const place of frame.place) place(frame, frameCtx);
 
     return { width: frame.size.width, height: frame.size.height };
   }

--- a/src/lib/renderer/pdf-document-renderer.ts
+++ b/src/lib/renderer/pdf-document-renderer.ts
@@ -1,6 +1,7 @@
 import { PDFDocumentElement } from "../elements/pdf-document-element.ts";
 import {
   layoutPageBands,
+  pageFrame,
   PageElement,
   PDFPageConfig,
   resolvePageSize,
@@ -106,11 +107,15 @@ export class PDFDocumentRenderer {
 
     // Header/footer repeat on every physical page, so the body only ever flows into the
     // band between them. Resolve that band once (config is already merged by pass 1).
+    // The frame is a throwaway: this pass only wants the band HEIGHTS, and an out-of-flow child
+    // contributes none. It exists because a `Positioned` in a band demands one; pass 2 builds the
+    // real frame (in `PageElement`) and drains it.
     const pageCtx: LayoutContext = {
       metrics: ctx.metrics,
       pageConfig: config!,
       textStyle: ctx.textStyle,
       onOverflow: ctx.onOverflow,
+      frame: pageFrame(config!),
     };
     const { bodyWidth: width, bodyHeight: height } = layoutPageBands(
       config!,

--- a/tests/unit/elements/positioned-element.test.ts
+++ b/tests/unit/elements/positioned-element.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { PositionedElement } from "../../../src/lib/elements/layout/positioned-element";
 import { RectangleElement } from "../../../src/lib/elements/rectangle-element";
 import { ContainerElement } from "../../../src/lib/elements/container-element";
-import { PageElement } from "../../../src/lib/elements/page-element";
+import { layoutPageBands, PageElement, pageFrame } from "../../../src/lib/elements/page-element";
 import { RectangleRenderer } from "../../../src/lib/renderer/rectangle-renderer";
 import { LayoutContext } from "../../../src/lib/elements/pdf-element";
 import { BoxConstraints } from "../../../src/lib/layout/box-constraints";
@@ -22,6 +22,7 @@ const ctx = { metrics } as LayoutContext;
 // never drained: they assert what the element does NOT do to the flow, not where the child lands.
 const ctxWithFrame = {
   metrics,
+  pageConfig: {},
   frame: { origin: { x: 0, y: 0 }, size: { width: 100, height: 100 }, place: [] },
 } as LayoutContext;
 
@@ -190,6 +191,57 @@ describe("PositionedElement - the page is the default frame", () => {
     pageWith({ footer: new PositionedElement({ child, bottom: 0, right: 0 }) });
     expect(child.getSize().x).toBe(A4_CONTENT.right - 20);
     expect(child.getSize().y).toBe(A4_CONTENT.bottom - 10);
+  });
+
+  it("registers a band's placement ONCE, though the footer subtree is laid out twice", () => {
+    // `layoutPageBands` measures the footer to learn its height, then lays it out again at the
+    // bottom edge. Without a throwaway frame for the measuring pass, its `Positioned` registers on
+    // both and the child is placed twice.
+    const config = {
+      pageSize: PageSize.A4,
+      orientation: Orientation.portrait,
+      margin: { top: 50, right: 50, bottom: 50, left: 50 },
+    };
+    for (const band of ["header", "footer"] as const) {
+      const frame = pageFrame(config);
+      const positioned = new PositionedElement({ child: fixed(20, 10), top: 5, left: 5 });
+      layoutPageBands(
+        config,
+        band === "header" ? positioned : undefined,
+        band === "footer" ? positioned : undefined,
+        { metrics, pageConfig: {}, frame } as LayoutContext,
+      );
+      expect(frame.place, `${band} registered more than once`).toHaveLength(1);
+    }
+  });
+
+  it("resolves a Positioned nested inside another one, against the page", () => {
+    // The drain loop must hand the callback a context that still carries the frame, and must pick up
+    // the placements appended while it walks. Otherwise the inner one throws (or, before the throw
+    // existed, silently drew in the page corner).
+    const inner = fixed(10, 10);
+    const outer = new RectangleElement({
+      x: 0,
+      y: 0,
+      width: 40,
+      height: 40,
+      borderWidth: 0,
+      children: [new PositionedElement({ child: inner, top: 10, left: 10 })],
+    });
+    new PageElement({
+      children: [new PositionedElement({ child: outer, top: 100, left: 100 })],
+      config: {
+        pageSize: PageSize.A4,
+        orientation: Orientation.portrait,
+        margin: { top: 50, right: 50, bottom: 50, left: 50 },
+      },
+    }).calculateLayout(new BoxConstraints(), { x: 0, y: 0 }, {
+      metrics,
+      pageConfig: {},
+    } as LayoutContext);
+    // The page is the nearest frame (the outer Positioned is not one), so 50 + 10 on both axes.
+    expect(inner.getSize().x).toBe(60);
+    expect(inner.getSize().y).toBe(60);
   });
 
   it("keeps a body Positioned put when a header is added (the frame is the page, not the body band)", () => {

--- a/tests/unit/elements/positioned-element.test.ts
+++ b/tests/unit/elements/positioned-element.test.ts
@@ -18,6 +18,12 @@ const metrics: FontMetrics = {
   getFontVerticals: unitVerticals,
 };
 const ctx = { metrics } as LayoutContext;
+// A `Positioned` refuses to lay out without a frame, so the out-of-flow tests below need one. It is
+// never drained: they assert what the element does NOT do to the flow, not where the child lands.
+const ctxWithFrame = {
+  metrics,
+  frame: { origin: { x: 0, y: 0 }, size: { width: 100, height: 100 }, place: [] },
+} as LayoutContext;
 
 // A fixed-size box with no border, easy to read coordinates off via getSize().
 const fixed = (width: number, height: number) =>
@@ -37,7 +43,11 @@ const frame = (opts: { width: number; height: number }, children: PositionedElem
 describe("PositionedElement - out of flow", () => {
   it("takes zero space in the normal flow", () => {
     const positioned = new PositionedElement({ child: fixed(20, 10), top: 0, left: 0 });
-    const size = positioned.calculateLayout(BoxConstraints.loose(100, 100), { x: 0, y: 0 }, ctx);
+    const size = positioned.calculateLayout(
+      BoxConstraints.loose(100, 100),
+      { x: 0, y: 0 },
+      ctxWithFrame,
+    );
     expect(size).toEqual({ width: 0, height: 0 });
   });
 
@@ -48,10 +58,19 @@ describe("PositionedElement - out of flow", () => {
       x: 0,
       y: 0,
       children: [a, new PositionedElement({ child: fixed(50, 50), top: 0, left: 0 }), b],
-    }).calculateLayout(BoxConstraints.loose(100, Infinity), { x: 0, y: 0 }, ctx);
+    }).calculateLayout(BoxConstraints.loose(100, Infinity), { x: 0, y: 0 }, ctxWithFrame);
     // b sits directly below a (12), unaffected by the 50-tall Positioned between them.
     expect(a.getSize().y).toBe(0);
     expect(b.getSize().y).toBe(12);
+  });
+
+  it("refuses to lay out with no frame, instead of silently drawing at (0, 0)", () => {
+    // It used to fall through and leave the child at its default origin, which is how a header
+    // watermark landed in the page corner without a word (ISSUE-4).
+    const positioned = new PositionedElement({ child: fixed(20, 10), top: 50, left: 50 });
+    expect(() =>
+      positioned.calculateLayout(BoxConstraints.loose(100, 100), { x: 0, y: 0 }, ctx),
+    ).toThrow(/no positioning frame/);
   });
 });
 
@@ -135,9 +154,59 @@ describe("PositionedElement - the page is the default frame", () => {
       metrics,
       pageConfig: {},
     } as LayoutContext);
-    // Body origin = the top-left margin (50, 50); child = origin + (left, top).
+    // Content-box origin = the top-left margin (50, 50); child = origin + (left, top).
     expect(child.getSize().x).toBe(58);
     expect(child.getSize().y).toBe(55);
+  });
+
+  // ISSUE-4. A band used to be laid out BEFORE the frame existed, so a `Positioned` in it had
+  // nothing to resolve against and its child stayed at (0, 0) - a watermark in the page corner.
+  const A4_CONTENT = { top: 50, bottom: 791.89, left: 50, right: 545.28 }; // A4 minus a 50pt margin
+
+  const pageWith = (bands: { header?: PositionedElement; footer?: PositionedElement }): void => {
+    new PageElement({
+      children: [fixed(10, 10)],
+      config: {
+        pageSize: PageSize.A4,
+        orientation: Orientation.portrait,
+        margin: { top: 50, right: 50, bottom: 50, left: 50 },
+      },
+      ...bands,
+    }).calculateLayout(new BoxConstraints(), { x: 0, y: 0 }, {
+      metrics,
+      pageConfig: {},
+    } as LayoutContext);
+  };
+
+  it("anchors a Positioned in the HEADER to the page, exactly like one in the body", () => {
+    const child = fixed(20, 10);
+    pageWith({ header: new PositionedElement({ child, top: 5, left: 8 }) });
+    expect(child.getSize().x).toBe(A4_CONTENT.left + 8);
+    expect(child.getSize().y).toBe(A4_CONTENT.top + 5);
+  });
+
+  it("anchors a Positioned in the FOOTER to the page, so bottom:0 is the foot of the page", () => {
+    const child = fixed(20, 10);
+    pageWith({ footer: new PositionedElement({ child, bottom: 0, right: 0 }) });
+    expect(child.getSize().x).toBe(A4_CONTENT.right - 20);
+    expect(child.getSize().y).toBe(A4_CONTENT.bottom - 10);
+  });
+
+  it("keeps a body Positioned put when a header is added (the frame is the page, not the body band)", () => {
+    const child = fixed(20, 10);
+    new PageElement({
+      children: [new PositionedElement({ child, top: 5, left: 8 })],
+      header: fixed(100, 40), // 40pt of header used to push the frame - and the child - down with it
+      config: {
+        pageSize: PageSize.A4,
+        orientation: Orientation.portrait,
+        margin: { top: 50, right: 50, bottom: 50, left: 50 },
+      },
+    }).calculateLayout(new BoxConstraints(), { x: 0, y: 0 }, {
+      metrics,
+      pageConfig: {},
+    } as LayoutContext);
+    expect(child.getSize().y).toBe(A4_CONTENT.top + 5); // not 50 + 40 + 5
   });
 });
 


### PR DESCRIPTION
## Summary

Positioned element has wrong position inside header/footer. The box (relative) makes sense! But not that much inside header/footer - so the Positioned element now get a frame-context to calculate its position correctly.

Important: For all other scenarios Box relative must be use by design!

## Related issue(s)

Closes #18 

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [ ] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Positioned elements now anchor consistently to the same page content area in body, header, and footer.
  * Header/footer positioned elements repeat on every page while not consuming layout space (e.g., watermarks/draft stamps).
  * If a positioning reference isn’t available, positioned elements now fail with a clear error instead of rendering at the page origin.
* **Documentation**
  * Updated guidance on how the page “frame” reference is defined and reused across bands.
* **Tests**
  * Expanded coverage for header/footer anchoring, nested positioning, and missing-frame error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->