### PR TITLE
feat: letter spacing and kerning

### DIFF
--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -23,6 +23,7 @@ const textStyleProps = {
   strikethrough: { type: Boolean, default: undefined },
   /** Step the underline around descenders. Needs an embedded font. */
   skipInk: { type: Boolean, default: undefined },
+  letterSpacing: Number,
 };
 // A link target. Shared by `<Text>`/`<Paragraph>` (links the whole run) and `<Span>` (links just that
 // run). NOT part of `textStyleProps`: `<Document>` and `<DefaultTextStyle>` set defaults, they cannot link.

--- a/src/lib/api/structure.ts
+++ b/src/lib/api/structure.ts
@@ -247,6 +247,10 @@ export interface RenderOptions {
   standardFonts?: boolean;
   /** FlateDecode-compress the streams (default true). Set false for a greppable, uncompressed PDF. */
   compress?: boolean;
+  /** EXPERIMENTAL, off by default: kern the text (emit `TJ` adjustments). Standard-14 fonts only for
+   *  now - embedded fonts are not kerned yet (`kern`/`GPOS` unparsed), so leaving it off avoids setting
+   *  the 14 system fonts finer than a user's own font. Becomes a supported default once GPOS lands. */
+  kerning?: boolean;
   /** What to do when content is taller than a page and cannot break: `"error"` throws (default),
    *  `"warn"` logs and clips, `"ignore"` clips silently. It is always clipped either way. */
   onOverflow?: OverflowPolicy;
@@ -294,6 +298,8 @@ export async function renderPdf(doc: PDFDocumentElement, options?: RenderOptions
       const om = this.objectManager;
       om.setCompress(options?.compress !== false); // FlateDecode streams by default
       om.setOverflowPolicy(options?.onOverflow ?? "error");
+      om.setKerning(options?.kerning === true); // EXPERIMENTAL: standard-14 only until GPOS lands
+
       for (const [name, value] of Object.entries(fonts)) {
         if (isFontBytes(value)) {
           om.registerCustomFont(name, value);

--- a/src/lib/api/text.ts
+++ b/src/lib/api/text.ts
@@ -24,6 +24,8 @@ export interface TextStyle {
    *  EMBEDDED font - the standard-14 outlines live in the viewer, so we cannot see where their ink
    *  is. Asking for it with a standard font is an error, not a silent no-op. */
   skipInk?: boolean;
+  /** Extra space after every glyph, in points (CSS `letter-spacing`). Negative tightens. Default 0. */
+  letterSpacing?: number;
   /** External URL - makes this run an inline hyperlink (a /Link annotation over its glyphs). On a
    *  `span` it links just that run; on a whole `Text` (plain string) it links the whole text. */
   href?: string;
@@ -100,6 +102,7 @@ export function span(text: string, style: TextStyle = {}): TextSegment {
     fontColor: style.color !== undefined ? toColor(style.color) : undefined,
     underline: style.underline,
     strikethrough: style.strikethrough,
+    letterSpacing: style.letterSpacing,
     href: style.href,
     dest: style.to,
   };
@@ -134,6 +137,7 @@ export function Text(content: string | TextSegment[], opts: TextOptions = {}): T
     underline: opts.underline,
     strikethrough: opts.strikethrough,
     skipInk: opts.skipInk,
+    letterSpacing: opts.letterSpacing,
     role: opts.role,
   });
 }
@@ -156,6 +160,7 @@ export interface TextDefaults {
   underline?: boolean;
   strikethrough?: boolean;
   skipInk?: boolean;
+  letterSpacing?: number;
 }
 
 /** Maps the `Text`-style option names onto a partial engine `ResolvedTextStyle` (only the set
@@ -173,5 +178,6 @@ export function toTextStyleOverride(opts: TextDefaults): Partial<ResolvedTextSty
   if (opts.underline !== undefined) style.underline = opts.underline;
   if (opts.strikethrough !== undefined) style.strikethrough = opts.strikethrough;
   if (opts.skipInk !== undefined) style.skipInk = opts.skipInk;
+  if (opts.letterSpacing !== undefined) style.letterSpacing = opts.letterSpacing;
   return style;
 }

--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -16,6 +16,7 @@ import {
   TextOverflow,
 } from "../text/line-breaker.ts";
 import { lineBoxForSegmentLine, lineBoxForString } from "../text/line-metrics.ts";
+import { runAdvance } from "../text/advance.ts";
 import { HorizontalAlignment, LayoutContext, SizedPDFElement } from "./pdf-element.ts";
 export interface TextSegment {
   content: string;
@@ -30,6 +31,8 @@ export interface TextSegment {
   /** Unset inherits the Text's own setting; `true`/`false` overrides it for this run only. */
   underline?: boolean;
   strikethrough?: boolean;
+  /** Extra space after every glyph, in points; unset inherits the Text's own value. */
+  letterSpacing?: number;
 }
 
 /** Accessibility role for the tagged structure tree: a heading level or a paragraph (the default). */
@@ -57,6 +60,8 @@ interface TextElementParams {
   strikethrough?: boolean;
   /** Let the underline step around descenders. Needs an embedded font. */
   skipInk?: boolean;
+  /** Extra space after every glyph, in points (CSS `letter-spacing`). Default 0. */
+  letterSpacing?: number;
   /** Accessibility role for the tagged structure tree (heading level or paragraph; default `"p"`). */
   role?: TextRole;
 }
@@ -73,6 +78,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
   private readonly rawUnderline?: boolean;
   private readonly rawStrikethrough?: boolean;
   private readonly rawSkipInk?: boolean;
+  private readonly rawLetterSpacing?: number;
 
   // Resolved style (raw -> inherited -> built-in default). Seeded to the built-in default in the
   // constructor so the element is self-sufficient, then refined against the cascade at layout time.
@@ -85,6 +91,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
   private underline!: boolean;
   private strikethrough!: boolean;
   private skipInk!: boolean;
+  private letterSpacing!: number;
 
   private content: string | TextSegment[];
   private maxLines?: number;
@@ -104,6 +111,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     underline,
     strikethrough,
     skipInk,
+    letterSpacing,
     role,
   }: TextElementParams) {
     super({ x: 0, y: 0 });
@@ -118,6 +126,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     this.rawUnderline = underline;
     this.rawStrikethrough = strikethrough;
     this.rawSkipInk = skipInk;
+    this.rawLetterSpacing = letterSpacing;
     this.content = content;
     this.maxLines = maxLines;
     this.overflow = overflow;
@@ -139,6 +148,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     this.underline = this.rawUnderline ?? ts.underline;
     this.strikethrough = this.rawStrikethrough ?? ts.strikethrough;
     this.skipInk = this.rawSkipInk ?? ts.skipInk;
+    this.letterSpacing = this.rawLetterSpacing ?? ts.letterSpacing;
   }
 
   /**
@@ -171,6 +181,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       ctx.metrics,
       this.maxLines,
       this.overflow,
+      this.letterSpacing,
     );
 
     const box = lineBoxForString(
@@ -202,6 +213,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       fontFamily: this.fontFamily,
       fontSize: this.fontSize,
       fontStyle: this.fontStyle,
+      letterSpacing: this.letterSpacing,
     };
     const lines = breakSegmentsIntoLines(
       content,
@@ -246,6 +258,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       underline: this.underline,
       strikethrough: this.strikethrough,
       skipInk: this.skipInk,
+      letterSpacing: this.letterSpacing,
       role: this.role,
     }).adoptStructId(this); // a wrapped remainder is the SAME logical paragraph (one P across pages)
   }
@@ -272,6 +285,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       this.maxLines,
       this.overflow,
       this.lineHeight,
+      this.letterSpacing,
     );
 
     // Top-left coordinates (y = top of the text box). The baseline offset and the
@@ -289,19 +303,33 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
    *  - enough to tip a borderline string (e.g. "20 Jun 2026", wider than "04 Jul 2026" only because
    *  'n' beats 'l') one bit over its own width, dropping the last word onto a second line. */
   private naturalWidth(metrics: FontMetrics): number {
-    const oneLine = (text: string, family: string, size: number, style: FontStyle): number => {
+    const oneLine = (
+      text: string,
+      family: string,
+      size: number,
+      style: FontStyle,
+      letterSpacing: number,
+    ): number => {
+      const font = { fontFamily: family, fontSize: size, fontStyle: style };
       const words = text.split(" ");
-      const space = metrics.getCharWidth(" ", size, undefined, family, style);
+      const space = runAdvance(metrics, " ", font, letterSpacing);
       let width = 0;
       words.forEach((word, i) => {
-        const w = metrics.getStringWidth(word, family, size, style);
-        // Group (word + space) as one term, exactly like the breaker - see the note above.
+        const w = runAdvance(metrics, word, font, letterSpacing);
+        // Group (word + space) as one term, exactly like the breaker - see the note above. Both use
+        // the same `runAdvance`, so the two agree bit for bit even with letterSpacing.
         width += i < words.length - 1 ? w + space : w;
       });
       return width;
     };
     if (typeof this.content === "string") {
-      return oneLine(this.content, this.fontFamily, this.fontSize, this.fontStyle);
+      return oneLine(
+        this.content,
+        this.fontFamily,
+        this.fontSize,
+        this.fontStyle,
+        this.letterSpacing,
+      );
     }
     return this.content.reduce(
       (sum, seg) =>
@@ -311,6 +339,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
           seg.fontFamily ?? this.fontFamily,
           seg.fontSize ?? this.fontSize,
           seg.fontStyle ?? this.fontStyle,
+          seg.letterSpacing ?? this.letterSpacing,
         ),
       0,
     );
@@ -334,6 +363,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       underline: this.underline,
       strikethrough: this.strikethrough,
       skipInk: this.skipInk,
+      letterSpacing: this.letterSpacing,
       role: this.role,
     };
   }

--- a/src/lib/ir/display-list.ts
+++ b/src/lib/ir/display-list.ts
@@ -38,6 +38,7 @@ export interface TextRun {
   fontStyle: FontStyle;
   fontSize: number;
   color: Color;
+  letterSpacing?: number; // extra advance after every glyph, in points (Tc); absent/0 = none
   tag?: StructTag; // accessible tagging; absent = Artifact
 }
 

