### PR TITLE
feat: add underline and strikethrough (including ink skip)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,10 +130,12 @@ reasoning from our own code.
 react-pdf hard-codes `ascent = 900` for every standard font, commented "based on empirical observation".
 That is a **rounded `FontBBox`**, not a guess. For embedded fonts it reads real `hhea` values, like we do.
 
-**Available and deliberately not parsed yet:** AFM gives `UnderlinePosition -100`, `UnderlineThickness 50`,
-`CapHeight`, `XHeight`. TrueType has the same in `post` and `OS/2` (`sxHeight`, `sCapHeight`) — `OS/2` is not
-parsed at all today. The planned `underline` / `strikethrough` / `letterSpacing` work needs these. Take them
-from the font. **Do not invent a constant** — that is exactly how `BASELINE_RATIO = 683/1000` happened.
+**Glyph metrics, for decoration** (parsed since 2026-07-10): AFM gives `UnderlinePosition -100`,
+`UnderlineThickness 50`, `CapHeight`, `XHeight`; TrueType the same in `post` + `OS/2` (`sxHeight`,
+`sCapHeight`, version ≥ 2, else measured off the `x`/`H` outline). Surfaced by
+`FontMetrics.getFontDecoration` and consumed by `text/text-decoration.ts` — kept in a SEPARATE module from
+`line-metrics.ts` precisely so a glyph metric can never again be used as a line metric. **Do not invent a
+constant** — that is exactly how `BASELINE_RATIO = 683/1000` happened. `letterSpacing` is still to come.
 
 ### State threading — explicit, no singleton (since roadmap Phase 2)
 
@@ -324,6 +326,17 @@ lineHeight, align, bold, italic }, …)` sets doc-wide text defaults; `DefaultTe
   (a 90/270 turn swaps w/h, so a vertical label reserves its strip). One IR pair `TransformPush{matrix}` /
   `TransformPop` → `q … cm … Q`; `flipY` conjugates the matrix (`M_pdf = F·M·F`) so producers stay
   coordinate-blind. Known gap: an annotation inside a transform does NOT rotate (see gap 6 below).
+- ✅ **Text decoration** (2026-07-10) — `Text({ underline, strikethrough })`, also per `span` and inheritable
+  from `Document`/`DefaultTextStyle`. The stroke sits at the font's `UnderlinePosition` and is
+  `UnderlineThickness` thick; a strikethrough crosses at half the `XHeight` (which is where Chrome puts it,
+  measured). One `Line` IR node per drawn run, so a wrapped paragraph gets one stroke per LINE and a
+  decorated span only spans its own glyphs. A `Link` is NOT underlined by default.
+  **`skipInk`** steps the underline around descenders (CSS `text-decoration-skip-ink`) by scanline-filling
+  the real glyph outlines (`TTFParser.inkSpansInBand`). Gap widths match Chrome to 1-2 px at 200 dpi
+  (`[25, 85, 192, 59, 120]` vs `[24, 85, 190, 58, 120]`). **react-pdf cannot do this at all** (verified: its
+  underline runs straight through `g` and `p`). It needs an EMBEDDED font — the standard-14 outlines live in
+  the viewer, not in the AFM — and asking for it with a standard font **throws** rather than silently drawing
+  a solid line. Gallery `19-text-decoration`; the skipInk specimen is `claude-data/out/decoration/`.
 - ✅ **Navigation** (2026-07-09, `@jasy/pdf@alpha.6`) — `Link({ href })` (external URL) or `Link({ to })`
   (internal jump); `href`/`to` on a `span` links just that run (one /Rect per wrapped line); `Anchor({ name })`
   is the jump target, resolved through the catalog `/Names /Dests` name tree, so a link may point at a page

--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -19,6 +19,10 @@ const textStyleProps = {
   bold: { type: Boolean, default: undefined },
   italic: { type: Boolean, default: undefined },
   color: colorProp,
+  underline: { type: Boolean, default: undefined },
+  strikethrough: { type: Boolean, default: undefined },
+  /** Step the underline around descenders. Needs an embedded font. */
+  skipInk: { type: Boolean, default: undefined },
 };
 // A link target. Shared by `<Text>`/`<Paragraph>` (links the whole run) and `<Span>` (links just that
 // run). NOT part of `textStyleProps`: `<Document>` and `<DefaultTextStyle>` set defaults, they cannot link.

--- a/src/lib/api/text.ts
+++ b/src/lib/api/text.ts
@@ -15,6 +15,15 @@ export interface TextStyle {
   bold?: boolean;
   italic?: boolean;
   color?: ColorInput;
+  /** Draw a line under the text. Its position and thickness come from the font, not from a guess.
+   *  A `Link` is NOT underlined automatically - say so if you want it. */
+  underline?: boolean;
+  /** Draw a line through the text, at half its x-height (where a browser puts it). */
+  strikethrough?: boolean;
+  /** Let the underline step around descenders, like a browser (`text-decoration-skip-ink`). Needs an
+   *  EMBEDDED font - the standard-14 outlines live in the viewer, so we cannot see where their ink
+   *  is. Asking for it with a standard font is an error, not a silent no-op. */
+  skipInk?: boolean;
   /** External URL - makes this run an inline hyperlink (a /Link annotation over its glyphs). On a
    *  `span` it links just that run; on a whole `Text` (plain string) it links the whole text. */
   href?: string;
@@ -89,6 +98,8 @@ export function span(text: string, style: TextStyle = {}): TextSegment {
         ? toFontStyle(style.bold, style.italic)
         : undefined,
     fontColor: style.color !== undefined ? toColor(style.color) : undefined,
+    underline: style.underline,
+    strikethrough: style.strikethrough,
     href: style.href,
     dest: style.to,
   };
@@ -120,6 +131,9 @@ export function Text(content: string | TextSegment[], opts: TextOptions = {}): T
     maxLines: opts.maxLines,
     overflow: opts.overflow,
     lineHeight: opts.lineHeight,
+    underline: opts.underline,
+    strikethrough: opts.strikethrough,
+    skipInk: opts.skipInk,
     role: opts.role,
   });
 }
@@ -139,6 +153,9 @@ export interface TextDefaults {
   color?: ColorInput;
   align?: "left" | "center" | "right";
   lineHeight?: number;
+  underline?: boolean;
+  strikethrough?: boolean;
+  skipInk?: boolean;
 }
 
 /** Maps the `Text`-style option names onto a partial engine `ResolvedTextStyle` (only the set
@@ -153,5 +170,8 @@ export function toTextStyleOverride(opts: TextDefaults): Partial<ResolvedTextSty
   if (opts.color !== undefined) style.color = toColor(opts.color);
   if (opts.align !== undefined) style.textAlignment = ALIGN[opts.align];
   if (opts.lineHeight !== undefined) style.lineHeight = opts.lineHeight;
+  if (opts.underline !== undefined) style.underline = opts.underline;
+  if (opts.strikethrough !== undefined) style.strikethrough = opts.strikethrough;
+  if (opts.skipInk !== undefined) style.skipInk = opts.skipInk;
   return style;
 }

--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -27,6 +27,9 @@ export interface TextSegment {
   href?: string;
   /** Internal named destination (an `Anchor`): this segment links to it (a /GoTo /Link annotation). */
   dest?: string;
+  /** Unset inherits the Text's own setting; `true`/`false` overrides it for this run only. */
+  underline?: boolean;
+  strikethrough?: boolean;
 }
 
 /** Accessibility role for the tagged structure tree: a heading level or a paragraph (the default). */
