### PR TITLE
feat: `AcroForm` support in `VUE`

### DIFF
--- a/packages/vue/playground/App.vue
+++ b/packages/vue/playground/App.vue
@@ -9,6 +9,7 @@ import Showcase from "./samples/Showcase.vue";
 import Report from "./samples/Report.vue";
 import Transparency from "./samples/Transparency.vue";
 import Encrypted from "./samples/Encrypted.vue";
+import Form from "./samples/Form.vue";
 import fontUrl from "./assets/GreatVibes-Regular.ttf?url";
 import imgUrl from "./assets/photo.jpg?url";
 import logoUrl from "./assets/logo.png?url";
@@ -21,6 +22,7 @@ const samples: { label: string; comp: any; assets?: AssetKey[]; encrypt?: boolea
   { label: "Invitation", comp: Invitation },
   { label: "Showcase", comp: Showcase, assets: ["font", "image"] },
   { label: "Transparency", comp: Transparency, assets: ["logo"] },
+  { label: "Form", comp: Form },
   { label: "Encrypted", comp: Encrypted, encrypt: true },
 ];
 

--- a/packages/vue/playground/samples/Form.vue
+++ b/packages/vue/playground/samples/Form.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+// Namespace import - sidesteps a UI lib's own Row/Text/Box without per-name aliasing.
+import * as Pdf from "@jasy/vue";
+import { ref, computed } from "vue";
+
+// The point of the sample: the PDF is built from ordinary reactive state. Type in the boxes on the left
+// and the form fields IN THE GENERATED PDF change with them - rendered in this browser, no server.
+const name = ref("Ada Lovelace");
+const notes = ref("jasyPDF is great!");
+const plan = ref("pro");
+
+// Options come from data, in the short spelling where the stored value IS the visible text ...
+const sizes = ["S", "M", "L"];
+// ... and in the explicit one where they differ: the PDF stores "EUR", the reader sees "Euro".
+const currencies = [
+  { value: "EUR", label: "Euro" },
+  { value: "CHF", label: "Swiss franc" },
+  { value: "GBP", label: "Pound sterling" },
+];
+
+const label = computed(() => `I agree to the terms, ${name.value.split(" ")[0]}`);
+</script>
+
+<template>
+  <Pdf.Document :size="11">
+    <Pdf.Page :size="'A4'" :margin="48" :gap="6">
+      <Pdf.Text :size="24" bold :color="'#0a2348'">Membership form</Pdf.Text>
+      <Pdf.Text :size="11" :color="'#475569'"
+        >Every field below is a real AcroForm widget. Open the PDF in any viewer and type into
+        it.</Pdf.Text
+      >
+
+      <Pdf.Text :size="9" :color="'#64748b'">Full name</Pdf.Text>
+      <Pdf.TextField name="full_name" :value="name" :height="24" border="#94a3b8" />
+
+      <Pdf.Text :size="9" :color="'#64748b'">Notes (multiline)</Pdf.Text>
+      <Pdf.TextField name="notes" :value="notes" multiline :height="52" border="#94a3b8" />
+
+      <!-- The label is the default slot: no Row to assemble by hand. -->
+      <Pdf.Checkbox name="agree" checked :size="14">{{ label }}</Pdf.Checkbox>
+
+      <Pdf.Text :size="9" :color="'#64748b'">Plan</Pdf.Text>
+      <Pdf.RadioGroup name="plan" :value="plan" :size="14" :options="['basic', 'pro']" />
+
+      <Pdf.Text :size="9" :color="'#64748b'">Size - options as plain strings</Pdf.Text>
+      <Pdf.ListBox
+        name="size"
+        value="M"
+        :width="200"
+        :height="56"
+        border="#94a3b8"
+        :options="sizes"
+      />
+
+      <Pdf.Text :size="9" :color="'#64748b'">Currency - value and label differ</Pdf.Text>
+      <Pdf.Dropdown
+        name="currency"
+        value="EUR"
+        :width="200"
+        :height="21"
+        border="#94a3b8"
+        :options="currencies"
+      />
+
+      <Pdf.Row :gap="12">
+        <Pdf.PushButton name="submit" :width="120" :height="26">Submit</Pdf.PushButton>
+        <Pdf.PushButton name="reset" :width="120" :height="26" :action="'reset'"
+          >Reset</Pdf.PushButton
+        >
+      </Pdf.Row>
+
+      <Pdf.Text :size="9" :color="'#64748b'">Signature</Pdf.Text>
+      <Pdf.SignatureField name="sig" :width="240" :height="46">Sign here</Pdf.SignatureField>
+
+      <Pdf.Spacer />
+      <Pdf.Text :size="10" :color="'#94a3b8'"
+        >Rendered 100% in your browser by @jasy/vue - no Java, no headless browser.</Pdf.Text
+      >
+    </Pdf.Page>
+  </Pdf.Document>
+</template>