--- a/src/lib/renderer/pdf-backend.ts
+++ b/src/lib/renderer/pdf-backend.ts
@@ -169,6 +169,27 @@ export class PdfBackend {
   }
 
   /**
+   * Builds the `[ ... ]` operand of a `TJ` from a run and its per-gap kern adjustments (em/1000, the
+   * sign the font declares - negative tightens). A `TJ` number moves the pen LEFT, so it is the
+   * NEGATED kern. Consecutive un-kerned glyphs stay in one encoded chunk, so `[(T) 40 (otal)]` rather
+   * than one chunk per glyph. `kerns[i]` is the adjustment AFTER code point `i`.
+   */
+  static kernedArray(text: string, kerns: number[], encode: (chunk: string) => string): string {
+    const chars = [...text];
+    let out = "";
+    let chunk = chars[0] ?? "";
+    for (let i = 0; i < kerns.length; i++) {
+      if (kerns[i] === 0) {
+        chunk += chars[i + 1];
+      } else {
+        out += encode(chunk) + ` ${-kerns[i]} `;
+        chunk = chars[i + 1];
+      }
+    }
+    return `[${out}${encode(chunk)}]`;
+  }
+
+  /**
    * Returns the `/GSx gs` operator that selects a transparency state, or `""` when both
    * alphas are fully opaque. Opaque draws emit nothing here, so output stays
    * byte-identical until transparency is actually used.
@@ -272,9 +293,19 @@ export class PdfBackend {
         const font = isCustom
           ? om.getCustomFontResource(node.fontFamily, node.fontStyle)!
           : om.registerFont(node.fontFamily, node.fontStyle);
-        const textOp = isCustom
-          ? `<${om.encodeCustomText(node.fontFamily, node.text, node.fontStyle)}>`
-          : `(${PdfBackend.escapePdfString(node.text)})`;
+        const encode = (t: string): string =>
+          isCustom
+            ? `<${om.encodeCustomText(node.fontFamily, t, node.fontStyle)}>`
+            : `(${PdfBackend.escapePdfString(t)})`;
+        // Kerning (if the document has it on): a `TJ` array with the font's per-pair adjustments
+        // between glyph chunks, measured into the layout by the SAME numbers (runAdvance). A plain
+        // `Tj` when the run has no kerning, byte-identical.
+        const kerns = om.kerningEnabled
+          ? om.getKernPairs(node.text, node.fontFamily, node.fontStyle)
+          : [];
+        const showOp = kerns.some((k) => k !== 0)
+          ? `${PdfBackend.kernedArray(node.text, kerns, encode)} TJ`
+          : `${encode(node.text)} Tj`;
         // letterSpacing is the `Tc` operator: extra advance after EVERY glyph (an embedded
         // Identity-H font too - that is `Tw`, word spacing, which only touches single-byte code 32).
         const spacing = node.letterSpacing ? `${node.letterSpacing.toFixed(3)} Tc\n` : "";
@@ -283,7 +314,7 @@ export class PdfBackend {
           `${node.color.toPDFColorString()} rg ` +
           `/F${font.fontIndex} ${node.fontSize} Tf ` +
           `${node.x.toFixed(3)} ${node.y.toFixed(3)} Td ` +
-          `${textOp} Tj\n` +
+          `${showOp}\n` +
           `ET\n`;
         const gs = PdfBackend.alphaPrefix(om, node.color.getAlpha(), 1);
         // `Tc` is graphics state and would leak into the next run, so isolate it in q/Q - the same

--- a/src/lib/renderer/pdf-backend.ts
+++ b/src/lib/renderer/pdf-backend.ts
@@ -275,6 +275,9 @@ export class PdfBackend {
         const textOp = isCustom
           ? `<${om.encodeCustomText(node.fontFamily, node.text, node.fontStyle)}>`
           : `(${PdfBackend.escapePdfString(node.text)})`;
+        // letterSpacing is the `Tc` operator: extra advance after EVERY glyph (an embedded
+        // Identity-H font too - that is `Tw`, word spacing, which only touches single-byte code 32).
+        const spacing = node.letterSpacing ? `${node.letterSpacing.toFixed(3)} Tc\n` : "";
         const block =
           `BT\n` +
           `${node.color.toPDFColorString()} rg ` +
@@ -282,9 +285,10 @@ export class PdfBackend {
           `${node.x.toFixed(3)} ${node.y.toFixed(3)} Td ` +
           `${textOp} Tj\n` +
           `ET\n`;
-        // Transparent text gets an isolating q/Q + gs; opaque text is byte-identical.
         const gs = PdfBackend.alphaPrefix(om, node.color.getAlpha(), 1);
-        return gs ? `q\n${gs}${block}Q\n` : block;
+        // `Tc` is graphics state and would leak into the next run, so isolate it in q/Q - the same
+        // reason transparent text is isolated. A run with neither stays byte-identical.
+        return gs || spacing ? `q\n${gs}${spacing}${block}Q\n` : block;
       }
       case "image": {
         // The backend owns PDF resource creation: register the XObject (using the

--- a/src/lib/renderer/text-renderer.ts
+++ b/src/lib/renderer/text-renderer.ts
@@ -20,6 +20,7 @@ import {
   TextOverflow,
 } from "../text/line-breaker.ts";
 import { lineBoxForSegmentLine, lineBoxForString } from "../text/line-metrics.ts";
+import { runAdvance } from "../text/advance.ts";
 import {
   DecorationStroke,
   skipInkSegments,
@@ -40,6 +41,7 @@ export class TextRenderer {
     maxLines?: number,
     overflow?: TextOverflow,
     lineHeight?: number,
+    letterSpacing = 0,
   ): number {
     // Plain string: every wrapped line gets the same box.
     if (typeof content === "string") {
@@ -52,13 +54,14 @@ export class TextRenderer {
         objectManager,
         maxLines,
         overflow,
+        letterSpacing,
       );
       const box = lineBoxForString(objectManager, fontFamily, fontStyle, fontSize, lineHeight);
       return lines.length * box.height;
     }
 
     // Segments: each line's box comes from the fonts actually on it.
-    const defaults = { fontFamily, fontSize, fontStyle };
+    const defaults = { fontFamily, fontSize, fontStyle, letterSpacing };
     const lines = breakSegmentsIntoLines(
       content,
       defaults,
@@ -94,6 +97,7 @@ export class TextRenderer {
       underline,
       strikethrough,
       skipInk,
+      letterSpacing,
       role,
     } = textElement.getProps();
 
@@ -117,6 +121,7 @@ export class TextRenderer {
       underline,
       strikethrough,
       skipInk,
+      letterSpacing,
     );
 
     // Accessible tagging: this whole text block is one structure element (a paragraph P, or a heading
@@ -182,8 +187,11 @@ export class TextRenderer {
         const l = fallback.getColorGlyph(fallback.getGlyphIndex(cp));
         if (l) [source, layers] = [fallback, l];
       }
-      // The advance matches measuring (getCharWidth applies the same emoji fallback).
-      const advance = om.getCharWidth(ch, run.fontSize, undefined, run.fontFamily, run.fontStyle);
+      // The advance matches measuring (getCharWidth applies the same emoji fallback), plus the run's
+      // letter-spacing so a spaced run's emoji sit where `Tc` advances them.
+      const advance =
+        om.getCharWidth(ch, run.fontSize, undefined, run.fontFamily, run.fontStyle) +
+        (run.letterSpacing ?? 0);
 
       if (source && layers) {
         flushPending();
@@ -348,6 +356,7 @@ export class TextRenderer {
     underline = false,
     strikethrough = false,
     skipInk = false,
+    letterSpacing = 0,
   ): { runs: TextRun[]; links: Link[]; decorations: Line[] } {
     const runs: TextRun[] = [];
     // /Link annotation rects for any `href` spans, collected as we place segments. Empty for the
@@ -377,6 +386,7 @@ export class TextRenderer {
       runColor: Color,
       wantsUnderline: boolean,
       wantsStrikethrough: boolean,
+      runLetterSpacing: number,
     ): void => {
       if ((!wantsUnderline && !wantsStrikethrough) || runWidth <= 0) return;
       const metrics = objectManager.getFontDecoration(family, style);
@@ -403,6 +413,7 @@ export class TextRenderer {
           family,
           style,
           stroke,
+          runLetterSpacing,
         )) {
           push(from, to, stroke);
         }
@@ -424,6 +435,7 @@ export class TextRenderer {
       family: string,
       style: FontStyle,
       stroke: DecorationStroke,
+      runLetterSpacing: number,
     ): Array<[number, number]> => {
       if (!skipInk) return [[0, runWidth]];
       if (!objectManager.isCustomFont(family, style)) {
@@ -443,25 +455,14 @@ export class TextRenderer {
         style,
         -below + half,
         -below - half,
+        runLetterSpacing,
       );
       return skipInkSegments(runWidth, inkSpans, stroke.thickness);
     };
 
-    // Advance width WITHOUT kerning. This is how Tj moves the text cursor, so
-    // segments flowing after each other land here. (Standard-14 fonts carry no
-    // /Widths array; the viewer advances by the AFM widths - same source as below.)
-    const advanceNoKerning = (
-      text: string,
-      family: string,
-      size: number,
-      style: FontStyle,
-    ): number => {
-      let width = 0;
-      for (const ch of text) {
-        width += objectManager.getCharWidth(ch, size, undefined, family, style);
-      }
-      return width;
-    };
+    // The advance the viewer will use: plain glyph widths (a `Tj` never kerns) plus one
+    // `letterSpacing` per code point (the `Tc` operator), from the one shared `advance.ts` primitive.
+    const font = { fontFamily, fontSize, fontStyle };
 
     // --- Plain string: one run per wrapped line. ---
     if (typeof content === "string") {
@@ -474,12 +475,13 @@ export class TextRenderer {
         objectManager,
         maxLines,
         overflow,
+        letterSpacing,
       );
       // yPosition is the top of the text box (top-left). The line box seats its own baseline; lines
       // then stack by that box's height. Same numbers as calculateTextHeight, by construction.
       const box = lineBoxForString(objectManager, fontFamily, fontStyle, fontSize, lineHeight);
       lines.forEach((line, index) => {
-        const lineWidth = objectManager.getStringWidth(line, fontFamily, fontSize, fontStyle);
+        const lineWidth = runAdvance(objectManager, line, font, letterSpacing);
         const x = initialX + alignmentOffset(lineWidth);
         const baseline = yPosition + box.baseline + box.height * index;
         runs.push({
@@ -491,11 +493,8 @@ export class TextRenderer {
           fontStyle,
           fontSize,
           color,
+          ...(letterSpacing ? { letterSpacing } : {}),
         });
-        // `lineWidth` IS the advance the viewer will use: `getStringWidth` sums the plain glyph
-        // widths, and a `Tj` is advanced by exactly those. (It used to fold in AFM kerning that we
-        // never emitted, so the stroke came out short - 19pt on "AVATAR Wave" at 40pt. Fixed at the
-        // root; see the note on getStringWidth.)
         decorate(
           line,
           x,
@@ -507,6 +506,7 @@ export class TextRenderer {
           color,
           underline,
           strikethrough,
+          letterSpacing,
         );
       });
       return { runs, links, decorations };
@@ -523,7 +523,13 @@ export class TextRenderer {
         const family = segment.fontFamily || fontFamily;
         const size = segment.fontSize || fontSize;
         const style = segment.fontStyle || fontStyle;
-        const advance = advanceNoKerning(segment.content, family, size, style);
+        const segLetterSpacing = segment.letterSpacing ?? letterSpacing;
+        const advance = runAdvance(
+          objectManager,
+          segment.content,
+          { fontFamily: family, fontSize: size, fontStyle: style },
+          segLetterSpacing,
+        );
         const runColor = segment.fontColor || color;
         runs.push({
           type: "text",
@@ -534,6 +540,7 @@ export class TextRenderer {
           fontStyle: style,
           fontSize: size,
           color: runColor,
+          ...(segLetterSpacing ? { letterSpacing: segLetterSpacing } : {}),
         });
         decorate(
           segment.content,
@@ -546,6 +553,7 @@ export class TextRenderer {
           runColor,
           segment.underline ?? underline,
           segment.strikethrough ?? strikethrough,
+          segLetterSpacing,
         );
         // An href/to span becomes a /Link annotation over exactly this run's glyph box: from its own
         // ascent above the baseline down to its own descender. A span wrapped across lines yields

--- a/src/lib/renderer/text-renderer.ts
+++ b/src/lib/renderer/text-renderer.ts
@@ -576,8 +576,10 @@ export class TextRenderer {
 
     // yPosition is the top of the text box (top-left). Each line seats its own baseline inside its
     // own box (tallest ascent / deepest descent ON THAT LINE), then the next line starts below it.
-    // The seam flips the whole thing to PDF space.
-    const defaults = { fontFamily, fontSize, fontStyle };
+    // The seam flips the whole thing to PDF space. `letterSpacing` MUST be in the defaults so a span
+    // that does not override it wraps and aligns with the element's spacing - the same defaults the
+    // measure path (calculateTextHeight) uses, or segmented spaced text mis-wraps (measured != drawn).
+    const defaults = { fontFamily, fontSize, fontStyle, letterSpacing };
     let top = yPosition;
     for (const line of breakSegmentsIntoLines(
       content,

--- a/src/lib/text/advance.ts
+++ b/src/lib/text/advance.ts
@@ -1,0 +1,48 @@
+/**
+ * How wide a run of text is: the horizontal counterpart to `line-metrics.ts` (how tall a line is)
+ * and `line-breaker.ts` (where a line breaks). The ONE canonical answer to "how far does the pen
+ * move", so measuring and drawing can never disagree about it.
+ *
+ * An advance has three parts, each with its own PDF mechanism. Only the first is wired up today:
+ *
+ *     advance = sum(glyph widths)  +  sum(kerning)  +  n * letterSpacing
+ *                  /Widths             TJ array          Tc
+ *
+ * `letterSpacing` is added after EVERY code point, the last one included - exactly what the `Tc`
+ * operator does, and exactly what CSS `letter-spacing` does (which is why right-aligned spaced text
+ * looks a hair offset: a spacing hangs off the final glyph). Measuring `(n - 1)` spacings while `Tc`
+ * applies `n` would make every line draw one spacing wider than it was wrapped - text out of its box.
+ *
+ * Kerning is deliberately absent: a run is written as a single `Tj`, which a viewer advances by the
+ * plain widths. Folding kerning into the measurement while the output ignores it is the bug that was
+ * removed on 2026-07-10. When we emit `TJ`, kerning joins here and in the backend in the same change.
+ */
+
+import type { FontStyle } from "../utils/pdf-object-manager.ts";
+import type { FontMetrics } from "../utils/font-metrics.ts";
+
+/** The font a run is set in. */
+export interface RunFont {
+  fontFamily: string;
+  fontSize: number;
+  fontStyle: FontStyle;
+}
+
+/** Number of Unicode code points (not UTF-16 units): an astral char is ONE, so it takes one
+ *  letter-spacing, not two. Matches how `getStringWidth` iterates. */
+export function codePointCount(text: string): number {
+  let n = 0;
+  for (const _ of text) n++;
+  return n;
+}
+
+/** The advance of `text` in points: the plain glyph widths plus one `letterSpacing` per code point. */
+export function runAdvance(
+  metrics: FontMetrics,
+  text: string,
+  font: RunFont,
+  letterSpacing = 0,
+): number {
+  const glyphs = metrics.getStringWidth(text, font.fontFamily, font.fontSize, font.fontStyle);
+  return letterSpacing === 0 ? glyphs : glyphs + codePointCount(text) * letterSpacing;
+}