@@ -48,6 +51,12 @@ interface TextElementParams {
   /** Line-height multiplier: each line is `fontSize * lineHeight` tall. Unset means the font's
    *  natural line height (`ascent + descent + lineGap`), like CSS `line-height: normal`. */
   lineHeight?: number;
+  /** Draw a line under the text, at the position and thickness the font declares. */
+  underline?: boolean;
+  /** Draw a line through the text, at half its x-height. */
+  strikethrough?: boolean;
+  /** Let the underline step around descenders. Needs an embedded font. */
+  skipInk?: boolean;
   /** Accessibility role for the tagged structure tree (heading level or paragraph; default `"p"`). */
   role?: TextRole;
 }
@@ -61,6 +70,9 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
   private readonly rawColor?: Color;
   private readonly rawTextAlignment?: HorizontalAlignment;
   private readonly rawLineHeight?: number;
+  private readonly rawUnderline?: boolean;
+  private readonly rawStrikethrough?: boolean;
+  private readonly rawSkipInk?: boolean;
 
   // Resolved style (raw -> inherited -> built-in default). Seeded to the built-in default in the
   // constructor so the element is self-sufficient, then refined against the cascade at layout time.
@@ -70,6 +82,9 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
   private color!: Color;
   private textAlignment!: HorizontalAlignment;
   private lineHeight?: number; // undefined = the font's natural line height
+  private underline!: boolean;
+  private strikethrough!: boolean;
+  private skipInk!: boolean;
 
   private content: string | TextSegment[];
   private maxLines?: number;
@@ -86,6 +101,9 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     maxLines,
     overflow = "clip",
     lineHeight,