--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -1,5 +1,6 @@
 import { defineComponent, h, type PropType } from "vue";
 import type {
+  ButtonActionInput,
   ColorInput,
   Insets,
   ImageSource,
@@ -318,4 +319,182 @@ export const PageCount = defineComponent({
   inheritAttrs: false,
   props: pageNumberProps,
   setup: fwd("page-count"),
+});
+
+// ---------------------------------------------------------------------------------------------
+// Form fields
+// ---------------------------------------------------------------------------------------------
+// Two places where the template surface deliberately differs from the TypeScript one, both because a
+// template has no second argument and no way to compose a helper inline:
+//
+//   - the list-like fields take their choices as `:options`, not as a second parameter;
+//   - a field's LABEL is the default slot, so `<JasyCheckbox name="agree">I agree</JasyCheckbox>` writes
+//     itself instead of being assembled from a Row, a Checkbox and a Text.
+//
+// There is deliberately no `v-model`. It would promise two-way binding, and a generated PDF writes
+// nothing back - `:value` says exactly what happens.
+
+/** Shared by every field: what the PDF format lets you say about one, regardless of its kind. */
+const fieldProps = {
+  /** The field name - unique in the document; you read the value back by it. */
+  name: { type: String, required: true as const },
+  /** Tooltip / accessible name shown on hover. */
+  tooltip: String,
+  /** Show the value but do not let the reader change it. */
+  readOnly: { type: Boolean, default: undefined },
+  /** Must be filled in before the form is submitted. */
+  required: { type: Boolean, default: undefined },
+  /** Hide the widget entirely - neither on screen nor in print. */
+  hidden: { type: Boolean, default: undefined },
+  /** Include the widget when printing (default true). */
+  print: { type: Boolean, default: undefined },
+  width: Number,
+  height: Number,
+  color: colorProp,
+  border: colorProp,
+  background: colorProp,
+  borderWidth: Number,
+};
+
+/** The label a field draws beside itself. Usually the default slot; the prop is there for the cases a
+ *  slot cannot cover - a computed string, or a field built in a `v-for`. The slot wins when both exist. */
+const labelProps = {
+  label: String,
+  labelSize: Number,
+  labelColor: colorProp,
+  labelGap: Number,
+};
+
+/** `["S", "M"]` or `[{ value: "DE", label: "Germany" }]` - both accepted. */
+type ChoiceInput = string | { value: string; label?: string };
+const optionsProp = {
+  options: {
+    type: Array as PropType<ChoiceInput[]>,
+    required: true as const,
+  },
+};
+
+/**
+ * Forwards the default slot as a `label` PROP rather than as children: a field's label is text the
+ * factory draws beside the box, not a child element, and passing it as a child would make it a sibling
+ * the layout knows nothing about.
+ */
+const fwdLabelled =
+  (tag: string) =>
+  (props: any, { slots, attrs }: any) =>
+  () => {
+    const slot = slots.default?.();
+    const fromSlot = slot
+      ?.map((v: any) => (typeof v.children === "string" ? v.children : ""))
+      .join("")
+      .trim();
+    const label = fromSlot || props.label;
+    return h(tag, { ...attrs, ...props, ...(label ? { label } : {}) });
+  };
+
+export const TextField = defineComponent({
+  name: "JasyTextField",
+  inheritAttrs: false,
+  props: {
+    ...fieldProps,
+    /** Initial value written into the document. */
+    value: String,
+    /** Accept several lines (give it a `height` to match). */
+    multiline: { type: Boolean, default: undefined },
+    /** Mask the characters - a password field. */
+    password: { type: Boolean, default: undefined },
+    /** How the value sits in the box. */
+    align: String as PropType<"left" | "center" | "right">,
+    maxLength: Number,
+    fontSize: Number,
+  },
+  setup: fwd("text-field"),
+});
+
+export const Checkbox = defineComponent({
+  name: "JasyCheckbox",
+  inheritAttrs: false,
+  props: {
+    ...fieldProps,
+    ...labelProps,
+    /** Whether it starts ticked. */
+    checked: { type: Boolean, default: undefined },
+    /** The value stored when ticked (default "Yes"). */
+    onValue: String,
+    /** Box side length in points. */
+    size: Number,
+  },
+  setup: fwdLabelled("checkbox"),
+});
+
+export const RadioGroup = defineComponent({
+  name: "JasyRadioGroup",
+  inheritAttrs: false,
+  props: {
+    ...fieldProps,
+    ...labelProps,
+    ...optionsProp,
+    /** Which option starts selected, by its value. */
+    value: String,
+    /** Button diameter in points. */
+    size: Number,
+    /** Space between the buttons. */
+    gap: Number,
+  },
+  setup: fwd("radio-group"),
+});
+
+export const Dropdown = defineComponent({
+  name: "JasyDropdown",
+  inheritAttrs: false,
+  props: {
+    ...fieldProps,
+    ...optionsProp,
+    value: String,
+    /** Let the reader type a value that is not in the list. */
+    editable: { type: Boolean, default: undefined },
+    fontSize: Number,
+  },
+  setup: fwd("dropdown"),
+});
+
+export const ListBox = defineComponent({
+  name: "JasyListBox",
+  inheritAttrs: false,
+  props: {
+    ...fieldProps,
+    ...optionsProp,
+    value: String,
+    /** Several values selectable at once. */
+    multiSelect: { type: Boolean, default: undefined },
+    fontSize: Number,
+  },
+  setup: fwd("list-box"),
+});
+
+export const PushButton = defineComponent({
+  name: "JasyPushButton",
+  inheritAttrs: false,
+  props: {
+    ...fieldProps,
+    ...labelProps,
+    /**
+     * What pressing it does: `"reset"` clears the form, `{ submit: url }` posts it, `{ open: url }`
+     * follows a link. Viewer support varies and is documented on the factory - reset is the one that
+     * works everywhere.
+     */
+    action: [String, Object] as PropType<ButtonActionInput>,
+    fontSize: Number,
+  },
+  setup: fwdLabelled("push-button"),
+});
+
+export const SignatureField = defineComponent({
+  name: "JasySignatureField",
+  inheritAttrs: false,
+  props: {
+    ...fieldProps,
+    ...labelProps,
+  },
+  setup: fwdLabelled("signature-field"),
 });

--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -356,14 +356,23 @@ const fieldProps = {
   borderWidth: Number,
 };
 
-/** The label a field draws beside itself. Usually the default slot; the prop is there for the cases a
- *  slot cannot cover - a computed string, or a field built in a `v-for`. The slot wins when both exist. */
-const labelProps = {
-  label: String,
+/**
+ * The label a field draws beside itself. Usually the default slot; the prop is there for the cases a slot
+ * cannot cover - a computed string, or a field built in a `v-for`. The slot wins when both exist.
+ *
+ * Split into three sets rather than one, because the factories genuinely differ and a prop the engine
+ * ignores is worse than a missing one: it looks like a knob and does nothing. Only a check box styles its
+ * own label; a push button and a signature field draw theirs inside the widget; a radio group has no
+ * single label at all - `labelSize`/`labelColor` there style the CHOICES.
+ */
+const labelOnly = { label: String };
+const checkboxLabelProps = {
+  ...labelOnly,
   labelSize: Number,
   labelColor: colorProp,
   labelGap: Number,
 };
+const choiceLabelProps = { labelSize: Number, labelColor: colorProp };
 
 /** `["S", "M"]` or `[{ value: "DE", label: "Germany" }]` - both accepted. */
 type ChoiceInput = string | { value: string; label?: string };
@@ -416,7 +425,7 @@ export const Checkbox = defineComponent({
   inheritAttrs: false,
   props: {
     ...fieldProps,
-    ...labelProps,
+    ...checkboxLabelProps,
     /** Whether it starts ticked. */
     checked: { type: Boolean, default: undefined },
     /** The value stored when ticked (default "Yes"). */
@@ -432,7 +441,7 @@ export const RadioGroup = defineComponent({
   inheritAttrs: false,
   props: {
     ...fieldProps,
-    ...labelProps,
+    ...choiceLabelProps,
     ...optionsProp,
     /** Which option starts selected, by its value. */
     value: String,
@@ -477,7 +486,7 @@ export const PushButton = defineComponent({
   inheritAttrs: false,
   props: {
     ...fieldProps,
-    ...labelProps,
+    ...labelOnly,
     /**
      * What pressing it does: `"reset"` clears the form, `{ submit: url }` posts it, `{ open: url }`
      * follows a link. Viewer support varies and is documented on the factory - reset is the one that
@@ -494,7 +503,7 @@ export const SignatureField = defineComponent({
   inheritAttrs: false,
   props: {
     ...fieldProps,
-    ...labelProps,
+    ...labelOnly,
   },
   setup: fwdLabelled("signature-field"),
 });

--- a/packages/vue/tests/forms.test.ts
+++ b/packages/vue/tests/forms.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import { h, type Component } from "vue";
+import {
+  Checkbox,
+  Column,
+  Document,
+  Dropdown,
+  ListBox,
+  Page,
+  PushButton,
+  RadioGroup,
+  SignatureField,
+  TextField,
+  renderToPdf,
+  renderToPdfString,
+} from "../src/index.ts";
+import { PdfDocument, readAcroForm } from "@jasy/pdf/edit";
+
+// Form fields as Vue components. Two things are deliberately NOT a one-to-one mapping of the TypeScript
+// surface, and both are what these tests are mostly about:
+//
+//   - the list-like fields take `:options`, because a template has no second argument;
+//   - a field's label is the default slot, so a check box is one tag instead of a Row + Checkbox + Text.
+
+const doc = (...children: unknown[]): Component => ({
+  render: () => h(Document, {}, () => h(Page, { margin: 40 }, () => h(Column, {}, () => children))),
+});
+
+/** Render, then read the result back with our own reader - the fields are what the test is about. */
+const fieldsOf = async (component: Component) => {
+  const form = readAcroForm(PdfDocument.load(await renderToPdf(component)));
+  return form?.fields ?? [];
+};
+
+describe("form fields as components", () => {
+  it("carries every kind through to a real AcroForm", async () => {
+    const fields = await fieldsOf(
+      doc(
+        h(TextField, { name: "full_name", value: "Ada Lovelace", height: 24 }),
+        h(Checkbox, { name: "agree", checked: true }),
+        h(RadioGroup, { name: "plan", value: "pro", options: ["basic", "pro"] }),
+        h(Dropdown, { name: "country", value: "France", options: ["Germany", "France"] }),
+        h(ListBox, { name: "size", value: "M", options: ["S", "M", "L"] }),
+        h(PushButton, { name: "go", label: "Submit" }),
+        h(SignatureField, { name: "sig", label: "Sign" }),
+      ),
+    );
+    expect(fields.map((f) => [f.name, f.type])).toEqual([
+      ["full_name", "Tx"],
+      ["agree", "Btn"],
+      ["plan", "Btn"],
+      ["country", "Ch"],
+      ["size", "Ch"],
+      ["go", "Btn"],
+      ["sig", "Sig"],
+    ]);
+    expect(fields.find((f) => f.name === "full_name")?.value).toBe("Ada Lovelace");
+    expect(fields.find((f) => f.name === "plan")?.value).toBe("pro");
+  });
+
+  it("takes the choices as a prop, in either spelling", async () => {
+    // The short one where the stored value IS the visible text, the explicit one where they differ.
+    const fields = await fieldsOf(
+      doc(
+        h(Dropdown, { name: "size", options: ["S", "M"] }),
+        h(Dropdown, {
+          name: "currency",
+          options: [
+            { value: "EUR", label: "Euro" },
+            { value: "CHF", label: "Swiss franc" },
+          ],
+        }),
+      ),
+    );
+    expect(fields.find((f) => f.name === "size")?.options).toEqual([
+      { value: "S", label: "S" },
+      { value: "M", label: "M" },
+    ]);
+    expect(fields.find((f) => f.name === "currency")?.options).toEqual([
+      { value: "EUR", label: "Euro" },
+      { value: "CHF", label: "Swiss franc" },
+    ]);
+  });
+
+  it("says what is wrong when the choices are missing", async () => {
+    // A choice field without options is a field the reader can never answer. Better a named error than
+    // an empty dropdown nobody notices until the form comes back blank.
+    // Thrown while the tree is built, so it surfaces synchronously - catch either shape.
+    const err = await Promise.resolve()
+      .then(() => renderToPdf(doc(h(Dropdown, { name: "x" } as never))))
+      .then(
+        () => undefined,
+        (e) => e,
+      );
+    expect(String(err)).toMatch(/options/);
+  });
+});
+
+describe("the label is the default slot", () => {
+  it("draws the text beside the box without a Row to assemble", async () => {
+    // Uncompressed, otherwise the text sits inside a Flate stream. And unkerned: a label is ordinary
+    // PAGE text, which kerning splits into a TJ array, so the string is no longer contiguous. (A field's
+    // own appearance is unkerned anyway - viewers do not kern field text.)
+    const pdf = await renderToPdfString(
+      doc(h(Checkbox, { name: "agree", checked: true }, () => "I agree to the terms")),
+      undefined,
+      { compress: false, kerning: false },
+    );
+    expect(pdf).toContain("I agree to the terms");
+    // ... and it really is one field, not a stray text element that happens to sit nearby.
+    const fields = await fieldsOf(
+      doc(h(Checkbox, { name: "agree", checked: true }, () => "I agree to the terms")),
+    );
+    expect(fields.map((f) => f.name)).toEqual(["agree"]);
+  });
+
+  it("labels a push button and a signature field the same way", async () => {
+    const pdf = await renderToPdfString(
+      doc(
+        h(PushButton, { name: "go" }, () => "Submit"),
+        h(SignatureField, { name: "sig" }, () => "Sign here"),
+      ),
+      undefined,
+      { compress: false },
+    );
+    expect(pdf).toContain("Submit");
+    expect(pdf).toContain("Sign here");
+  });
+
+  it("leaves a field without a slot exactly as it was", async () => {
+    // The label is optional everywhere; omitting it must not wrap anything.
+    const fields = await fieldsOf(doc(h(Checkbox, { name: "agree" })));
+    expect(fields.map((f) => f.name)).toEqual(["agree"]);
+  });
+});
+
+describe("a field name is an identity", () => {
+  it("refuses two fields of the same name", async () => {
+    // The format allows it and says nothing: a viewer treats them as ONE field, showing the same value
+    // in both places. Silent in every other library, named here.
+    const err = await Promise.resolve()
+      .then(() => renderToPdf(doc(h(TextField, { name: "email" }), h(Checkbox, { name: "email" }))))
+      .then(
+        () => undefined,
+        (e) => e,
+      );
+    expect(String(err)).toMatch(/two form fields are called "email"/);
+  });
+
+  it("still lets a radio group share one name across its buttons", async () => {
+    // That is what MAKES a radio group - the shared name is why the buttons are mutually exclusive.
+    const fields = await fieldsOf(
+      doc(h(RadioGroup, { name: "plan", value: "a", options: ["a", "b", "c"] })),
+    );
+    expect(fields.map((f) => f.name)).toEqual(["plan"]);
+    expect(fields[0].widgets.length).toBe(3);
+  });
+});

--- a/packages/vue/tests/forms.test.ts
+++ b/packages/vue/tests/forms.test.ts
@@ -147,6 +147,35 @@ describe("a field name is an identity", () => {
     expect(String(err)).toMatch(/two form fields are called "email"/);
   });
 
+  it("catches a radio group colliding with an ordinary field", async () => {
+    // The group's own buttons share a name on purpose, so the check has to fire once per GROUP - not per
+    // button, or the group would collide with itself.
+    const err = await Promise.resolve()
+      .then(() =>
+        renderToPdf(
+          doc(h(TextField, { name: "plan" }), h(RadioGroup, { name: "plan", options: ["a"] })),
+        ),
+      )
+      .then(
+        () => undefined,
+        (e) => e,
+      );
+    expect(String(err)).toMatch(/two form fields are called "plan"/);
+  });
+
+  it("lets a second group of the same name JOIN the first", async () => {
+    // Deliberate: it is how one question's buttons are placed in two different spots and stay mutually
+    // exclusive. They end up as one field with all the widgets.
+    const fields = await fieldsOf(
+      doc(
+        h(RadioGroup, { name: "plan", options: ["a", "b"] }),
+        h(RadioGroup, { name: "plan", options: ["c"] }),
+      ),
+    );
+    expect(fields.map((f) => f.name)).toEqual(["plan"]);
+    expect(fields[0].widgets.length).toBe(3);
+  });
+
   it("still lets a radio group share one name across its buttons", async () => {
     // That is what MAKES a radio group - the shared name is why the buttons are mutually exclusive.
     const fields = await fieldsOf(

--- a/src/lib/api/descriptor.ts
+++ b/src/lib/api/descriptor.ts
@@ -23,6 +23,15 @@ import { Divider, Image } from "./content.ts";
 import { Page, Document, DefaultTextStyle } from "./structure.ts";
 import { PageNumber, PageCount } from "./page-builder.ts";
 import { Table, Cell } from "./table.ts";
+import {
+  Checkbox,
+  Dropdown,
+  ListBox,
+  PushButton,
+  RadioGroup,
+  SignatureField,
+  TextField,
+} from "./forms.ts";
 
 /**
  * The framework-agnostic contract (the firewall). A binding (Vue/React, or any tree-builder)
@@ -156,7 +165,34 @@ const REGISTRY: Record<string, ElementFactory> = {
   // cannot express. These two cover what the closure exists for.
   "page-number": (props) => PageNumber(props),
   "page-count": (props) => PageCount(props),
+
+  // Form fields. The three list-like ones take their choices as a SECOND argument in TypeScript; a
+  // template has no second argument, so here they arrive as an `options` prop. `choiceList` accepts both
+  // the short spelling and the explicit one, because an export value and its label are usually the same
+  // string and having to write it twice is noise.
+  "text-field": (props) => TextField(props),
+  checkbox: (props) => Checkbox(props),
+  "radio-group": (props) => RadioGroup(props, radioChoices(props.options)),
+  dropdown: (props) => Dropdown(props, choiceList(props.options)),
+  "list-box": (props) => ListBox(props, choiceList(props.options)),
+  "push-button": (props) => PushButton(props),
+  "signature-field": (props) => SignatureField(props),
 };
+
+/** `["S", "M"]` or `[{ value: "DE", label: "Germany" }]` - both mean the same thing to a choice field. */
+function choiceList(raw: unknown): Array<string | { value: string; label?: string }> {
+  if (!Array.isArray(raw)) {
+    throw new Error("jasy: a choice field needs an `options` array (strings or {value, label}).");
+  }
+  return raw as Array<string | { value: string; label?: string }>;
+}
+
+/** A radio button always shows a label, so the short spelling means "label is the value". */
+function radioChoices(raw: unknown): Array<{ value: string; label: string }> {
+  return choiceList(raw).map((o) =>
+    typeof o === "string" ? { value: o, label: o } : { value: o.value, label: o.label ?? o.value },
+  );
+}
 
 /**
  * Registers a custom element type, so a binding (or a user-defined component) can introduce

--- a/src/lib/api/forms.ts
+++ b/src/lib/api/forms.ts
@@ -76,6 +76,15 @@ export function TextField(opts: TextFieldOptions): TextFieldElement {
 export interface CheckboxOptions {
   /** The field name - unique in the document. */
   name: string;
+  /** Text placed beside the box. Given one, the box and the text become a row - the same shape
+   *  `RadioGroup` builds for its choices, so a lone check box does not have to be assembled by hand. */
+  label?: string;
+  /** Size of the label text (default 12). */
+  labelSize?: number;
+  /** Colour of the label text. */
+  labelColor?: ColorInput;
+  /** Space between the box and its label, in points (default 8). */
+  labelGap?: number;
   /** Whether it starts checked. */
   checked?: boolean;
   /** The "on" export value stored when checked (default `"Yes"`). */
@@ -110,13 +119,19 @@ export interface CheckboxOptions {
  * Row({ gap: 6, align: "center" }, [Checkbox({ name: "agree" }), Text("I agree")])
  * ```
  */
-export function Checkbox(opts: CheckboxOptions): CheckboxElement {
-  return new CheckboxElement({
+export function Checkbox(opts: CheckboxOptions): PDFElement {
+  const box = new CheckboxElement({
     ...opts,
     color: opts.color !== undefined ? toColor(opts.color) : undefined,
     border: opts.border !== undefined ? toColor(opts.border) : undefined,
     background: opts.background !== undefined ? toColor(opts.background) : undefined,
   });
+  // Without a label the box IS the element, so nothing wraps it and the output is unchanged.
+  if (opts.label === undefined) return box;
+  return Row({ gap: opts.labelGap ?? 8, align: "center" }, [
+    box,
+    Text(opts.label, { size: opts.labelSize ?? 12, color: opts.labelColor }),
+  ]);
 }
 
 /** Options for a single `Radio` button. Several sharing a `group` are one mutually-exclusive field. */

--- a/src/lib/forms/acroform.ts
+++ b/src/lib/forms/acroform.ts
@@ -216,6 +216,8 @@ export class AcroFormCollector {
   private zadbNum?: number;
   // Set once a signature field exists; the catalog then needs /SigFlags.
   private hasSignature = false;
+  // Field name -> its kind, so a collision can say WHAT collided.
+  private usedNames = new Map<string, string>();
   // Bake every field's appearance (default). Off = emit no /AP and set /NeedAppearances, i.e. let the
   // viewer draw everything - what react-pdf/pdfkit always does, and what we did before this step.
   private bake = true;
@@ -348,10 +350,31 @@ export class AcroFormCollector {
     ));
   }
 
+  /**
+   * A field name is its identity: two fields sharing one are ONE field to every viewer, showing the same
+   * value in both places and overwriting each other as the reader types. The format allows it and says
+   * nothing, so the mistake surfaces only when someone fills the form. Named here instead.
+   *
+   * A radio GROUP is the exception - its buttons deliberately share a name, which is what makes them
+   * mutually exclusive - so it never comes through here.
+   */
+  private claimName(name: string, kind: string): void {
+    const taken = this.usedNames.get(name);
+    if (taken !== undefined) {
+      throw new Error(
+        `@jasy/pdf: two form fields are called "${name}" (a ${taken} and a ${kind}). A name is a field's ` +
+          "identity - a viewer would treat them as one field and show the same value in both places. " +
+          "Give them different names, or use a RadioGroup if they are meant to belong together.",
+      );
+    }
+    this.usedNames.set(name, kind);
+  }
+
   /** Emit the widget object for one form-field IR node, register it as a field, and return its object
    *  number so the PageRenderer can add it to that page's /Annots. */
   addField(node: FormFieldNode, om: PDFObjectManager): number {
     if (node.field.kind === "radio") return this.addRadio(node, om);
+    this.claimName(node.field.name, node.field.kind);
     let dict: string;
     if (node.field.kind === "checkbox") {
       this.zadb(om); // its /DA names /ZaDb, so /DR has to carry it

--- a/src/lib/forms/acroform.ts
+++ b/src/lib/forms/acroform.ts
@@ -448,6 +448,11 @@ export class AcroFormCollector {
     if (f.kind !== "radio") throw new Error("addRadio: not a radio");
     let g = this.radioGroups.get(f.group);
     if (!g) {
+      // Claimed ONCE, when the group comes into being: its buttons share the name deliberately, but the
+      // group as a whole still has to collide with a text field of the same name like any other field.
+      // A SECOND RadioGroup of the same name therefore joins this one rather than colliding - that is
+      // how the buttons of one question are placed in two different spots and stay exclusive.
+      this.claimName(f.group, "radio group");
       g = { parentNum: om.addObject(""), kids: [], flags: 0 };
       this.radioGroups.set(f.group, g);
       this.fieldRefs.push(g.parentNum);

--- a/src/lib/validators/element-validator.ts
+++ b/src/lib/validators/element-validator.ts
@@ -56,9 +56,15 @@ export class Validator {
   }
 
   static validateFlexElement(element: FlexiblePDFElement): void {
-    // Ensure flexible elements have valid flex values
-    if (element.getFlex() <= 0) {
-      throw new Error(`Flexible element ${element.constructor.name} has invalid flex value`);
+    // Ensure flexible elements have valid flex values. The message names what the CALLER wrote, not the
+    // element class: `Spacer` and `Expanded` are what exists in their document, `ExpandedElement` is not.
+    const flex = element.getFlex();
+    if (flex <= 0) {
+      throw new Error(
+        `@jasy/pdf: Spacer/Expanded needs a flex above 0, got ${flex}. Flex is a SHARE of the leftover ` +
+          "space, so 0 would claim none - which is what leaving the element out does. For a fixed gap " +
+          "use the `gap` of the surrounding Column or Row, or a Box with a height.",
+      );
     }
 
     // Ensure a flexible element does not contain another flexible element

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
   // the TS source so they run against live source without a build step.
   resolve: {
     alias: {
+      // The subpath needs its own entry: an alias matches exactly, so "@jasy/pdf" alone would leave
+      // "@jasy/pdf/edit" to fall through to node resolution, which vitest handles differently.
+      "@jasy/pdf/edit": resolve(rootDir, "src/lib/edit/index.ts"),
       "@jasy/pdf": resolve(rootDir, "src/lib/index.ts"),
       // @jasy/e-invoice has no dist in a fresh CI test job (build runs in a separate job); alias it to
       // source too so the CLI suites resolve it without a build, same as @jasy/pdf above.


### PR DESCRIPTION
## Summary

AcroForm in VUE apps! Create each form field you want!

## Related issue(s)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Vue PDF form-field components (text, checkbox, radio group, dropdown, list box, push button, signature) and wired them into the renderer.
  * Added customizable labeled checkboxes and updated label handling across choice/button/signature fields.
  * Added a “Membership form” example to the Vue playground.
* **Bug Fixes**
  * Improved form-field option validation and enforced clearer duplicate-name collision rules.
  * Improved validation for invalid flex values.
* **Tests**
  * Added end-to-end PDF AcroForm tests covering labels, choice options, radio behavior, and field naming collisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->