--- a/src/lib/text/advance.ts
+++ b/src/lib/text/advance.ts
@@ -3,7 +3,7 @@
  * and `line-breaker.ts` (where a line breaks). The ONE canonical answer to "how far does the pen
  * move", so measuring and drawing can never disagree about it.
  *
- * An advance has three parts, each with its own PDF mechanism. Only the first is wired up today:
+ * An advance has three parts, each with its own PDF mechanism:
  *
  *     advance = sum(glyph widths)  +  sum(kerning)  +  n * letterSpacing
  *                  /Widths             TJ array          Tc
@@ -13,9 +13,10 @@
  * looks a hair offset: a spacing hangs off the final glyph). Measuring `(n - 1)` spacings while `Tc`
  * applies `n` would make every line draw one spacing wider than it was wrapped - text out of its box.
  *
- * Kerning is deliberately absent: a run is written as a single `Tj`, which a viewer advances by the
- * plain widths. Folding kerning into the measurement while the output ignores it is the bug that was
- * removed on 2026-07-10. When we emit `TJ`, kerning joins here and in the backend in the same change.
+ * Kerning is added ONLY when the document has it on (`metrics.kerningEnabled`), and then the backend
+ * emits a `TJ` with the same per-pair adjustments - so a measured advance always equals the drawn
+ * one. With kerning off, `getStringWidth` is the whole advance (its plain glyph sum), byte-identical
+ * to before. Folding kerning into the measurement while the output ignored it was the 2026-07-10 bug.
  */
 
 import type { FontStyle } from "../utils/pdf-object-manager.ts";
@@ -36,13 +37,20 @@ export function codePointCount(text: string): number {
   return n;
 }
 
-/** The advance of `text` in points: the plain glyph widths plus one `letterSpacing` per code point. */
+/** The advance of `text` in points: the plain glyph widths, plus kerning (if the document has it on),
+ *  plus one `letterSpacing` per code point. */
 export function runAdvance(
   metrics: FontMetrics,
   text: string,
   font: RunFont,
   letterSpacing = 0,
 ): number {
-  const glyphs = metrics.getStringWidth(text, font.fontFamily, font.fontSize, font.fontStyle);
-  return letterSpacing === 0 ? glyphs : glyphs + codePointCount(text) * letterSpacing;
+  let advance = metrics.getStringWidth(text, font.fontFamily, font.fontSize, font.fontStyle);
+  if (letterSpacing !== 0) advance += codePointCount(text) * letterSpacing;
+  if (metrics.kerningEnabled) {
+    let units = 0;
+    for (const k of metrics.getKernPairs(text, font.fontFamily, font.fontStyle)) units += k;
+    advance += (units / 1000) * font.fontSize; // kern units are em/1000
+  }
+  return advance;
 }

--- a/src/lib/text/line-breaker.ts
+++ b/src/lib/text/line-breaker.ts
@@ -1,12 +1,15 @@
 import type { FontStyle } from "../utils/pdf-object-manager.ts";
 import type { FontMetrics } from "../utils/font-metrics.ts";
 import type { TextSegment } from "../elements/text-element.ts";