+    underline,
+    strikethrough,
+    skipInk,
     role,
   }: TextElementParams) {
     super({ x: 0, y: 0 });
@@ -97,6 +115,9 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     this.rawColor = color;
     this.rawTextAlignment = textAlignment;
     this.rawLineHeight = lineHeight;
+    this.rawUnderline = underline;
+    this.rawStrikethrough = strikethrough;
+    this.rawSkipInk = skipInk;
     this.content = content;
     this.maxLines = maxLines;
     this.overflow = overflow;
@@ -115,6 +136,9 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     this.color = this.rawColor ?? ts.color;
     this.textAlignment = this.rawTextAlignment ?? ts.textAlignment;
     this.lineHeight = this.rawLineHeight ?? ts.lineHeight;
+    this.underline = this.rawUnderline ?? ts.underline;
+    this.strikethrough = this.rawStrikethrough ?? ts.strikethrough;
+    this.skipInk = this.rawSkipInk ?? ts.skipInk;
   }
 
   /**
@@ -219,6 +243,9 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       maxLines: this.maxLines,
       overflow: this.overflow,
       lineHeight: this.lineHeight,
+      underline: this.underline,
+      strikethrough: this.strikethrough,
+      skipInk: this.skipInk,
       role: this.role,
     }).adoptStructId(this); // a wrapped remainder is the SAME logical paragraph (one P across pages)
   }
@@ -304,6 +331,9 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       maxLines: this.maxLines,
       overflow: this.overflow,
       lineHeight: this.lineHeight,
+      underline: this.underline,
+      strikethrough: this.strikethrough,
+      skipInk: this.skipInk,
       role: this.role,
     };
   }

--- a/src/lib/renderer/text-renderer.ts
+++ b/src/lib/renderer/text-renderer.ts
@@ -10,7 +10,7 @@ import type {
   TTFParser,
   ColorGlyphLayer,
 } from "../utils/ttf-parser.ts";
-import { IRNode, TextRun, PathCommand, Gradient, Link } from "../ir/display-list.ts";
+import { IRNode, TextRun, PathCommand, Gradient, Line, Link } from "../ir/display-list.ts";
 import { isEmojiCodePoint } from "../text/emoji-codepoints.ts";
 import { emojiImageNode } from "./emoji-image.ts";
 import {
@@ -20,6 +20,12 @@ import {
   TextOverflow,
 } from "../text/line-breaker.ts";
 import { lineBoxForSegmentLine, lineBoxForString } from "../text/line-metrics.ts";
+import {
+  DecorationStroke,
+  skipInkSegments,
+  strikethroughStroke,
+  underlineStroke,
+} from "../text/text-decoration.ts";
 
 export class TextRenderer {
   // Measuring only needs metrics, not the full object manager. (The render pass below
@@ -85,13 +91,16 @@ export class TextRenderer {
       maxLines,
       overflow,
       lineHeight,
+      underline,
+      strikethrough,
+      skipInk,
       role,
     } = textElement.getProps();
 
     // Component -> display list. Wrapping and positioning stay here; the backend
     // turns each run into BT/Tf/Td/Tj/ET. The wrapping algorithm is unchanged from
     // the original renderer - unifying it into the engine is Phase 3.
-    const { runs, links } = TextRenderer._buildRuns(
+    const { runs, links, decorations } = TextRenderer._buildRuns(
       content,
       fontSize,
       fontFamily,
@@ -105,6 +114,9 @@ export class TextRenderer {
       maxLines,
       overflow,
       lineHeight,
+      underline,
+      strikethrough,
+      skipInk,
     );
 
     // Accessible tagging: this whole text block is one structure element (a paragraph P, or a heading
@@ -121,9 +133,11 @@ export class TextRenderer {
     const drawn = (
       await Promise.all(runs.map((run) => TextRenderer._expandColorGlyphs(run, objectManager)))
     ).flat();
+    // Underline / strikethrough go on TOP of the glyphs (a strikethrough must), and stay untagged,
+    // so the structure tree treats them as artifacts rather than as text.
     // Inline hyperlinks (href spans) ride along as /Link annotations - they draw nothing, so order
     // vs the drawn runs does not matter; the page renderer peels them off into /Annots.
-    return links.length > 0 ? [...drawn, ...links] : drawn;
+    return [...drawn, ...decorations, ...links];
   }
 
   // Splits a text run into normal text sub-runs + filled `Path` layers for any COLR color glyphs,
@@ -331,17 +345,106 @@ export class TextRenderer {
     maxLines?: number,
     overflow?: TextOverflow,
     lineHeight?: number,
-  ): { runs: TextRun[]; links: Link[] } {
+    underline = false,
+    strikethrough = false,
+    skipInk = false,
+  ): { runs: TextRun[]; links: Link[]; decorations: Line[] } {
     const runs: TextRun[] = [];
     // /Link annotation rects for any `href` spans, collected as we place segments. Empty for the
     // common (no-href) case, so plain text keeps producing exactly the runs it did before.
     const links: Link[] = [];
+    // Underline / strikethrough strokes, one per decorated run (so a wrapped paragraph gets one
+    // per line, and a decorated span only spans its own glyphs).
+    const decorations: Line[] = [];
 
     // Horizontal offset of a line of the given width under the current alignment.
     const alignmentOffset = (lineWidth: number): number => {
       if (textAlignment === HorizontalAlignment.center) return (maxWidth - lineWidth) / 2;
       if (textAlignment === HorizontalAlignment.right) return maxWidth - lineWidth;
       return 0;
+    };
+
+    // The decoration strokes for one drawn run, at the geometry ITS OWN font declares. A mixed-size
+    // line therefore gets a thicker line under the bigger span, which is what a browser does too.
+    const decorate = (
+      text: string,
+      runX: number,
+      runWidth: number,
+      baselineY: number,
+      family: string,
+      style: FontStyle,
+      size: number,
+      runColor: Color,
+      wantsUnderline: boolean,
+      wantsStrikethrough: boolean,
+    ): void => {
+      if ((!wantsUnderline && !wantsStrikethrough) || runWidth <= 0) return;
+      const metrics = objectManager.getFontDecoration(family, style);
+
+      const push = (from: number, to: number, stroke: DecorationStroke): void => {
+        decorations.push({
+          type: "line",
+          x1: runX + from,
+          y1: stroke.y,
+          x2: runX + to,
+          y2: stroke.y,
+          stroke: runColor,
+          strokeWidth: stroke.thickness,
+        });
+      };
+
+      if (wantsUnderline) {
+        const stroke = underlineStroke(metrics, size, baselineY);
+        for (const [from, to] of underlineSegments(
+          text,
+          runWidth,
+          baselineY,
+          size,
+          family,
+          style,
+          stroke,
+        )) {
+          push(from, to, stroke);
+        }
+      }
+      // A strikethrough crosses the letters by definition, so it is never interrupted.
+      if (wantsStrikethrough) {
+        const stroke = strikethroughStroke(metrics, size, baselineY);
+        push(0, runWidth, stroke);
+      }
+    };
+
+    // The x-ranges the underline actually draws. Without `skipInk` that is the whole run; with it,
+    // the descenders are cut out of it (which needs the real outlines, i.e. an embedded font).
+    const underlineSegments = (
+      text: string,
+      runWidth: number,
+      baselineY: number,
+      size: number,
+      family: string,
+      style: FontStyle,
+      stroke: DecorationStroke,
+    ): Array<[number, number]> => {
+      if (!skipInk) return [[0, runWidth]];
+      if (!objectManager.isCustomFont(family, style)) {
+        throw new Error(
+          `skipInk needs an embedded font, but "${family}" is a standard-14 font whose glyph outlines ` +
+            `live in the PDF viewer, not in the document - we cannot see where its ink is. Register a ` +
+            `font (the document's \`fonts\` option) or drop \`skipInk\`.`,
+        );
+      }
+      // The band the stroke covers, in points from the baseline, y UP (so both values are negative).
+      const below = stroke.y - baselineY;
+      const half = stroke.thickness / 2;
+      const inkSpans = objectManager.getInkSpansInBand(
+        text,
+        size,
+        family,
+        style,
+        -below + half,
+        -below - half,
+      );
+      return skipInkSegments(runWidth, inkSpans, stroke.thickness);
     };
 
     // Advance width WITHOUT kerning. This is how Tj moves the text cursor, so
@@ -377,18 +480,32 @@ export class TextRenderer {
       const box = lineBoxForString(objectManager, fontFamily, fontStyle, fontSize, lineHeight);
       lines.forEach((line, index) => {
         const lineWidth = objectManager.getStringWidth(line, fontFamily, fontSize, fontStyle);
+        const x = initialX + alignmentOffset(lineWidth);
+        const baseline = yPosition + box.baseline + box.height * index;
         runs.push({
           type: "text",
-          x: initialX + alignmentOffset(lineWidth),
-          y: yPosition + box.baseline + box.height * index,
+          x,
+          y: baseline,
           text: line,
           fontFamily,
           fontStyle,
           fontSize,
           color,
         });
+        decorate(
+          line,
+          x,
+          lineWidth,
+          baseline,
+          fontFamily,
+          fontStyle,
+          fontSize,
+          color,
+          underline,
+          strikethrough,
+        );
       });
-      return { runs, links };
+      return { runs, links, decorations };
     }
 
     // --- Segments: break into lines (shared breaker), then emit one run per segment.
@@ -403,6 +520,7 @@ export class TextRenderer {
         const size = segment.fontSize || fontSize;
         const style = segment.fontStyle || fontStyle;
         const advance = advanceNoKerning(segment.content, family, size, style);
+        const runColor = segment.fontColor || color;
         runs.push({
           type: "text",
           x,
@@ -411,8 +529,20 @@ export class TextRenderer {
           fontFamily: family,
           fontStyle: style,
           fontSize: size,
-          color: segment.fontColor || color,
+          color: runColor,
         });
+        decorate(
+          segment.content,
+          x,
+          advance,
+          lineY,
+          family,
+          style,
+          size,
+          runColor,
+          segment.underline ?? underline,
+          segment.strikethrough ?? strikethrough,
+        );
         // An href/to span becomes a /Link annotation over exactly this run's glyph box: from its own
         // ascent above the baseline down to its own descender. A span wrapped across lines yields
         // one rect per line.
@@ -450,6 +580,6 @@ export class TextRenderer {
       top += box.height;
     }
 
-    return { runs, links };
+    return { runs, links, decorations };
   }
 }

--- a/src/lib/renderer/text-renderer.ts
+++ b/src/lib/renderer/text-renderer.ts
@@ -492,6 +492,10 @@ export class TextRenderer {
           fontSize,
           color,
         });
+        // `lineWidth` IS the advance the viewer will use: `getStringWidth` sums the plain glyph
+        // widths, and a `Tj` is advanced by exactly those. (It used to fold in AFM kerning that we
+        // never emitted, so the stroke came out short - 19pt on "AVATAR Wave" at 40pt. Fixed at the
+        // root; see the note on getStringWidth.)
         decorate(
           line,
           x,

--- a/src/lib/text/text-decoration.ts
+++ b/src/lib/text/text-decoration.ts
@@ -1,0 +1,96 @@
+/**
+ * Where an underline and a strikethrough sit, and how thick they are.
+ *
+ * These are GLYPH metrics, and they are deliberately NOT part of `FontVerticals` in
+ * `line-metrics.ts`, which holds LINE metrics. Confusing the two is exactly what produced ISSUE-5:
+ * the AFM's `Ascender` (the height of a `b`) was used to seat a baseline, a job that belongs to the
+ * `FontBBox`. Keep the two kinds of number in two places so they cannot be mixed up again.
+ *
+ * Every number here comes out of the font: the standard-14 AFM header, or a TrueType `post` +
+ * `OS/2` table. Nothing is invented. Verified against `google-chrome --headless --print-to-pdf` on
+ * the same font: Chrome's strikethrough centre lands on `xHeight / 2` (measured 0.260 em vs the
+ * font's 0.262), and its underline stroke with `text-decoration-thickness: from-font` is the font's
+ * `underlineThickness` (0.048 em vs 0.050). Chrome does NOT use the font's underline POSITION - it
+ * has its own offset - so we follow the font there and land within 0.02 em of it.
+ */
+
+/** A font's decoration metrics, as fractions of the em. */
+export interface FontDecoration {
+  /** Distance BELOW the baseline to the CENTRE of the underline stroke. Positive.
+   *  (The AFM defines it as "the distance from the baseline for centering underlining strokes";
+   *  FreeType reads TrueType's `post.underlinePosition` the same way.) */
+  underlinePosition: number;
+  /** Stroke thickness, used by both the underline and the strikethrough. */
+  underlineThickness: number;
+  /** Height of a lowercase `x` above the baseline. Sets where a strikethrough crosses. */
+  xHeight: number;
+  /** Height of a capital above the baseline. */
+  capHeight: number;
+}
+
+/** A decoration stroke: the y of its centre line, and how thick it is. Points, engine coords. */
+export interface DecorationStroke {
+  y: number;
+  thickness: number;
+}
+
+/** The underline for a run whose baseline sits at `baselineY` (engine coords, y grows down). */
+export function underlineStroke(
+  decoration: FontDecoration,
+  fontSize: number,
+  baselineY: number,
+): DecorationStroke {
+  return {
+    y: baselineY + decoration.underlinePosition * fontSize,
+    thickness: decoration.underlineThickness * fontSize,
+  };
+}
+
+/**
+ * The strikethrough for a run whose baseline sits at `baselineY`. It crosses at half the x-height,
+ * which is what a browser does and what looks right: through the middle of the lowercase letters,
+ * not through the middle of the capitals.
+ */
+export function strikethroughStroke(
+  decoration: FontDecoration,
+  fontSize: number,
+  baselineY: number,
+): DecorationStroke {
+  return {
+    y: baselineY - (decoration.xHeight / 2) * fontSize,
+    thickness: decoration.underlineThickness * fontSize,
+  };
+}
+
+/**
+ * Horizontal breathing room left on each side of a descender that interrupts an underline. Unlike
+ * everything else in this file this is a DESIGN choice, not a number read from the font - so it is
+ * expressed in the one quantity the font does give us, the stroke thickness.
+ */
+const SKIP_INK_PADDING = 1.0;
+
+/**
+ * Cuts `[0, runWidth]` at every place the glyphs put ink, leaving the segments an underline should
+ * actually draw. `inkSpans` are x-intervals in points from the start of the run.
+ *
+ * This is CSS `text-decoration-skip-ink`, and it needs the real glyph outlines - so it only works
+ * for an embedded font. Segments narrower than the padding are dropped: a sliver of a line between
+ * two descenders reads as dirt, not as an underline.
+ */
+export function skipInkSegments(
+  runWidth: number,
+  inkSpans: Array<[number, number]>,
+  thickness: number,
+): Array<[number, number]> {
+  const pad = SKIP_INK_PADDING * thickness;
+  const segments: Array<[number, number]> = [];
+  let cursor = 0;
+  for (const [start, end] of inkSpans) {
+    const gapStart = Math.max(0, start - pad);
+    const gapEnd = Math.min(runWidth, end + pad);
+    if (gapStart > cursor + pad) segments.push([cursor, gapStart]);
+    cursor = Math.max(cursor, gapEnd);
+  }
+  if (runWidth > cursor + pad) segments.push([cursor, runWidth]);
+  return segments;
+}

--- a/src/lib/text/text-style.ts
+++ b/src/lib/text/text-style.ts
@@ -17,6 +17,13 @@ export interface ResolvedTextStyle {
   /** Multiplier of the font size. `undefined` means the font's natural line height
    *  (`ascent + descent + lineGap`), i.e. CSS `line-height: normal`. */
   lineHeight?: number;
+  /** Draw a line under the text, at the position and thickness the font declares. */
+  underline: boolean;
+  /** Draw a line through the text, at half its x-height. */
+  strikethrough: boolean;
+  /** Let the underline step around descenders (CSS `text-decoration-skip-ink`). Needs an EMBEDDED
+   *  font: the standard-14 outlines live in the viewer, not in the AFM. */
+  skipInk: boolean;
 }
 
 /**
@@ -30,6 +37,9 @@ export const DEFAULT_TEXT_STYLE: ResolvedTextStyle = {
   color: new Color(0, 0, 0),
   textAlignment: HorizontalAlignment.left,
   lineHeight: undefined,
+  underline: false,
+  strikethrough: false,
+  skipInk: false,
 };
 
 /** Layers a partial override onto a complete style; an unset (undefined) field keeps the base. */
@@ -45,5 +55,8 @@ export function mergeTextStyle(
     color: override.color ?? base.color,
     textAlignment: override.textAlignment ?? base.textAlignment,
     lineHeight: override.lineHeight ?? base.lineHeight,
+    underline: override.underline ?? base.underline,
+    strikethrough: override.strikethrough ?? base.strikethrough,
+    skipInk: override.skipInk ?? base.skipInk,
   };
 }

--- a/src/lib/utils/afm-parser.ts
+++ b/src/lib/utils/afm-parser.ts
@@ -1,5 +1,6 @@
 import { AGL } from "../assets/font-data.ts";
 import type { FontVerticals } from "../text/line-metrics.ts";