+import { runAdvance } from "./advance.ts";
 
 /** Default font for segments that don't override it. */
 export interface SegmentDefaults {
   fontFamily: string;
   fontSize: number;
   fontStyle: FontStyle;
+  /** Extra space after every glyph, in points; a segment may override it. Default 0. */
+  letterSpacing?: number;
 }
 
 /** What happens to text beyond `maxLines`: `"clip"` drops it, `"ellipsis"` ends the last kept line
@@ -41,15 +44,19 @@ export function wrapStringIntoLines(
   metrics: FontMetrics,
   maxLines?: number,
   overflow?: TextOverflow,
+  letterSpacing = 0,
 ): string[] {
   let currentLine = "";
   let currentWidth = 0;
   const lines: string[] = [];
 
+  const font = { fontFamily, fontSize, fontStyle };
   const words = text.split(" ");
   words.forEach((word, index) => {
-    const wordWidth = metrics.getStringWidth(word, fontFamily, fontSize, fontStyle);
-    const spaceWidth = metrics.getCharWidth(" ", fontSize, undefined, fontFamily, fontStyle);
+    // Word and space advances come from the one shared primitive (`advance.ts`), the same one
+    // `naturalWidth` uses - so a bounded and an unbounded layout of the same text agree bit for bit.
+    const wordWidth = runAdvance(metrics, word, font, letterSpacing);
+    const spaceWidth = runAdvance(metrics, " ", font, letterSpacing);
 
     // Break before a word that won't fit - but only once the line has content. A single word wider
     // than maxWidth must sit on its (empty) line and overflow, not push a phantom empty line before
@@ -71,7 +78,15 @@ export function wrapStringIntoLines(
   const kept = lines.slice(0, maxLines);
   if (overflow === "ellipsis") {
     const last = kept.length - 1;
-    kept[last] = ellipsize(kept[last], fontFamily, fontSize, fontStyle, maxWidth, metrics);
+    kept[last] = ellipsize(
+      kept[last],
+      fontFamily,
+      fontSize,
+      fontStyle,
+      maxWidth,
+      metrics,
+      letterSpacing,
+    );
   }
   return kept;
 }
@@ -99,7 +114,9 @@ export function breakSegmentsIntoLines(
     const family = segment.fontFamily || defaults.fontFamily;
     const size = segment.fontSize || defaults.fontSize;
     const style = segment.fontStyle || defaults.fontStyle;
-    const spaceWidth = metrics.getCharWidth(" ", size, undefined, family, style);
+    const letterSpacing = segment.letterSpacing ?? defaults.letterSpacing ?? 0;
+    const font = { fontFamily: family, fontSize: size, fontStyle: style };
+    const spaceWidth = runAdvance(metrics, " ", font, letterSpacing);
     const words = segment.content.split(" ");
 
     // Start this segment's piece empty; its content is filled word-by-word below. (Not
@@ -109,7 +126,7 @@ export function breakSegmentsIntoLines(
     combined = "";
 
     words.forEach((word, wordIndex) => {
-      const wordWidth = metrics.getStringWidth(word, family, size, style);
+      const wordWidth = runAdvance(metrics, word, font, letterSpacing);
 
       // Same guard as the string path: don't open a phantom empty line for an over-wide first word -
       // place it (overflowing) on the current empty line instead.
@@ -171,9 +188,11 @@ function ellipsize(
   fontStyle: FontStyle,
   maxWidth: number,
   metrics: FontMetrics,
+  letterSpacing = 0,
 ): string {
+  const font = { fontFamily, fontSize, fontStyle };
   const fits = (s: string): boolean =>
-    metrics.getStringWidth(s + ELLIPSIS, fontFamily, fontSize, fontStyle) <= maxWidth;
+    runAdvance(metrics, s + ELLIPSIS, font, letterSpacing) <= maxWidth;
   if (fits(line)) return line + ELLIPSIS;
 
   const words = line.split(" ");
@@ -202,12 +221,17 @@ function ellipsizeSegmentLine(
 ): void {
   const segs = line.segments;
   if (segs.length === 0) return;
+  const lsOf = (seg: TextSegment): number => seg.letterSpacing ?? defaults.letterSpacing ?? 0;
   const widthOf = (seg: TextSegment): number =>
-    metrics.getStringWidth(
+    runAdvance(
+      metrics,
       seg.content,
-      seg.fontFamily || defaults.fontFamily,
-      seg.fontSize || defaults.fontSize,
-      seg.fontStyle || defaults.fontStyle,
+      {
+        fontFamily: seg.fontFamily || defaults.fontFamily,
+        fontSize: seg.fontSize || defaults.fontSize,
+        fontStyle: seg.fontStyle || defaults.fontStyle,
+      },
+      lsOf(seg),
     );
   let prefix = 0;
   for (let i = 0; i < segs.length - 1; i++) prefix += widthOf(segs[i]);
@@ -219,6 +243,7 @@ function ellipsizeSegmentLine(
     last.fontStyle || defaults.fontStyle,
     maxWidth - prefix,
     metrics,
+    lsOf(last),
   );
   line.width = prefix + widthOf(last);
 }

--- a/src/lib/text/text-style.ts
+++ b/src/lib/text/text-style.ts
@@ -24,6 +24,8 @@ export interface ResolvedTextStyle {
   /** Let the underline step around descenders (CSS `text-decoration-skip-ink`). Needs an EMBEDDED
    *  font: the standard-14 outlines live in the viewer, not in the AFM. */
   skipInk: boolean;
+  /** Extra space after every glyph, in points (CSS `letter-spacing`). Default 0. */
+  letterSpacing: number;
 }
 
 /**
@@ -40,6 +42,7 @@ export const DEFAULT_TEXT_STYLE: ResolvedTextStyle = {
   underline: false,
   strikethrough: false,
   skipInk: false,
+  letterSpacing: 0,
 };
 
 /** Layers a partial override onto a complete style; an unset (undefined) field keeps the base. */
@@ -58,5 +61,6 @@ export function mergeTextStyle(
     underline: override.underline ?? base.underline,
     strikethrough: override.strikethrough ?? base.strikethrough,
     skipInk: override.skipInk ?? base.skipInk,
+    letterSpacing: override.letterSpacing ?? base.letterSpacing,
   };
 }

--- a/src/lib/utils/font-metrics.ts
+++ b/src/lib/utils/font-metrics.ts
@@ -27,4 +27,12 @@ export interface FontMetrics {
   /** Underline / strikethrough geometry of a face, in em fractions. GLYPH metrics, deliberately kept
    *  apart from the LINE metrics above (see `text/text-decoration.ts`). */
   getFontDecoration(fontFamily: string, fontStyle: FontStyle): FontDecoration;
+
+  /** Whether kerning is on for this document. `runAdvance` reads it so a measured advance matches the
+   *  drawn one (the backend emits a `TJ` under the same flag). */
+  readonly kerningEnabled: boolean;
+
+  /** Per-adjacent-pair kerning of `text`, in em/1000 (negative tightens); length `codePoints - 1`,
+   *  zero next to a space. Only meaningful when `kerningEnabled`. */
+  getKernPairs(text: string, fontFamily: string, fontStyle: FontStyle): number[];
 }

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -948,6 +948,7 @@ endstream`;
     fontStyle: FontStyle,
     bandTop: number,
     bandBottom: number,
+    letterSpacing = 0,
   ): Array<[number, number]> {
     const ttf = this.getCustomFont(fontFamily, fontStyle);
     if (!ttf) return [];
@@ -961,7 +962,9 @@ endstream`;
           spans.push([pen + x0 * scale, pen + x1 * scale]);
         }
       }
-      pen += this.getCharWidth(ch, fontSize, undefined, fontFamily, fontStyle);
+      // The pen advances by the glyph AND its letter-spacing, so the ink of the next glyph lands
+      // where `Tc` actually draws it - otherwise the skipped gaps drift under the wrong letters.
+      pen += this.getCharWidth(ch, fontSize, undefined, fontFamily, fontStyle) + letterSpacing;
     }
     return mergeSpans(spans);
   }

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -933,6 +933,41 @@ endstream`;
     return decoration;
   }
 
+  // Whether to kern. Document-level: measuring (via `runAdvance`, which reads this off the metrics)
+  // and drawing (the backend emits a `TJ`) both consult it, so they can never disagree. OFF while the
+  // embedded-font path (kern/GPOS) is unbuilt - a standard-14-only kerning would set the 14 system
+  // fonts finer than a user's own font, which is worse than none. Flip to on when GPOS lands.
+  kerningEnabled = false;
+
+  setKerning(enabled: boolean): void {
+    this.kerningEnabled = enabled;
+  }
+
+  /**
+   * The kerning adjustment for each adjacent code-point pair of `text`, in em/1000 (the sign the
+   * font declares: negative tightens). Length is `codePointCount - 1`. Zero at any pair next to a
+   * space - letters are never kerned against a space, which also keeps a per-word measure equal to a
+   * whole-line one (the space pairs contribute nothing either way).
+   *
+   * Standard-14 answers from the AFM `KPX` pairs. An embedded font has no kerning yet (its `kern` /
+   * `GPOS` tables are unparsed), so it returns zeros - never a wrong value, just no adjustment.
+   */
+  getKernPairs(text: string, fontFamily: string, fontStyle: FontStyle): number[] {
+    const chars = [...text];
+    if (chars.length < 2) return [];
+    const out: number[] = [];
+    const ttf = this.getCustomFont(fontFamily, fontStyle);
+    const parser = ttf
+      ? undefined
+      : this.getAVMParserByFont(undefined, fontFamily, fontStyle).parser;
+    for (let i = 0; i < chars.length - 1; i++) {
+      const a = chars[i];
+      const b = chars[i + 1];
+      out.push(a === " " || b === " " || !parser ? 0 : parser.getKerning(a, b));
+    }
+    return out;
+  }
+
   /**
    * Where the glyphs of `text` put ink inside a horizontal band, as x-intervals in POINTS measured
    * from the start of the run. This is what an underline steps around ("skip-ink").

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -956,6 +956,7 @@ endstream`;
     const chars = [...text];
     if (chars.length < 2) return [];
     const out: number[] = [];
+    // An embedded font kerns by GLYPH id (kern table / GPOS); a standard-14 one by character (AFM).
     const ttf = this.getCustomFont(fontFamily, fontStyle);
     const parser = ttf
       ? undefined