+import type { FontDecoration } from "../text/text-decoration.ts";
 
 export class AFMParser {
   private advanceWidths: Record<string, number> = {};
@@ -10,6 +11,14 @@ export class AFMParser {
   // `Ascender` line - is what a line box is built from; see `verticals()`.
   private bbox: [number, number, number, number] = [0, 0, 0, 0];
   private cachedVerticals?: FontVerticals; // never changes for a face; asked once per line
+
+  // Glyph metrics from the AFM header, for underline / strikethrough. All 14 standard fonts carry
+  // the underline pair; Symbol and ZapfDingbats have no CapHeight/XHeight (they have no lowercase).
+  private underlinePosition = 0; // negative, as the AFM writes it: below the baseline
+  private underlineThickness = 0;
+  private capHeight = 0;
+  private xHeight = 0;
+  private cachedDecoration?: FontDecoration;
 
   constructor(afmData: string) {
     this.parseAFMData(afmData);
@@ -61,6 +70,22 @@ export class AFMParser {
           const { charName, wx } = charData;
           this.advanceWidths[charName] = wx;
         }
+      }
+
+      if (line.startsWith("UnderlinePosition ")) {
+        this.underlinePosition = parseFloat(line.slice(18));
+      }
+
+      if (line.startsWith("UnderlineThickness ")) {
+        this.underlineThickness = parseFloat(line.slice(19));
+      }
+
+      if (line.startsWith("CapHeight ")) {
+        this.capHeight = parseFloat(line.slice(10));
+      }
+
+      if (line.startsWith("XHeight ")) {
+        this.xHeight = parseFloat(line.slice(8));
       }
 
       if (line.startsWith("FontBBox ")) {
@@ -125,6 +150,25 @@ export class AFMParser {
     const [, yMin, , yMax] = this.bbox;
     this.cachedVerticals = { ascent: yMax / 1000, descent: -yMin / 1000, lineGap: 0 };
     return this.cachedVerticals;
+  }
+
+  /**
+   * The font's decoration metrics (underline / strikethrough), as fractions of the em.
+   *
+   * Symbol and ZapfDingbats declare no `CapHeight`/`XHeight` - they have no lowercase letters. For
+   * those the bbox top is the only height the font gives us, so the capitals reach it and a
+   * strikethrough crosses at half of that. Still read from the font, not guessed.
+   */
+  decoration(): FontDecoration {
+    if (this.cachedDecoration) return this.cachedDecoration;
+    const capHeight = this.capHeight || this.bbox[3];
+    this.cachedDecoration = {
+      underlinePosition: -this.underlinePosition / 1000, // AFM writes it negative (below the baseline)
+      underlineThickness: this.underlineThickness / 1000,
+      capHeight: capHeight / 1000,
+      xHeight: (this.xHeight || capHeight / 2) / 1000,
+    };
+    return this.cachedDecoration;
   }
 
   getAdvanceWidth(charName: string): number {

--- a/src/lib/utils/font-metrics.ts
+++ b/src/lib/utils/font-metrics.ts
@@ -1,5 +1,6 @@
 import type { FontStyle } from "./pdf-object-manager.ts";
 import type { FontVerticals } from "../text/line-metrics.ts";
+import type { FontDecoration } from "../text/text-decoration.ts";
 
 /**
  * Read-only font measurement - the slice of the object manager that the layout pass
@@ -22,4 +23,8 @@ export interface FontMetrics {
   /** Ascent / descent / lineGap of a face, in em fractions - the vertical counterpart of the widths
    *  above. Drives the line box and the baseline (see `text/line-metrics.ts`). */
   getFontVerticals(fontFamily: string, fontStyle: FontStyle): FontVerticals;
+
+  /** Underline / strikethrough geometry of a face, in em fractions. GLYPH metrics, deliberately kept
+   *  apart from the LINE metrics above (see `text/text-decoration.ts`). */
+  getFontDecoration(fontFamily: string, fontStyle: FontStyle): FontDecoration;
 }

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -5,13 +5,14 @@ import { md5, md5Hex } from "./md5.ts";
 import { zlibSync } from "fflate";
 import { bytesFromLatin1, latin1FromBytes } from "./bytes.ts";
 import { AFMParser } from "./afm-parser.ts";
-import { TTFParser } from "./ttf-parser.ts";
+import { mergeSpans, TTFParser } from "./ttf-parser.ts";
 import { subsetTTF } from "./ttf-subsetter.ts";
 import { getArrayBuffer } from "./utf8-to-windows1252-encoder.ts";
 import type { SecurityHandler } from "../crypto/security-handler.ts";
 import type { Gradient, GradientStop } from "../ir/display-list.ts";
 import { isEmojiCodePoint } from "../text/emoji-codepoints.ts";
 import type { FontVerticals } from "../text/line-metrics.ts";
+import type { FontDecoration } from "../text/text-decoration.ts";
 import { StructTree } from "./struct-tree.ts";
 import { OutlineBuilder } from "./outline.ts";
 import { DestRegistry } from "./dest-registry.ts";
@@ -191,6 +192,8 @@ export class PDFObjectManager implements FontMetrics {
   private customFonts = new Map<string, Map<FontStyle, TTFParser>>();
   // Memoised getFontVerticals answers, family -> style -> metrics. Cleared when a font registers.
   private verticalsCache = new Map<string, Map<FontStyle, FontVerticals>>();
+  // Same, for getFontDecoration.
+  private decorationCache = new Map<string, Map<FontStyle, FontDecoration>>();
   // Per-registered face: the reserved font-object numbers + the glyph ids actually used. The font
   // program is subsetted and the objects filled in by finalizeCustomFonts(), after the render pass.
   private customFontEmit = new Map<
@@ -613,6 +616,7 @@ endstream`;
       return this.fonts.getFont(fontName, fontStyle)!; // Already exists? Return it!
     }
     this.verticalsCache.delete(fontName);
+    this.decorationCache.delete(fontName);
 
     const data = STANDARD_AFM[fullName];
     if (data !== undefined) {
@@ -651,6 +655,7 @@ endstream`;
     if (byStyle.has(style)) return;
     byStyle.set(style, new TTFParser(data));
     this.verticalsCache.delete(name); // this family now answers from the .ttf, not from an AFM
+    this.decorationCache.delete(name);
     // Emission (the PDF font objects + page resource) is DEFERRED to first use via ensureEmitted(),
     // so a registered-but-never-rendered face - e.g. a bundled family the document doesn't touch -
     // costs nothing in the output. The metrics above are still available for layout immediately.
@@ -905,6 +910,60 @@ endstream`;
     }
     byStyle.set(fontStyle, verticals);
     return verticals;
+  }
+
+  // Underline / strikethrough geometry of a face, in em fractions. Same shape as getFontVerticals:
+  // an embedded font answers from its `post`/`OS/2` tables, a standard-14 one from its AFM header,
+  // and the answer is memoised per face because it is asked once per decorated run.
+  getFontDecoration(fontFamily: string, fontStyle: FontStyle): FontDecoration {
+    let byStyle = this.decorationCache.get(fontFamily);
+    const hit = byStyle?.get(fontStyle);
+    if (hit) return hit;
+
+    const ttf = this.getCustomFont(fontFamily, fontStyle);
+    const decoration = ttf
+      ? ttf.decoration()
+      : this.getAVMParserByFont(undefined, fontFamily, fontStyle).parser.decoration();
+
+    if (!byStyle) {
+      byStyle = new Map();
+      this.decorationCache.set(fontFamily, byStyle);
+    }
+    byStyle.set(fontStyle, decoration);
+    return decoration;
+  }
+
+  /**
+   * Where the glyphs of `text` put ink inside a horizontal band, as x-intervals in POINTS measured
+   * from the start of the run. This is what an underline steps around ("skip-ink").
+   *
+   * `bandTop` / `bandBottom` are in points relative to the baseline, y UP (so both negative under
+   * it). Only an EMBEDDED font can answer: the standard-14 outlines live in the viewer, not here.
+   * Callers must check `isCustomFont` first rather than treat an empty result as "no descenders".
+   */
+  getInkSpansInBand(
+    text: string,
+    fontSize: number,
+    fontFamily: string,
+    fontStyle: FontStyle,
+    bandTop: number,
+    bandBottom: number,
+  ): Array<[number, number]> {
+    const ttf = this.getCustomFont(fontFamily, fontStyle);
+    if (!ttf) return [];
+    const scale = fontSize / ttf.unitsPerEm;
+    const spans: Array<[number, number]> = [];
+    let pen = 0;
+    for (const ch of text) {
+      const codePoint = ch.codePointAt(0);
+      if (codePoint !== undefined) {
+        for (const [x0, x1] of ttf.inkSpansInBand(codePoint, bandTop / scale, bandBottom / scale)) {
+          spans.push([pen + x0 * scale, pen + x1 * scale]);
+        }
+      }
+      pen += this.getCharWidth(ch, fontSize, undefined, fontFamily, fontStyle);
+    }
+    return mergeSpans(spans);
   }
 
   // Returns the current width of a text, included kernings

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -978,20 +978,15 @@ endstream`;
     // Iterate code points, not UTF-16 units: an astral char (emoji, CJK-ext) is a surrogate pair,
     // and indexing by unit would measure each half as its own (zero-width) "char". The spread splits
     // on code points; for BMP text this is one unit each, so the result is unchanged.
-    const chars = [...text];
-    for (let i = 0; i < chars.length; i++) {
-      const char = chars[i];
-      const nextChar = chars[i + 1] || null;
-
-      // Get signs width
-      const charWidth = this.getCharWidth(char, fontSize, undefined, fontFamily, fontStyle);
-      width += charWidth;
-
-      // If a next sign available calculate the kerning
-      if (nextChar) {
-        const kerning = this.getKerning(char, nextChar, undefined, fontFamily, fontStyle);
-        width += kerning * fontSize; // Kerning must be scaled with the font size
-      }
+    //
+    // NO KERNING. We write a run as a single `Tj`, and a viewer advances that by the font's plain
+    // widths - PDF never kerns on its own; a producer has to say so with a `TJ` array. Folding the
+    // AFM's kerning into the MEASUREMENT while the OUTPUT ignores it made every kerned string draw
+    // wider than its box: "AVATAR Wave" at 40pt by 19pt, "Total" at 11pt by 5.7%. Measured must equal
+    // drawn. The AFM kerning pairs stay parsed (`getKerning`) for the day we emit `TJ` - see the
+    // "real kerning" item in todo.md, which must cover embedded fonts too (`kern`/`GPOS`).
+    for (const char of text) {
+      width += this.getCharWidth(char, fontSize, undefined, fontFamily, fontStyle);
     }
 
     return width;
@@ -1075,20 +1070,6 @@ endstream`;
   }
 
   // Method to get the kerning, if available, between two signs
-  private getKerning(
-    char: string,
-    nextChar: string,
-    fullFontName?: string,
-    fontName?: string,
-    fontStyle?: FontStyle,
-  ): number {
-    // TrueType kerning (the kern/GPOS tables) is not wired up yet - no kerning for custom fonts.
-    if (this.getCustomFont(fullFontName ?? fontName, fontStyle)) return 0;
-
-    const currentParser = this.getAVMParserByFont(fullFontName, fontName, fontStyle);
-
-    return currentParser.parser.getKerning(char, nextChar) / 1000;
-  }
 
   // Returns all fonts
   getAllFontsRaw() {

--- a/src/lib/utils/ttf-parser.ts
+++ b/src/lib/utils/ttf-parser.ts
@@ -3,6 +3,7 @@
 // text width the same way AFMParser does for the standard-14. Embedding/subsetting come later.
 
 import { i16, latin1FromBytes, u8, u16, u32 } from "./bytes.ts";
+import type { FontDecoration } from "../text/text-decoration.ts";
 
 interface TableRecord {
   offset: number;
@@ -82,6 +83,19 @@ export interface ColorGlyphLayer {
 
 const IDENTITY: Affine = [1, 0, 0, 1, 0, 0];
 
+/** Sorts x-intervals and unions the overlapping ones. */
+export function mergeSpans(spans: Array<[number, number]>): Array<[number, number]> {
+  if (spans.length === 0) return spans;
+  const sorted = [...spans].sort((a, b) => a[0] - b[0]);
+  const out: Array<[number, number]> = [sorted[0]];
+  for (const [start, end] of sorted.slice(1)) {
+    const last = out[out.length - 1];
+    if (start <= last[1]) last[1] = Math.max(last[1], end);
+    else out.push([start, end]);
+  }
+  return out;
+}
+
 function isIdentity(m: Affine): boolean {
   return m[0] === 1 && m[1] === 0 && m[2] === 0 && m[3] === 1 && m[4] === 0 && m[5] === 0;
 }
@@ -121,6 +135,14 @@ export class TTFParser {
   descent = 0;
   // Extra leading the font asks for between two lines (hhea), same glyph space. Often 0.
   lineGap = 0;
+  // Decoration metrics in RAW font units (divide by unitsPerEm). `post` always carries the underline
+  // pair; `OS/2` only carries sxHeight/sCapHeight from version 2 on, so those may stay 0 and are
+  // then measured off the glyph outlines instead (see `decoration()`).
+  private underlinePositionRaw = 0; // negative = below the baseline
+  private underlineThicknessRaw = 0;
+  private xHeightRaw = 0;
+  private capHeightRaw = 0;
+  private cachedDecoration?: FontDecoration;
   bbox: [number, number, number, number] = [0, 0, 0, 0];
   private numGlyphs = 0;
   private numHMetrics = 0;
@@ -154,6 +176,7 @@ export class TTFParser {
     this.ascent = this.toGlyphSpace(i16(this.data, hhea + 4));
     this.descent = this.toGlyphSpace(i16(this.data, hhea + 6));
     this.lineGap = this.toGlyphSpace(i16(this.data, hhea + 8));
+    this.readDecorationMetrics();
     this.indexToLocFormat = i16(this.data, head + 50);
     this.readHmtx();
     this.readCmap();
@@ -223,6 +246,122 @@ export class TTFParser {
     let width = 0;
     for (const ch of text) width += this.getCharWidth(ch, fontSize);
     return width;
+  }
+
+  // `post` carries the underline pair (always, from its header); `OS/2` carries the x- and cap-height
+  // but only from version 2 on. Both tables are optional in principle, so nothing here may throw.
+  private readDecorationMetrics(): void {
+    const post = this.tables["post"];
+    if (post) {
+      this.underlinePositionRaw = i16(this.data, post.offset + 8);
+      this.underlineThicknessRaw = i16(this.data, post.offset + 10);
+    }
+    const os2 = this.tables["OS/2"];
+    if (os2 && u16(this.data, os2.offset) >= 2) {
+      this.xHeightRaw = i16(this.data, os2.offset + 86);
+      this.capHeightRaw = i16(this.data, os2.offset + 88);
+    }
+  }
+
+  /**
+   * Underline / strikethrough geometry, as fractions of the em.
+   *
+   * A font without `post` (rare) gets the classic 10% below the baseline at 5% thickness - the same
+   * numbers all 14 standard AFMs happen to declare, so it is a measured convention rather than an
+   * invention. A font whose `OS/2` predates version 2 has no x- or cap-height, so we MEASURE them off
+   * the outlines of `x` and `H` instead of guessing.
+   */
+  decoration(): FontDecoration {
+    if (this.cachedDecoration) return this.cachedDecoration;
+    const em = this.unitsPerEm;
+    const xHeight = this.xHeightRaw || this.outlineTop(0x78); // "x"
+    const capHeight = this.capHeightRaw || this.outlineTop(0x48); // "H"
+    this.cachedDecoration = {
+      underlinePosition: this.underlinePositionRaw ? -this.underlinePositionRaw / em : 0.1,
+      underlineThickness: this.underlineThicknessRaw ? this.underlineThicknessRaw / em : 0.05,
+      xHeight: xHeight / em,
+      capHeight: capHeight / em,
+    };
+    return this.cachedDecoration;
+  }
+
+  /** The highest ON-CURVE point of a code point's outline, in font units; 0 for a missing glyph.
+   *  A quadratic's control point may sit above the curve, so it is not a bound - and `x`/`H` have
+   *  flat tops in any face where this fallback matters. */
+  private outlineTop(codePoint: number): number {
+    let top = 0;
+    for (const cmd of this.getGlyphPath(this.getGlyphIndex(codePoint))) {
+      if (cmd.type !== "Z" && cmd.y > top) top = cmd.y;
+    }
+    return top;
+  }
+
+  /**
+   * Where a glyph's INK crosses a horizontal band, as x-intervals in font units (pen origin at 0).
+   * This is what lets an underline step around a descender ("skip-ink"), the way a browser does.
+   *
+   * Scanline fill: sample a few horizontal lines across the band, find every place the outline
+   * crosses them, and pair the crossings up into filled spans. A handful of scanlines is plenty -
+   * the band is a few percent of the em tall, and a descender stem does not wander inside it.
+   *
+   * `yTop` / `yBottom` are in font units, y UP from the baseline (so both are negative under it).
+   * Returns [] for a glyph with no outline (a space, an unmapped code point, a composite we cannot
+   * decompose) - the caller then leaves the line unbroken there, which is the safe direction.
+   */
+  inkSpansInBand(codePoint: number, yTop: number, yBottom: number): Array<[number, number]> {
+    const path = this.getGlyphPath(this.getGlyphIndex(codePoint));
+    if (path.length === 0) return [];
+
+    // Flatten to straight edges; a quadratic becomes a short polyline (the band is thin, so a
+    // coarse subdivision is already below the printing resolution).
+    const edges: Array<[number, number, number, number]> = [];
+    let startX = 0;
+    let startY = 0;
+    let curX = 0;
+    let curY = 0;
+    const edge = (x: number, y: number): void => {
+      edges.push([curX, curY, x, y]);
+      curX = x;
+      curY = y;
+    };
+    for (const cmd of path) {
+      if (cmd.type === "M") {
+        [curX, curY] = [cmd.x, cmd.y];
+        [startX, startY] = [cmd.x, cmd.y];
+      } else if (cmd.type === "L") {
+        edge(cmd.x, cmd.y);
+      } else if (cmd.type === "Q") {
+        const [x0, y0] = [curX, curY];
+        const STEPS = 8;
+        for (let i = 1; i <= STEPS; i++) {
+          const t = i / STEPS;
+          const u = 1 - t;
+          edge(
+            u * u * x0 + 2 * u * t * cmd.cx + t * t * cmd.x,
+            u * u * y0 + 2 * u * t * cmd.cy + t * t * cmd.y,
+          );
+        }
+      } else {
+        edge(startX, startY); // Z: close the contour
+      }
+    }
+
+    const SCANLINES = 5;
+    const spans: Array<[number, number]> = [];
+    for (let i = 0; i < SCANLINES; i++) {
+      const y = yTop + ((yBottom - yTop) * i) / (SCANLINES - 1);
+      const xs: number[] = [];
+      for (const [x0, y0, x1, y1] of edges) {
+        if (y0 === y1) continue;
+        // Half-open test so a vertex on the scanline is counted exactly once.
+        if (y >= Math.min(y0, y1) && y < Math.max(y0, y1)) {
+          xs.push(x0 + ((y - y0) / (y1 - y0)) * (x1 - x0));
+        }
+      }
+      xs.sort((a, b) => a - b);
+      for (let k = 0; k + 1 < xs.length; k += 2) spans.push([xs[k], xs[k + 1]]);
+    }
+    return mergeSpans(spans);
   }
 
   private table(tag: string): TableRecord {

--- a/tests/unit/text/text-decoration.test.ts
+++ b/tests/unit/text/text-decoration.test.ts
@@ -90,6 +90,35 @@ describe("skipInkSegments", () => {
   });
 });
 
+describe("the stroke spans exactly the glyphs the viewer draws", () => {
+  it("underlines the full Tj advance of a kern-heavy string", async () => {
+    // Regression guard for the day someone re-introduces kerning into the MEASUREMENT without also
+    // emitting it. Back when `getStringWidth` kerned, "AVATAR Wave" measured 19pt narrower at 40pt
+    // than the `Tj` that draws it - so the stroke stopped 19pt short of the last glyph.
+    const { Document, Page, Text, renderToBytes } = await import("../../../src/lib/api");
+    const om = helvetica();
+    const advance = [..."AVATAR Wave"].reduce(
+      (w, c) => w + om.getCharWidth(c, 40, undefined, "Helvetica", FontStyle.Normal),
+      0,
+    );
+    expect(om.getStringWidth("AVATAR Wave", "Helvetica", 40, FontStyle.Normal)).toBeCloseTo(
+      advance,
+      9,
+    );
+
+    const pdf = new TextDecoder("latin1").decode(
+      await renderToBytes(
+        Document([Page({ margin: 30 }, [Text("AVATAR Wave", { size: 40, underline: true })])]),
+        { compress: false },
+      ),
+    );
+    // The stroke is a `x1 y m \n x2 y l \n S` path; grab its two x coordinates.
+    const stroke = /([\d.]+) ([\d.]+) m\s+([\d.]+) [\d.]+ l/.exec(pdf);
+    expect(stroke).not.toBeNull();
+    expect(Number(stroke![3]) - Number(stroke![1])).toBeCloseTo(advance, 2);
+  });
+});
+
 describe("skipInk without glyph outlines", () => {
   it("refuses on a standard-14 font instead of silently drawing a solid line", async () => {
     const { Document, Page, Text, renderToBytes } = await import("../../../src/lib/api");

--- a/tests/unit/text/text-decoration.test.ts
+++ b/tests/unit/text/text-decoration.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+  skipInkSegments,
+  strikethroughStroke,
+  underlineStroke,
+} from "../../../src/lib/text/text-decoration";
+import { PDFObjectManager, FontStyle } from "../../../src/lib/utils/pdf-object-manager";
+
+// Every number an underline or a strikethrough uses comes out of the font. Verified against
+// `google-chrome --headless --print-to-pdf` on the SAME font (FreeSans): Chrome's strikethrough
+// centre sits on xHeight/2 and its `from-font` stroke is the font's underlineThickness.
+
+const helvetica = () => {
+  const om = new PDFObjectManager();
+  om.registerFont("Helvetica", FontStyle.Normal, "Helvetica");
+  om.registerFont("Symbol", FontStyle.Normal, "Symbol");
+  return om;
+};
+
+describe("decoration metrics come from the font", () => {
+  it("reads Helvetica's underline and heights out of its AFM header", () => {
+    // Helvetica.afm: UnderlinePosition -100, UnderlineThickness 50, CapHeight 718, XHeight 523.
+    const d = helvetica().getFontDecoration("Helvetica", FontStyle.Normal);
+    expect(d.underlinePosition).toBeCloseTo(0.1); // positive = BELOW the baseline
+    expect(d.underlineThickness).toBeCloseTo(0.05);
+    expect(d.capHeight).toBeCloseTo(0.718);
+    expect(d.xHeight).toBeCloseTo(0.523);
+  });
+
+  it("falls back to the bbox for a font with no lowercase (Symbol has no XHeight)", () => {
+    // Symbol.afm carries no CapHeight/XHeight at all. Its FontBBox top is 1010.
+    const d = helvetica().getFontDecoration("Symbol", FontStyle.Normal);
+    expect(d.capHeight).toBeCloseTo(1.01);
+    expect(d.xHeight).toBeCloseTo(0.505); // half of it, so a strikethrough still crosses the glyphs
+  });
+});
+
+describe("stroke geometry", () => {
+  const d = { underlinePosition: 0.1, underlineThickness: 0.05, xHeight: 0.5, capHeight: 0.7 };
+
+  it("puts the underline below the baseline, the strikethrough above it", () => {
+    expect(underlineStroke(d, 100, 500)).toEqual({ y: 510, thickness: 5 });
+    expect(strikethroughStroke(d, 100, 500)).toEqual({ y: 475, thickness: 5 });
+  });
+
+  it("scales both with the font size", () => {
+    expect(underlineStroke(d, 10, 0).y).toBeCloseTo(1);
+    expect(underlineStroke(d, 20, 0).y).toBeCloseTo(2);
+  });
+});
+
+describe("skipInkSegments", () => {
+  const THICK = 2; // so the padding around a descender is 2pt on each side
+
+  it("returns the whole run when nothing dips into the stroke", () => {
+    expect(skipInkSegments(100, [], THICK)).toEqual([[0, 100]]);
+  });
+
+  it("cuts a gap around each descender, padded by the stroke thickness", () => {
+    expect(skipInkSegments(100, [[40, 50]], THICK)).toEqual([
+      [0, 38],
+      [52, 100],
+    ]);
+  });
+
+  it("merges two descenders that sit closer together than the padding", () => {
+    // Gaps 38..52 and 51..65 overlap, so no sliver of line survives between them.
+    expect(
+      skipInkSegments(
+        100,
+        [
+          [40, 50],
+          [53, 63],
+        ],
+        THICK,
+      ),
+    ).toEqual([
+      [0, 38],
+      [65, 100],
+    ]);
+  });
+
+  it("drops a segment narrower than the padding rather than drawing dirt", () => {
+    expect(skipInkSegments(100, [[1, 99]], THICK)).toEqual([]);
+  });
+
+  it("keeps the run's own bounds (a descender at the very edge does not overhang)", () => {
+    const [first] = skipInkSegments(100, [[0, 10]], THICK);
+    expect(first[0]).toBeGreaterThanOrEqual(12);
+  });
+});
+
+describe("skipInk without glyph outlines", () => {
+  it("refuses on a standard-14 font instead of silently drawing a solid line", async () => {
+    const { Document, Page, Text, renderToBytes } = await import("../../../src/lib/api");
+    await expect(
+      renderToBytes(
+        Document([Page({}, [Text("Hxgp", { size: 40, underline: true, skipInk: true })])]),
+      ),
+    ).rejects.toThrow(/skipInk needs an embedded font/);
+  });
+});

--- a/tests/unit/utils/font-metrics.oracle.test.ts
+++ b/tests/unit/utils/font-metrics.oracle.test.ts
@@ -35,18 +35,25 @@ describe("font metrics - Adobe AFM oracle (points)", () => {
     expect(stringWidth("A", "Times-Roman", 1000)).toBeCloseTo(722, 6);
   });
 
-  // Kerning must be looked up per ordered pair, with the right sign and scaled by
-  // font size. assets/Helvetica.afm: KPX A V -70, KPX V A -80.
-  it("applies kerning with the correct pair, sign and scale", () => {
-    // "AV" @12pt = adv(A) + adv(V) + kern(A,V) = 8.004 + 8.004 - 0.84 = 15.168
-    expect(stringWidth("AV", "Helvetica", 12)).toBeCloseTo(15.168, 6);
-    // "VA" @12pt uses the other pair: kern(V,A) = -80 -> 16.008 - 0.96 = 15.048
-    expect(stringWidth("VA", "Helvetica", 12)).toBeCloseTo(15.048, 6);
+  // A string's width is the PLAIN sum of its advances - NO kerning.
+  //
+  // This is not an oversight, it is the contract: we write a run as one `Tj`, and a viewer advances
+  // that by the font's widths. PDF never kerns on its own; a producer has to say so with a `TJ`
+  // array, and we do not. Folding the AFM's kern pairs into the measurement while the output ignored
+  // them made every kerned string DRAW wider than the box it was measured into ("AVATAR Wave" at
+  // 40pt: 19pt too wide; "Total" at 11pt: 5.7%). Measured must equal drawn.
+  //
+  // The kern pairs are still parsed (`AFMParser.getKerning`) for the day we emit `TJ`. When that
+  // lands, these expectations change - and so must the backend, in the same commit.
+  it("sums advances without kerning, because a Tj is advanced without kerning", () => {
+    // assets/Helvetica.afm: adv(A) = adv(V) = 667. It also declares KPX A V -70, KPX V A -80,
+    // and neither may show up here.
+    expect(stringWidth("AV", "Helvetica", 12)).toBeCloseTo(16.008, 6); // NOT 15.168
+    expect(stringWidth("VA", "Helvetica", 12)).toBeCloseTo(16.008, 6); // NOT 15.048
+    expect(stringWidth("AVA", "Helvetica", 12)).toBeCloseTo(24.012, 6); // NOT 22.212
   });
 
-  // Multi-char width is the sum of advances plus every interior kern pair.
-  it("sums advances and kernings across a word", () => {
-    // "AVA" @12pt = 3*8.004 + kern(A,V) + kern(V,A) = 24.012 - 0.84 - 0.96 = 22.212
-    expect(stringWidth("AVA", "Helvetica", 12)).toBeCloseTo(22.212, 6);
+  it("is order-independent, which a kerned measure could never be", () => {
+    expect(stringWidth("AV", "Helvetica", 12)).toBeCloseTo(stringWidth("VA", "Helvetica", 12), 9);
   });
 });

--- a/tests/unit/utils/pdf-object-manager.test.ts
+++ b/tests/unit/utils/pdf-object-manager.test.ts
@@ -39,24 +39,16 @@ describe("PDFObjectManager - Fonts", () => {
     expect(font.resourceIndex).toBe(1);
   });
 
-  it("should return the correct string width with mocked char width and kerning", () => {
+  it("is the plain sum of the char widths - no kerning is folded in", () => {
     const manager = new PDFObjectManager();
     manager.registerFont("Helvetica", FontStyle.Normal);
 
-    // Mock the getCharWidth method for predictable results
     vitest.spyOn(manager, "getCharWidth").mockReturnValue(600);
 
-    // Mock the getKerning method to simulate kerning between 'A' and 'V'
-    vitest.spyOn(manager as any, "getKerning").mockImplementation((char, nextChar) => {
-      if (char === "A" && nextChar === "V") {
-        return 0.1; // Simulated kerning value for 'A' and 'V'
-      }
-      return 0;
-    });
-
+    // "AV" is Helvetica's most famous kern pair (KPX A V -70). It must not appear here: we emit a
+    // single `Tj`, which the viewer advances by the plain widths.
     const width = manager.getStringWidth("AV", "Helvetica", 12, FontStyle.Normal);
-    // char width: 600 for each + kerning: 0.1 * 12 (font size)
-    expect(width).toBe(600 + 600 + 0.1 * 12); // 1200 + 1.2 = 1201.2
+    expect(width).toBe(1200);
   });
 
   it("rejects a non-string font family with a clear hint (font bytes passed as a name)", () => {
@@ -151,16 +143,20 @@ describe("PDFObjectManager - AFM Parsing", () => {
   });
 });
 
-describe("PDFObjectManager - Kerning Calculation", () => {
-  it("should apply kerning when calculating string width", () => {
+describe("PDFObjectManager - measured width equals drawn width", () => {
+  it("does not kern, so a string is exactly as wide as the glyphs the viewer advances by", () => {
     const manager = new PDFObjectManager();
     manager.registerFont("Helvetica", FontStyle.Normal);
 
-    const kerningSpy = vitest.spyOn(manager as any, "getKerning").mockReturnValue(0.1);
-
-    const width = manager.getStringWidth("AV", "Helvetica", 12, FontStyle.Normal);
-    expect(kerningSpy).toHaveBeenCalledWith("A", "V", undefined, "Helvetica", "normal");
-    expect(width).toBeGreaterThan(12); // Kerning adds to width
+    const chars = [...("AVATAR Wave" as string)];
+    const summed = chars.reduce(
+      (w, c) => w + manager.getCharWidth(c, 40, undefined, "Helvetica", FontStyle.Normal),
+      0,
+    );
+    const measured = manager.getStringWidth("AVATAR Wave", "Helvetica", 40, FontStyle.Normal);
+    // With kerning folded in this was 19pt narrower than what a `Tj` actually draws, so the text
+    // overflowed its box. The AFM pairs live on in `AFMParser.getKerning` for a future `TJ` path.
+    expect(measured).toBeCloseTo(summed, 9);
   });
 });
 


### PR DESCRIPTION
## Summary

Now we can underline and strikethrough texts! Underline can have the `inkSkip` prop!

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added underline and strikethrough text styling, configurable per style and per text segment.
  * Added `skipInk` to reduce underline overlap with descenders (requires an embedded font).
* **Bug Fixes**
  * Improved decoration placement and thickness using font metrics, keeping decoration colors and style overrides consistent with the text.
  * Updated `stringWidth` to be kerning-free and consistent with rendered advances.
* **Documentation**
  * Documented decoration behavior, supported features, limitations, and usage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->