@@ -963,7 +964,18 @@ endstream`;
     for (let i = 0; i < chars.length - 1; i++) {
       const a = chars[i];
       const b = chars[i + 1];
-      out.push(a === " " || b === " " || !parser ? 0 : parser.getKerning(a, b));
+      if (a === " " || b === " ") {
+        out.push(0);
+      } else if (ttf) {
+        out.push(
+          ttf.getKerning(
+            ttf.getGlyphIndex(a.codePointAt(0)!),
+            ttf.getGlyphIndex(b.codePointAt(0)!),
+          ),
+        );
+      } else {
+        out.push(parser!.getKerning(a, b));
+      }
     }
     return out;
   }

--- a/src/lib/utils/ttf-parser.ts
+++ b/src/lib/utils/ttf-parser.ts
@@ -159,6 +159,12 @@ export class TTFParser {
   // COLR v1: base glyph id → the absolute offset of its Paint table (a recursive paint graph).
   private colrBaseV1 = new Map<number, number>();
   private colrLayerListOffset = 0; // absolute offset of the v1 LayerList (paint-offset array)
+  // Kerning: (leftGid << 16 | rightGid) -> value in FONT UNITS (from the `kern` table and/or GPOS).
+  private kernPairs = new Map<number, number>();
+  private hasKerning = false;
+  // GPOS Type 2 (pair positioning) subtables, in absolute byte offsets. Queried per pair (format 2
+  // is class-based, so it cannot be enumerated into `kernPairs` up front). Preferred over `kern`.
+  private gposPairPos: number[] = [];
 
   constructor(private data: Uint8Array) {
     this.readTableDirectory();
@@ -183,6 +189,16 @@ export class TTFParser {
     if (this.tables["COLR"] && this.tables["CPAL"]) {
       this.readColr();
       this.readCpal();
+    }
+    // Kerning tables are optional and only ever make text prettier; a malformed one must degrade to
+    // "no kerning", never break font loading. Guard both.
+    try {
+      if (this.tables["kern"]) this.readKern();
+      if (this.tables["GPOS"]) this.readGpos();
+    } catch {
+      this.kernPairs.clear();
+      this.gposPairPos = [];
+      this.hasKerning = false;
     }
   }
 
@@ -362,6 +378,201 @@ export class TTFParser {
       for (let k = 0; k + 1 < xs.length; k += 2) spans.push([xs[k], xs[k + 1]]);
     }
     return mergeSpans(spans);
+  }
+
+  /** True if the font declares any horizontal kerning (kern table or GPOS). */
+  kerns(): boolean {
+    return this.hasKerning;
+  }
+
+  /** Kerning between two glyphs, in em/1000 (the standard-14 unit); 0 if the pair is not kerned.
+   *  Negative tightens, matching the AFM sign. GPOS wins over the legacy `kern` table when both
+   *  exist (it is what a modern shaper uses, and can carry more pairs). */
+  getKerning(leftGid: number, rightGid: number): number {
+    let units: number | undefined;
+    if (this.gposPairPos.length > 0) units = this.gposKern(leftGid, rightGid);
+    if (units === undefined) units = this.kernPairs.get((leftGid << 16) | rightGid);
+    return units === undefined ? 0 : Math.round((units * 1000) / this.unitsPerEm);
+  }
+
+  // The legacy `kern` table, format 0 (an explicit list of glyph-pair adjustments). Only horizontal
+  // format-0 subtables are read; GPOS (parsed separately) supersedes this in modern fonts, but old
+  // TrueType (DejaVu, FreeSans) carries its kerning here.
+  private readKern(): void {
+    const base = this.tables["kern"].offset;
+    // The OpenType (Microsoft) header is version:u16 = 0, nTables:u16. (Apple's is a u32 version; the
+    // fonts we target use the OpenType form.)
+    if (u16(this.data, base) !== 0) return;
+    const nTables = u16(this.data, base + 2);
+    let p = base + 4;
+    for (let t = 0; t < nTables; t++) {
+      const length = u16(this.data, p + 2);
+      const coverage = u16(this.data, p + 4);
+      const format = coverage >> 8;
+      const horizontal = (coverage & 0x1) === 1;
+      if (format === 0 && horizontal) {
+        const nPairs = u16(this.data, p + 6);
+        let q = p + 14; // past nPairs, searchRange, entrySelector, rangeShift
+        for (let i = 0; i < nPairs; i++) {
+          const left = u16(this.data, q);
+          const right = u16(this.data, q + 2);
+          const value = i16(this.data, q + 4);
+          this.kernPairs.set((left << 16) | right, value);
+          q += 6;
+        }
+      }
+      p += length;
+    }
+    if (this.kernPairs.size > 0) this.hasKerning = true;
+  }
+
+  // GPOS pair-adjustment kerning. We collect the PairPos (lookup type 2) subtables of the `kern`
+  // FEATURE only - not every pair-positioning lookup - so this is kerning, not arbitrary shaping.
+  // Script/language selection is skipped: the `kern` feature is the same across the Latin scripts we
+  // target, so a flat scan of the feature list for tag "kern" is correct here. Only pair positioning
+  // (type 2) is read; the rest of GPOS (mark attachment, cursive, contextual) is not kerning.
+  private readGpos(): void {
+    const base = this.tables["GPOS"].offset;
+    const featureListOffset = base + u16(this.data, base + 6);
+    const lookupListOffset = base + u16(this.data, base + 8);
+
+    // Every lookup index referenced by a "kern" feature.
+    const kernLookups = new Set<number>();
+    const featureCount = u16(this.data, featureListOffset);
+    for (let i = 0; i < featureCount; i++) {
+      const rec = featureListOffset + 2 + i * 6;
+      const tag = String.fromCharCode(
+        this.data[rec],
+        this.data[rec + 1],
+        this.data[rec + 2],
+        this.data[rec + 3],
+      );
+      if (tag !== "kern") continue;
+      const feature = featureListOffset + u16(this.data, rec + 4);
+      const lookupIndexCount = u16(this.data, feature + 2);
+      for (let j = 0; j < lookupIndexCount; j++) {
+        kernLookups.add(u16(this.data, feature + 4 + j * 2));
+      }
+    }
+    if (kernLookups.size === 0) return;
+
+    // The PairPos subtables of those lookups (a lookup of another type in the set is ignored).
+    const lookupCount = u16(this.data, lookupListOffset);
+    for (const idx of kernLookups) {
+      if (idx >= lookupCount) continue;
+      const lookup = lookupListOffset + u16(this.data, lookupListOffset + 2 + idx * 2);
+      if (u16(this.data, lookup) !== 2) continue; // lookupType 2 = pair adjustment
+      const subTableCount = u16(this.data, lookup + 4);
+      for (let s = 0; s < subTableCount; s++) {
+        this.gposPairPos.push(lookup + u16(this.data, lookup + 6 + s * 2));
+      }
+    }
+    if (this.gposPairPos.length > 0) this.hasKerning = true;
+  }
+
+  // The XAdvance adjustment on the LEFT glyph for a pair, in font units, from the first PairPos
+  // subtable that covers it; undefined if none does. (Kerning only ever uses value1's XAdvance.)
+  private gposKern(leftGid: number, rightGid: number): number | undefined {
+    for (const sub of this.gposPairPos) {
+      const posFormat = u16(this.data, sub);
+      const coverage = sub + u16(this.data, sub + 2);
+      const covIndex = this.coverageIndex(coverage, leftGid);
+      if (covIndex < 0) continue;
+      const valueFormat1 = u16(this.data, sub + 4);
+      const valueFormat2 = u16(this.data, sub + 6);
+      const v1size = TTFParser.valueRecordSize(valueFormat1);
+      const v2size = TTFParser.valueRecordSize(valueFormat2);
+
+      if (posFormat === 1) {
+        const pairSet = sub + u16(this.data, sub + 10 + covIndex * 2);
+        const pairValueCount = u16(this.data, pairSet);
+        const recSize = 2 + v1size + v2size;
+        for (let i = 0; i < pairValueCount; i++) {
+          const rec = pairSet + 2 + i * recSize;
+          if (u16(this.data, rec) === rightGid) {
+            return this.xAdvance(rec + 2, valueFormat1);
+          }
+        }
+      } else if (posFormat === 2) {
+        const classDef1 = sub + u16(this.data, sub + 8);
+        const classDef2 = sub + u16(this.data, sub + 10);
+        const class2Count = u16(this.data, sub + 14);
+        const c1 = this.classOf(classDef1, leftGid);
+        const c2 = this.classOf(classDef2, rightGid);
+        const recSize = v1size + v2size;
+        const record = sub + 16 + (c1 * class2Count + c2) * recSize;
+        return this.xAdvance(record, valueFormat1);
+      }
+    }
+    return undefined;
+  }
+
+  private static valueRecordSize(valueFormat: number): number {
+    let bits = 0;
+    for (let m = valueFormat; m; m >>= 1) bits += m & 1;
+    return bits * 2;
+  }
+
+  // The XAdvance field of a GPOS value record, or 0 if the format has none. XAdvance (bit 0x0004) is
+  // preceded by XPlacement (0x0001) and YPlacement (0x0002), each an i16 when present.
+  private xAdvance(recordOffset: number, valueFormat: number): number {
+    if ((valueFormat & 0x0004) === 0) return 0;
+    let off = recordOffset;
+    if (valueFormat & 0x0001) off += 2;
+    if (valueFormat & 0x0002) off += 2;
+    return i16(this.data, off);
+  }
+
+  // Coverage index of a glyph, or -1. Format 1: sorted glyph list. Format 2: sorted ranges.
+  private coverageIndex(offset: number, gid: number): number {
+    const format = u16(this.data, offset);
+    if (format === 1) {
+      const count = u16(this.data, offset + 2);
+      let lo = 0;
+      let hi = count - 1;
+      while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        const g = u16(this.data, offset + 4 + mid * 2);
+        if (gid < g) hi = mid - 1;
+        else if (gid > g) lo = mid + 1;
+        else return mid;
+      }
+      return -1;
+    }
+    if (format === 2) {
+      const rangeCount = u16(this.data, offset + 2);
+      for (let i = 0; i < rangeCount; i++) {
+        const rec = offset + 4 + i * 6;
+        const start = u16(this.data, rec);
+        const end = u16(this.data, rec + 2);
+        if (gid >= start && gid <= end) return u16(this.data, rec + 4) + (gid - start);
+      }
+    }
+    return -1;
+  }
+
+  // Class of a glyph in a ClassDef, or 0 (the default class). Format 1: run from a start glyph.
+  // Format 2: ranges. Glyphs not listed are class 0.
+  private classOf(offset: number, gid: number): number {
+    const format = u16(this.data, offset);
+    if (format === 1) {
+      const startGlyph = u16(this.data, offset + 2);
+      const glyphCount = u16(this.data, offset + 4);
+      if (gid >= startGlyph && gid < startGlyph + glyphCount) {
+        return u16(this.data, offset + 6 + (gid - startGlyph) * 2);
+      }
+      return 0;
+    }
+    if (format === 2) {
+      const rangeCount = u16(this.data, offset + 2);
+      for (let i = 0; i < rangeCount; i++) {
+        const rec = offset + 4 + i * 6;
+        const start = u16(this.data, rec);
+        const end = u16(this.data, rec + 2);
+        if (gid >= start && gid <= end) return u16(this.data, rec + 4);
+      }
+    }
+    return 0;
   }
 
   private table(tag: string): TableRecord {

--- a/tests/unit/elements/row-element.test.ts
+++ b/tests/unit/elements/row-element.test.ts
@@ -50,13 +50,14 @@ describe("RowElement", () => {
     expect(right.getProps().x).toBe(170);
   });
 
-  // Regression: a fixed Text in a Row must reserve its RENDERED width (per-glyph, no kerning) - the
-  // renderer advances without kerning, so reserving the kerning-narrower getStringWidth makes the
-  // text overflow its own box and wrap, even with plenty of space. (CSS: space → never constrains.)
+  // Regression: a fixed Text in a Row reserves its natural single-line width, and that width MUST
+  // equal the line-breaker's one-line measure - else the text re-wraps inside its own box. Both now
+  // go through the same `runAdvance`, so they agree by construction. (CSS: a space → never wraps.)
   it("a fixed Text in a Row takes its one-line width, so it never wraps inside its own box", () => {
+    // Consistent font: getStringWidth is the sum of getCharWidth. Every glyph, space included, 6 wide.
     const metrics = {
-      getStringWidth: (t: string) => t.length * 6 - 10, // per word; kerning pulls it IN
-      getCharWidth: () => 6, // the space advance
+      getStringWidth: (t: string) => t.length * 6,
+      getCharWidth: () => 6,
       getFontVerticals: unitVerticals,
     } as unknown as FontMetrics;
     const ctx = { metrics, pageConfig: {} } as LayoutContext;
@@ -69,10 +70,29 @@ describe("RowElement", () => {
     );
 
     const { width, height } = text.getProps();
-    // ONE line, no wrap. The width MUST equal the line-breaker's one-line measure (getStringWidth
-    // per word + the inter-word space), or the text re-wraps inside its own box:
-    // "Total"(20) + space(6) + "due"(8) = 34.
-    expect(width).toBe(34);
+    // "Total due" is 9 glyphs (incl. the space) * 6 = 54, on one line.
+    expect(width).toBe(54);
     expect(height).toBe(10); // 1 line x fontSize
+  });
+
+  // letterSpacing widens the reserved width by one spacing per glyph, and the breaker agrees, so the
+  // text still does not re-wrap in its own box.
+  it("reserves the letter-spaced width, so a spaced fixed Text still does not wrap", () => {
+    const metrics = {
+      getStringWidth: (t: string) => t.length * 6,
+      getCharWidth: () => 6,
+      getFontVerticals: unitVerticals,
+    } as unknown as FontMetrics;
+    const ctx = { metrics, pageConfig: {} } as LayoutContext;
+
+    const text = new TextElement({ fontSize: 10, content: "Total due", letterSpacing: 2 });
+    new RowElement({ children: [text] }).calculateLayout(
+      BoxConstraints.loose(500, Infinity),
+      { x: 0, y: 0 },
+      ctx,
+    );
+    // 9 glyphs * 6 + 9 spacings * 2 = 54 + 18 = 72. One line.
+    expect(text.getProps().width).toBe(72);
+    expect(text.getProps().height).toBe(10);
   });
 });

--- a/tests/unit/layout/box-fragment.test.ts
+++ b/tests/unit/layout/box-fragment.test.ts
@@ -11,8 +11,10 @@ import { unitVerticals } from "../support/metrics";
 
 // Each glyph 10 wide, spaces 0: "aa bb cc dd ee ff" wraps to 3 lines of 10pt at width 50.
 const metrics: FontMetrics = {
-  getStringWidth: (text) => text.length * 10,
-  getCharWidth: () => 0,
+  // Consistent font: getStringWidth is the sum of getCharWidth (as it is in reality). Each glyph is
+  // 10 wide, a space is 0, so word widths are len*10 and spaces cost nothing - the arithmetic below.
+  getStringWidth: (text: string) => [...text].reduce((w, c) => w + (c === " " ? 0 : 10), 0),
+  getCharWidth: (c: string) => (c === " " ? 0 : 10),
   getFontVerticals: unitVerticals,
 };
 const ctx = { metrics } as LayoutContext;

--- a/tests/unit/renderer/letter-spacing.test.ts
+++ b/tests/unit/renderer/letter-spacing.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { Document, Page, Text, renderToBytes } from "../../../src/lib/api";
+
+// letterSpacing -> the PDF `Tc` operator. It is graphics state and must be isolated so it cannot
+// leak into the next run; at 0 it must not appear at all (byte-identity for every existing document).
+
+const streamOf = async (letterSpacing?: number): Promise<string> => {
+  const bytes = await renderToBytes(
+    Document([Page({ margin: 40 }, [Text("Total", { size: 20, letterSpacing })])]),
+    { compress: false },
+  );
+  return new TextDecoder("latin1").decode(bytes);
+};
+
+describe("letterSpacing emits Tc", () => {
+  it("writes the spacing as a Tc operator", async () => {
+    expect(await streamOf(3)).toContain("3.000 Tc");
+  });
+
+  it("emits NO Tc when the spacing is 0 or unset", async () => {
+    expect(await streamOf(0)).not.toContain("Tc");
+    expect(await streamOf(undefined)).not.toContain("Tc");
+  });
+
+  it("isolates the Tc in a q/Q so it cannot leak into the next run", async () => {
+    const pdf = await streamOf(3);
+    // The spaced run's block is wrapped: q ... Tc ... BT ... ET ... Q
+    expect(pdf).toMatch(/q\s+3\.000 Tc\s+BT/);
+    expect(pdf).toContain("Q");
+  });
+});

--- a/tests/unit/renderer/letter-spacing.test.ts
+++ b/tests/unit/renderer/letter-spacing.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { Document, Page, Text, span, renderToBytes } from "../../../src/lib/api";
+import { Document, Page, Box, Text, span, renderToBytes } from "../../../src/lib/api";
+import type { TextSegment } from "../../../src/lib/elements/text-element";
 
 // letterSpacing -> the PDF `Tc` operator. It is graphics state and must be isolated so it cannot
 // leak into the next run; at 0 it must not appear at all (byte-identity for every existing document).
@@ -53,11 +54,12 @@ describe("letterSpacing emits Tc", () => {
     // the element letterSpacing (the bug), the segment version would wrap without spacing -> fewer
     // lines than the string version -> and fewer than the layout reserved (overflow).
     const CONTENT = "alpha bravo charlie delta echo foxtrot golf hotel india juliet";
-    const linesDrawn = async (content: string | ReturnType<typeof span>[]) => {
+    const linesDrawn = async (content: string | TextSegment[]) => {
       const bytes = await renderToBytes(
         Document([
           Page({ margin: 40 }, [
-            Text(content as never, { size: 16, letterSpacing: 3, width: 200 }),
+            // The Box bounds the width (Text has no width of its own); the spacing decides the break.
+            Box({ width: 200 }, [Text(content, { size: 16, letterSpacing: 3 })]),
           ]),
         ]),
         { compress: false },

--- a/tests/unit/renderer/letter-spacing.test.ts
+++ b/tests/unit/renderer/letter-spacing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Document, Page, Text, renderToBytes } from "../../../src/lib/api";
+import { Document, Page, Text, span, renderToBytes } from "../../../src/lib/api";
 
 // letterSpacing -> the PDF `Tc` operator. It is graphics state and must be isolated so it cannot
 // leak into the next run; at 0 it must not appear at all (byte-identity for every existing document).
@@ -27,5 +27,49 @@ describe("letterSpacing emits Tc", () => {
     // The spaced run's block is wrapped: q ... Tc ... BT ... ET ... Q
     expect(pdf).toMatch(/q\s+3\.000 Tc\s+BT/);
     expect(pdf).toContain("Q");
+  });
+
+  it("applies an element-level letterSpacing to spans that do not override it", async () => {
+    // Segmented content: the Text sets letterSpacing, the spans do not. Every drawn run must carry
+    // the 4pt Tc.
+    const bytes = await renderToBytes(
+      Document([
+        Page({ margin: 40 }, [
+          Text([span("one "), span("two three")], { size: 20, letterSpacing: 4 }),
+        ]),
+      ]),
+      { compress: false },
+    );
+    const pdf = new TextDecoder("latin1").decode(bytes);
+    const tcCount = (pdf.match(/4\.000 Tc/g) ?? []).length;
+    const runCount = (pdf.match(/ Tj/g) ?? []).length + (pdf.match(/ TJ/g) ?? []).length;
+    expect(tcCount).toBe(runCount);
+    expect(runCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it("wraps segmented spaced text with the element's spacing, like the plain-string path", async () => {
+    // The decisive check: a single span with the whole text must wrap into the SAME number of lines
+    // as the same text as a plain string, at the same width and spacing. If the render path dropped
+    // the element letterSpacing (the bug), the segment version would wrap without spacing -> fewer
+    // lines than the string version -> and fewer than the layout reserved (overflow).
+    const CONTENT = "alpha bravo charlie delta echo foxtrot golf hotel india juliet";
+    const linesDrawn = async (content: string | ReturnType<typeof span>[]) => {
+      const bytes = await renderToBytes(
+        Document([
+          Page({ margin: 40 }, [
+            Text(content as never, { size: 16, letterSpacing: 3, width: 200 }),
+          ]),
+        ]),
+        { compress: false },
+      );
+      const pdf = new TextDecoder("latin1").decode(bytes);
+      // distinct Td y-positions = number of drawn lines.
+      const ys = new Set([...pdf.matchAll(/[-\d.]+ ([-\d.]+) Td/g)].map((m) => m[1]));
+      return ys.size;
+    };
+    const asString = await linesDrawn(CONTENT);
+    const asSegments = await linesDrawn([span(CONTENT)]);
+    expect(asSegments).toBe(asString);
+    expect(asString).toBeGreaterThan(1); // it really did wrap
   });
 });

--- a/tests/unit/renderer/text-renderer.test.ts
+++ b/tests/unit/renderer/text-renderer.test.ts
@@ -10,19 +10,21 @@ import { unitVerticals } from "../support/metrics";
 describe("TextRenderer - calculateTextHeight", () => {
   it("should calculate the correct text height for a simple string", () => {
     const mockObjectManager = {
-      getStringWidth: vi.fn().mockReturnValue(10), // String width is used for each word = 20
-      getCharWidth: vi.fn().mockReturnValue(5), // Used for empty spaces = 5
+      // Consistent font (getStringWidth is the sum of getCharWidth): every glyph, space included, 5 wide.
+      getStringWidth: vi.fn((t: string) => t.length * 5),
+      getCharWidth: vi.fn().mockReturnValue(5),
       getFontVerticals: unitVerticals,
       struct: { enabled: false },
     } as unknown as PDFObjectManager;
 
+    // "Hello World" is 11 glyphs * 5 = 55 wide; width 100 leaves it on one line.
     const textHeight = TextRenderer.calculateTextHeight(
       "Hello World",
       12,
       "Helvetica",
       FontStyle.Normal,
       mockObjectManager,
-      25,
+      100,
     );
 
     expect(textHeight).toBe(12); // No line breaks

--- a/tests/unit/text/advance.test.ts
+++ b/tests/unit/text/advance.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { codePointCount, runAdvance } from "../../../src/lib/text/advance";
+import { PDFObjectManager, FontStyle } from "../../../src/lib/utils/pdf-object-manager";
+import type { FontMetrics } from "../../../src/lib/utils/font-metrics";
+
+// The one canonical run advance. letterSpacing is added after EVERY code point (the `Tc` operator),
+// the last one included - measuring `(n - 1)` would draw one spacing wider than it was wrapped.
+
+const helvetica = () => {
+  const m = new PDFObjectManager();
+  m.registerFont("Helvetica", FontStyle.Normal, "Helvetica");
+  return m;
+};
+const font = { fontFamily: "Helvetica", fontSize: 100, fontStyle: FontStyle.Normal };
+
+describe("codePointCount", () => {
+  it("counts code points, not UTF-16 units (an astral char is one)", () => {
+    expect(codePointCount("abc")).toBe(3);
+    expect(codePointCount(" ")).toBe(1);
+    expect(codePointCount("a😀b")).toBe(3); // the emoji is one code point, not two
+  });
+});
+
+describe("runAdvance", () => {
+  it("is the plain glyph width when there is no letter-spacing", () => {
+    const m = helvetica();
+    expect(runAdvance(m, "Total", font)).toBeCloseTo(
+      m.getStringWidth("Total", "Helvetica", 100, FontStyle.Normal),
+      9,
+    );
+  });
+
+  it("adds one spacing per code point, the last included", () => {
+    const m = helvetica();
+    const plain = m.getStringWidth("Total", "Helvetica", 100, FontStyle.Normal);
+    // "Total" is 5 code points -> 5 spacings, not 4.
+    expect(runAdvance(m, "Total", font, 3)).toBeCloseTo(plain + 5 * 3, 9);
+  });
+
+  it("counts the trailing spacing (n, not n-1) - the box must reserve what Tc draws", () => {
+    const m = helvetica();
+    const a = runAdvance(m, "ab", font, 10);
+    const b = runAdvance(m, "abc", font, 10);
+    // One more glyph adds its width AND one spacing.
+    const cWidth = m.getCharWidth("c", 100, undefined, "Helvetica", FontStyle.Normal);
+    expect(b - a).toBeCloseTo(cWidth + 10, 9);
+  });
+
+  it("tightens with a negative spacing", () => {
+    const m = helvetica();
+    const plain = m.getStringWidth("AV", "Helvetica", 100, FontStyle.Normal);
+    expect(runAdvance(m, "AV", font, -5)).toBeCloseTo(plain - 2 * 5, 9);
+  });
+
+  it("at spacing 0 returns the exact getStringWidth value (the fast path)", () => {
+    const m = helvetica();
+    const w = m.getStringWidth("hello world", "Helvetica", 100, FontStyle.Normal);
+    expect(runAdvance(m, "hello world", font, 0)).toBe(w);
+  });
+});
+
+describe("naturalWidth matches the wrapped width (via the shared primitive)", () => {
+  it("a spaced string measures the same whether laid out bounded or unbounded", async () => {
+    // The bug this guards: if the line-breaker and naturalWidth added spacing differently, a Row-sized
+    // text would re-wrap in its own box. Both call runAdvance, so they agree.
+    const { TextElement } = await import("../../../src/lib/elements/text-element");
+    const { BoxConstraints } = await import("../../../src/lib/layout/box-constraints");
+    const m: FontMetrics = {
+      getStringWidth: (t) => t.length * 6,
+      getCharWidth: () => 6,
+      getFontVerticals: () => ({ ascent: 0.8, descent: 0.2, lineGap: 0 }),
+    };
+    const ctx = { metrics: m, pageConfig: {} } as never;
+
+    const text = new TextElement({ fontSize: 10, content: "one two three", letterSpacing: 2 });
+    const unbounded = text.calculateLayout(
+      BoxConstraints.loose(Infinity, Infinity),
+      { x: 0, y: 0 },
+      ctx,
+    );
+    // 13 glyphs * 6 + 13 spacings * 2 = 78 + 26 = 104.
+    expect(unbounded.width).toBe(104);
+    // Laid out at exactly that width, it stays one line (height = one line box).
+    const bounded = text.calculateLayout(BoxConstraints.loose(104, Infinity), { x: 0, y: 0 }, ctx);
+    expect(bounded.height).toBe(10);
+  });
+});

--- a/tests/unit/text/kerning.test.ts
+++ b/tests/unit/text/kerning.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { PDFObjectManager, FontStyle } from "../../../src/lib/utils/pdf-object-manager";
+import { runAdvance } from "../../../src/lib/text/advance";
+import { Document, Page, Text, renderToBytes } from "../../../src/lib/api";
+
+// Standard-14 kerning: measuring (runAdvance) and drawing (a TJ array) both read the SAME AFM pairs,
+// so a kerned run is exactly as wide as it is drawn. OFF by default (embedded fonts are not kerned
+// yet), so every existing document stays byte-identical.
+
+const om = (kerning = false) => {
+  const m = new PDFObjectManager();
+  m.registerFont("Helvetica", FontStyle.Normal, "Helvetica");
+  m.setKerning(kerning);
+  return m;
+};
+
+describe("getKernPairs (AFM)", () => {
+  it("returns the font's declared pairs, one per gap", () => {
+    // Helvetica.afm: KPX A V -70, KPX V A -80. "AVA" has gaps A-V and V-A.
+    expect(om().getKernPairs("AVA", "Helvetica", FontStyle.Normal)).toEqual([-70, -80]);
+  });
+
+  it("is zero next to a space (letters are never kerned against a space)", () => {
+    const pairs = om().getKernPairs("A V", "Helvetica", FontStyle.Normal);
+    expect(pairs).toEqual([0, 0]); // A-space, space-V
+  });
+
+  it("is empty for a run shorter than two glyphs", () => {
+    expect(om().getKernPairs("A", "Helvetica", FontStyle.Normal)).toEqual([]);
+  });
+});
+
+describe("runAdvance with kerning", () => {
+  it("adds the kerning only when the document has it on", () => {
+    const off = om(false);
+    const on = om(true);
+    const font = { fontFamily: "Helvetica", fontSize: 1000, fontStyle: FontStyle.Normal };
+    const plain = off.getStringWidth("AV", "Helvetica", 1000, FontStyle.Normal);
+    expect(runAdvance(off, "AV", font)).toBeCloseTo(plain, 6); // off: no kerning
+    // on: A-V is -70 units at 1000pt em -> -70pt.
+    expect(runAdvance(on, "AV", font)).toBeCloseTo(plain - 70, 6);
+  });
+});
+
+describe("the backend emits a TJ that matches the measurement", () => {
+  const streamOf = async (kerning: boolean): Promise<string> => {
+    const bytes = await renderToBytes(
+      Document([Page({ margin: 20 }, [Text("AVATAR", { size: 40 })])]),
+      { compress: false, kerning },
+    );
+    return new TextDecoder("latin1").decode(bytes);
+  };
+
+  it("emits a plain Tj (no TJ) when kerning is off - byte-identical path", async () => {
+    const pdf = await streamOf(false);
+    expect(pdf).toContain("(AVATAR) Tj");
+    expect(pdf).not.toContain("TJ");
+  });
+
+  it("emits a TJ with the negated kern units between glyph chunks", async () => {
+    const pdf = await streamOf(true);
+    // KPX A V -70, V A -80, A T -120, T A -120 (A R has no pair) -> negated: 70 80 120 120.
+    expect(pdf).toMatch(/\[\(A\) 70 \(V\) 80 \(A\) 120 \(T\) 120 \(AR\)\] TJ/);
+    expect(pdf).not.toContain("(AVATAR) Tj");
+  });
+
+  it("the TJ advance equals runAdvance (measured == drawn)", async () => {
+    const m = om(true);
+    const font = { fontFamily: "Helvetica", fontSize: 40, fontStyle: FontStyle.Normal };
+    const measured = runAdvance(m, "AVATAR", font);
+    const plain = m.getStringWidth("AVATAR", "Helvetica", 40, FontStyle.Normal);
+    const kernUnits = m
+      .getKernPairs("AVATAR", "Helvetica", FontStyle.Normal)
+      .reduce((a, b) => a + b, 0);
+    // measured = plain glyph widths + kerning (em/1000 * size). The TJ moves the pen by exactly the
+    // same kern sum, so the drawn advance is identical.
+    expect(measured).toBeCloseTo(plain + (kernUnits / 1000) * 40, 6);
+  });
+});

--- a/tests/unit/text/kerning.test.ts
+++ b/tests/unit/text/kerning.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { PDFObjectManager, FontStyle } from "../../../src/lib/utils/pdf-object-manager";
 import { runAdvance } from "../../../src/lib/text/advance";
 import { Document, Page, Text, renderToBytes } from "../../../src/lib/api";
+import { buildKernTtf, buildGposKernTtf } from "../utils/ttf-fixture";
 
 // Standard-14 kerning: measuring (runAdvance) and drawing (a TJ array) both read the SAME AFM pairs,
 // so a kerned run is exactly as wide as it is drawn. OFF by default (embedded fonts are not kerned
@@ -75,5 +76,51 @@ describe("the backend emits a TJ that matches the measurement", () => {
     // measured = plain glyph widths + kerning (em/1000 * size). The TJ moves the pen by exactly the
     // same kern sum, so the drawn advance is identical.
     expect(measured).toBeCloseTo(plain + (kernUnits / 1000) * 40, 6);
+  });
+});
+
+describe("embedded fonts: kern table and GPOS", () => {
+  // The fixtures map 'A' -> gid 1, 'B' -> gid 2 (em 1000), and kern the pair A-B by a known amount.
+  const custom = (bytes: Uint8Array) => {
+    const m = new PDFObjectManager();
+    m.registerCustomFont("F", bytes, FontStyle.Normal);
+    m.setKerning(true);
+    return m;
+  };
+  const kern = (m: PDFObjectManager, text: string) => m.getKernPairs(text, "F", FontStyle.Normal);
+
+  it("reads kerning from a legacy `kern` table (format 0)", () => {
+    // The fixture kerns A-B by -100 font units at em 1000 -> -100 em/1000.
+    expect(kern(custom(buildKernTtf(-100)), "AB")).toEqual([-100]);
+    expect(kern(custom(buildKernTtf(40)), "AB")).toEqual([40]); // positive spreads
+  });
+
+  it("reads kerning from GPOS Type 2 on a font with NO kern table", () => {
+    // Only the GPOS PairPos parser (feature scan -> lookup -> coverage -> value record) can find this.
+    expect(kern(custom(buildGposKernTtf(-150)), "AB")).toEqual([-150]);
+  });
+
+  it("returns 0 for a pair the font does not kern, and next to a space", () => {
+    const m = custom(buildGposKernTtf(-150));
+    expect(kern(m, "BA")).toEqual([0]); // only A-B is kerned, not B-A
+    expect(kern(m, "A B")).toEqual([0, 0]); // never against a space
+  });
+
+  it("a run with no kern pairs measures the same with kerning on or off", () => {
+    const on = custom(buildKernTtf(-100));
+    const off = new PDFObjectManager();
+    off.registerCustomFont("F", buildKernTtf(-100), FontStyle.Normal);
+    const font = { fontFamily: "F", fontSize: 20, fontStyle: FontStyle.Normal };
+    // "BA" is unkerned by this fixture (only A-B is); on and off must be identical.
+    expect(runAdvance(on, "BA", font)).toBeCloseTo(runAdvance(off, "BA", font), 9);
+  });
+
+  it("kerning changes the advance of a kerned run by exactly the fixture amount", () => {
+    const on = custom(buildGposKernTtf(-150));
+    const font = { fontFamily: "F", fontSize: 1000, fontStyle: FontStyle.Normal };
+    const off = new PDFObjectManager();
+    off.registerCustomFont("F", buildGposKernTtf(-150), FontStyle.Normal);
+    // A-B kerned by -150 units at 1000pt em -> -150pt narrower.
+    expect(runAdvance(on, "AB", font)).toBeCloseTo(runAdvance(off, "AB", font) - 150, 6);
   });
 });

--- a/tests/unit/text/text-fragment.test.ts
+++ b/tests/unit/text/text-fragment.test.ts
@@ -9,8 +9,10 @@ import { unitVerticals } from "../support/metrics";
 // Deterministic metrics: each glyph is 10 wide, spaces are 0. With six 2-char words and
 // maxWidth 50 the greedy breaker yields three lines of two words each.
 const metrics: FontMetrics = {
-  getStringWidth: (text) => text.length * 10,
-  getCharWidth: () => 0,
+  // Consistent font: getStringWidth is the sum of getCharWidth (as it is in reality). Each glyph is
+  // 10 wide, a space is 0, so word widths are len*10 and spaces cost nothing - the arithmetic below.
+  getStringWidth: (text: string) => [...text].reduce((w, c) => w + (c === " " ? 0 : 10), 0),
+  getCharWidth: (c: string) => (c === " " ? 0 : 10),
   getFontVerticals: unitVerticals,
 };
 const ctx = { metrics } as LayoutContext;

--- a/tests/unit/utils/ttf-fixture.ts
+++ b/tests/unit/utils/ttf-fixture.ts
@@ -1,7 +1,8 @@
 // A minimal but valid TTF with the 5 metric tables and 4 glyphs (.notdef, 'A', 'B', ' ')
 // and known advance widths, so tests can assert exact metrics without an MB-sized font.
 // Pass `advances` to mint a distinct variant (e.g. a wider "bold") - default is A=500, B=700.
-export function buildTestTtf(advances: number[] = [0, 500, 700, 250]): Buffer {
+// The 5 metric tables of the minimal font: .notdef(0), 'A'(1), 'B'(2), ' '(3) at em 1000.
+function baseTables(advances: number[]): [string, Buffer][] {
   const head = Buffer.alloc(54);
   head.writeUInt16BE(1000, 18); // unitsPerEm
 
@@ -33,13 +34,82 @@ export function buildTestTtf(advances: number[] = [0, 500, 700, 250]): Buffer {
   cmapHeader.writeUInt32BE(12, 8); // subtable offset
   const cmap = Buffer.concat([cmapHeader, sub]);
 
-  return assembleTtf([
+  return [
     ["head", head],
     ["maxp", maxp],
     ["hhea", hhea],
     ["hmtx", hmtx],
     ["cmap", cmap],
-  ]);
+  ];
+}
+
+export function buildTestTtf(advances: number[] = [0, 500, 700, 250]): Buffer {
+  return assembleTtf(baseTables(advances));
+}
+
+// The minimal font plus a legacy `kern` table (format 0) kerning the pair A-B by `value` font units.
+// Layout: kern header(4) + subtable header(14: version, length, coverage, nPairs, search fields) +
+// one pair(6). Our reader takes length @p+2, coverage @p+4, nPairs @p+6, pairs @p+14 (p = byte 4).
+export function buildKernTtf(value = -100): Buffer {
+  const kern = Buffer.alloc(24);
+  kern.writeUInt16BE(0, 0); // kern version (OpenType/Microsoft)
+  kern.writeUInt16BE(1, 2); // nTables
+  kern.writeUInt16BE(0, 4); // subtable version               (p+0)
+  kern.writeUInt16BE(20, 6); // subtable length (14 + 6)       (p+2)
+  kern.writeUInt16BE(0x0001, 8); // coverage: horizontal, fmt 0 (p+4)
+  kern.writeUInt16BE(1, 10); // nPairs                          (p+6)
+  kern.writeUInt16BE(1, 18); // pair left glyph  A=1            (p+14)
+  kern.writeUInt16BE(2, 20); // pair right glyph B=2
+  kern.writeInt16BE(value, 22); // pair value
+  return assembleTtf([...baseTables([0, 500, 700, 250]), ["kern", kern]]);
+}
+
+// The minimal font plus a GPOS with a `kern` feature: one PairPos (format 1) lookup kerning A-B by
+// `xAdvance` font units. Exercises the feature scan, the lookup/subtable walk, coverage and the
+// value-record parsing - the whole GPOS Type 2 path, on a font that has NO `kern` table.
+export function buildGposKernTtf(xAdvance = -150): Buffer {
+  const g = Buffer.alloc(62);
+  // header
+  g.writeUInt16BE(1, 0); // majorVersion
+  g.writeUInt16BE(0, 2); // minorVersion
+  g.writeUInt16BE(10, 4); // scriptListOffset
+  g.writeUInt16BE(12, 6); // featureListOffset
+  g.writeUInt16BE(26, 8); // lookupListOffset
+  // scriptList @10: count 0
+  g.writeUInt16BE(0, 10);
+  // featureList @12: count 1, record "kern" -> feature @ +8
+  g.writeUInt16BE(1, 12);
+  g.write("kern", 14, "latin1");
+  g.writeUInt16BE(8, 18); // featureOffset (rel to featureList=12) -> 20
+  // feature table @20: featureParams 0, lookupIndexCount 1, lookupListIndex 0
+  g.writeUInt16BE(0, 20);
+  g.writeUInt16BE(1, 22);
+  g.writeUInt16BE(0, 24);
+  // lookupList @26: count 1, offset 4 -> lookup @30
+  g.writeUInt16BE(1, 26);
+  g.writeUInt16BE(4, 28);
+  // lookup @30: type 2, flag 0, subTableCount 1, subtableOffset 8 -> subtable @38
+  g.writeUInt16BE(2, 30);
+  g.writeUInt16BE(0, 32);
+  g.writeUInt16BE(1, 34);
+  g.writeUInt16BE(8, 36);
+  // PairPos format 1 @38: posFormat 1, coverageOffset 12, valueFormat1 0x0004, valueFormat2 0,
+  //                       pairSetCount 1, pairSetOffset 18
+  g.writeUInt16BE(1, 38);
+  g.writeUInt16BE(12, 40); // coverage @50
+  g.writeUInt16BE(0x0004, 42); // valueFormat1 = XAdvance
+  g.writeUInt16BE(0, 44); // valueFormat2
+  g.writeUInt16BE(1, 46); // pairSetCount
+  g.writeUInt16BE(18, 48); // pairSetOffset @56
+  // coverage (format 1) @50: format 1, glyphCount 1, glyph A=1
+  g.writeUInt16BE(1, 50);
+  g.writeUInt16BE(1, 52);
+  g.writeUInt16BE(1, 54);
+  // pairSet @56: pairValueCount 1, {secondGlyph B=2, value1.xAdvance}
+  g.writeUInt16BE(1, 56);
+  g.writeUInt16BE(2, 58);
+  g.writeInt16BE(xAdvance, 60);
+  return assembleTtf([...baseTables([0, 500, 700, 250]), ["GPOS", g]]);
 }
 
 // A minimal TTF whose cmap is FORMAT 12, mapping a single astral code point (default U+1F600 😀)


### PR DESCRIPTION
## Summary
A big step! Now jasy have letter spacing AND real kerning!

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `letterSpacing` styling support across text components, including correct wrapping/sizing and underline/decoration alignment.
  * Added experimental PDF kerning support via a new `kerning` render option (off by default), improving glyph spacing consistency in output.

* **Tests**
  * Added/expanded unit tests validating `letterSpacing` PDF `Tc` emission/placement, spacing-aware advance/measurement, and correct kerning behavior (including `TJ` output) across fonts.
  * Updated layout/font-metrics mocks and fixtures to reflect spacing behavior more realistically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->