### PR TITLE
feat: `AcroForm` support in `Nuxt`

### DIFF
--- a/packages/nuxt/playground/Form.vue
+++ b/packages/nuxt/playground/Form.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+// No imports at all: @jasy/nuxt auto-registers the form components alongside Document/Page/Text.
+// The values come from ordinary reactive state, so the PDF is built from whatever the app knows.
+const holder = ref("Ada Lovelace");
+const notes = ref("jasyPDF is also great with Nuxt!");
+const currencies = [
+  { value: "EUR", label: "Euro" },
+  { value: "CHF", label: "Swiss franc" },
+];
+</script>
+
+<template>
+  <Document :size="11">
+    <Page size="A4" :margin="48" :gap="6">
+      <Text :size="24" bold color="#0a2348">Membership form</Text>
+      <Text :size="11" color="#475569">
+        Rendered in your browser. Every field below is a real AcroForm widget - type into it.
+      </Text>
+
+      <Text :size="9" color="#64748b">Full name</Text>
+      <TextField name="full_name" :value="holder" :height="24" border="#94a3b8" />
+
+      <Text :size="9" color="#64748b">Notes (multiline)</Text>
+      <TextField name="notes" :value="notes" multiline :height="52" border="#94a3b8" />
+
+      <!-- The label is the default slot - no Row to assemble by hand. -->
+      <Checkbox name="agree" checked :size="14">I agree to the terms</Checkbox>
+
+      <Text :size="9" color="#64748b">Plan</Text>
+      <RadioGroup name="plan" value="pro" :size="14" :options="['basic', 'pro']" />
+
+      <Text :size="9" color="#64748b">Currency - stored value and shown label differ</Text>
+      <Dropdown
+        name="currency"
+        value="EUR"
+        :width="200"
+        :height="21"
+        border="#94a3b8"
+        :options="currencies"
+      />
+
+      <Text :size="9" color="#64748b">Size</Text>
+      <ListBox
+        name="size"
+        value="M"
+        :width="200"
+        :height="56"
+        border="#94a3b8"
+        :options="['S', 'M', 'L']"
+      />
+
+      <Row :gap="12">
+        <PushButton name="submit" :width="120" :height="26">Submit</PushButton>
+        <PushButton name="reset" action="reset" :width="120" :height="26">Reset</PushButton>
+      </Row>
+
+      <Text :size="9" color="#64748b">Signature</Text>
+      <SignatureField name="sig" :width="240" :height="46">Sign here</SignatureField>
+    </Page>
+  </Document>
+</template>

--- a/packages/nuxt/playground/app.vue
+++ b/packages/nuxt/playground/app.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import Invoice from "./Invoice.vue";
+import Form from "./Form.vue";
 
 // usePdf is auto-imported by @jasy/nuxt. open() renders on demand and reuses the result, so one click is
 // one render. Add `{ immediate: true }` to pre-render on mount - the button still won't render twice.
 const { pending, open } = usePdf(Invoice);
+// A second document, so the form can be rendered on the client and compared with the server route below.
+const { pending: formPending, open: openForm } = usePdf(Form);
 </script>
 
 <template>
@@ -27,6 +30,26 @@ const { pending, open } = usePdf(Invoice);
           request.
         </p>
         <a class="btn" href="/api/hello" target="_blank">Render on server &rarr;</a>
+      </section>
+
+      <section class="card">
+        <h2>Form (client)</h2>
+        <p>
+          A fillable AcroForm built from Vue components - text fields, a check box, radios, a
+          dropdown, a list box, buttons and a signature field. Open it and type into it.
+        </p>
+        <button :disabled="formPending" @click="openForm">
+          {{ formPending ? "Rendering..." : "Render form on client" }}
+        </button>
+      </section>
+
+      <section class="card">
+        <h2>Form (server)</h2>
+        <p>
+          The same form, built with the tree API in a Nitro route. Same fields, same widgets, no
+          Vue.
+        </p>
+        <a class="btn" href="/api/form" target="_blank">Render form on server &rarr;</a>
       </section>
 
       <section class="card">

--- a/packages/nuxt/playground/server/api/form.get.ts
+++ b/packages/nuxt/playground/server/api/form.get.ts
@@ -1,0 +1,51 @@
+// Zero imports again: the form factories are auto-imported in server/ exactly like Document and Text, so
+// a fillable PDF is built the same way as any other. Open /api/form.
+export default definePdfHandler(() =>
+  Document({ size: 11 }, [
+    Page({ size: "A4", margin: 48 }, [
+      Column({ gap: 6 }, [
+        Text("Membership form", { size: 24, bold: true, color: "#0a2348" }),
+        Text("Built server-side. Every field below is a real AcroForm widget - type into it.", {
+          size: 11,
+          color: "#475569",
+        }),
+
+        Text("Full name", { size: 9, color: "#64748b" }),
+        TextField({ name: "full_name", value: "Ada Lovelace", height: 24, border: "#94a3b8" }),
+
+        Text("Notes (multiline)", { size: 9, color: "#64748b" }),
+        TextField({ name: "notes", multiline: true, height: 52, border: "#94a3b8" }),
+
+        // The label is a plain option here - the slot form only exists in a template.
+        Checkbox({ name: "agree", checked: true, size: 14, label: "I agree to the terms" }),
+
+        Text("Plan", { size: 9, color: "#64748b" }),
+        RadioGroup({ name: "plan", value: "pro", size: 14 }, [
+          { value: "basic", label: "Basic" },
+          { value: "pro", label: "Pro" },
+        ]),
+
+        Text("Currency - stored value and shown label differ", { size: 9, color: "#64748b" }),
+        Dropdown({ name: "currency", value: "EUR", width: 200, height: 21, border: "#94a3b8" }, [
+          { value: "EUR", label: "Euro" },
+          { value: "CHF", label: "Swiss franc" },
+        ]),
+
+        Text("Size", { size: 9, color: "#64748b" }),
+        ListBox({ name: "size", value: "M", width: 200, height: 56, border: "#94a3b8" }, [
+          "S",
+          "M",
+          "L",
+        ]),
+
+        Row({ gap: 12 }, [
+          PushButton({ name: "submit", label: "Submit", width: 120, height: 26 }),
+          PushButton({ name: "reset", label: "Reset", action: "reset", width: 120, height: 26 }),
+        ]),
+
+        Text("Signature", { size: 9, color: "#64748b" }),
+        SignatureField({ name: "sig", label: "Sign here", width: 240, height: 46 }),
+      ]),
+    ]),
+  ]),
+);

--- a/packages/nuxt/src/imports.d.ts
+++ b/packages/nuxt/src/imports.d.ts
@@ -1,0 +1,10 @@
+// `#imports` resolves inside a NITRO server build, where Nitro contributes its own utils. Type-checking
+// this module's source in isolation only sees Nuxt's `#imports`, which does not carry them - so the one
+// util we use is declared here rather than suppressed. Runtime is unaffected: the real implementation is
+// whatever Nitro injects.
+declare module "#imports" {
+  export function defineCachedFunction<T extends (...args: never[]) => Promise<unknown>>(
+    fn: T,
+    opts?: Record<string, unknown>,
+  ): T;
+}

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -19,7 +19,7 @@ export interface ModuleOptions {
 }
 
 // @jasy/vue components, registered for client templates.
-const COMPONENTS = [
+export const COMPONENTS = [
   "Document",
   "Page",
   "Column",
@@ -48,10 +48,18 @@ const COMPONENTS = [
   "RotatedBox",
   "PageNumber",
   "PageCount",
+  // Form fields.
+  "TextField",
+  "Checkbox",
+  "RadioGroup",
+  "Dropdown",
+  "ListBox",
+  "PushButton",
+  "SignatureField",
 ];
 
 // @jasy/pdf tree factories for server/, prefixed like the components so `prefix` is consistent both sides.
-const SERVER_FACTORIES = [
+export const SERVER_FACTORIES = [
   "Document",
   "Page",
   "Column",
@@ -79,10 +87,20 @@ const SERVER_FACTORIES = [
   "PageCount",
   // Server code is plain JS, so the closure primitive is usable here (unlike in a client template).
   "PageBuilder",
+  // Form fields. Deliberately the SAME seven as the components above, not every export: `Select` is an
+  // alias of `Dropdown` and `Radio` is a single button that only makes sense inside a group, so
+  // auto-importing them would put two names on one thing and one name on half a thing.
+  "TextField",
+  "Checkbox",
+  "RadioGroup",
+  "Dropdown",
+  "ListBox",
+  "PushButton",
+  "SignatureField",
 ];
 
 // Render + unit helpers for server/ - not prefixed.
-const SERVER_UTILS = ["renderToBytes", "renderPdf", "mm"];
+export const SERVER_UTILS = ["renderToBytes", "renderPdf", "mm"];
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {

--- a/packages/nuxt/test/auto-imports.test.ts
+++ b/packages/nuxt/test/auto-imports.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import * as vue from "@jasy/vue";
+import * as pdf from "@jasy/pdf";
+import { COMPONENTS, SERVER_FACTORIES, SERVER_UTILS } from "../src/module.ts";
+
+// The module auto-registers by NAME, from two hand-written lists. Hand-written lists drift: the form
+// fields shipped in @jasy/vue and this module knew nothing about them for a while, so a Nuxt user got a
+// stale surface with no error anywhere. These tests are the guard - not that the lists are complete
+// (that is a judgement call), but that every name in them EXISTS. A typo or a removed export would
+// otherwise surface as a component that silently does not resolve in a template.
+
+describe("what the module claims to auto-import", () => {
+  it("names only components @jasy/vue really exports", () => {
+    const missing = COMPONENTS.filter((n) => !(n in vue));
+    expect(missing).toEqual([]);
+  });
+
+  it("names only factories @jasy/pdf really exports", () => {
+    const missing = [...SERVER_FACTORIES, ...SERVER_UTILS].filter((n) => !(n in pdf));
+    expect(missing).toEqual([]);
+  });
+
+  it("covers every form field on both sides", () => {
+    // The one group where client and server are deliberately identical: a form built in a template and
+    // one built in a Nitro route should offer the same seven things.
+    const fields = [
+      "TextField",
+      "Checkbox",
+      "RadioGroup",
+      "Dropdown",
+      "ListBox",
+      "PushButton",
+      "SignatureField",
+    ];
+    expect(fields.filter((n) => !COMPONENTS.includes(n))).toEqual([]);
+    expect(fields.filter((n) => !SERVER_FACTORIES.includes(n))).toEqual([]);
+  });
+
+  it("registers each name exactly once", () => {
+    // A duplicate would register the component twice and Nuxt would warn at build time - easy to add by
+    // hand, invisible until someone reads the log.
+    expect(new Set(COMPONENTS).size).toBe(COMPONENTS.length);
+    expect(new Set(SERVER_FACTORIES).size).toBe(SERVER_FACTORIES.length);
+  });
+});

--- a/packages/nuxt/test/auto-imports.test.ts
+++ b/packages/nuxt/test/auto-imports.test.ts
@@ -37,9 +37,13 @@ describe("what the module claims to auto-import", () => {
   });
 
   it("registers each name exactly once", () => {
-    // A duplicate would register the component twice and Nuxt would warn at build time - easy to add by
-    // hand, invisible until someone reads the log.
+    // A duplicate registers the same name twice and Nuxt warns at build time - easy to add by hand,
+    // invisible until someone reads the log.
     expect(new Set(COMPONENTS).size).toBe(COMPONENTS.length);
-    expect(new Set(SERVER_FACTORIES).size).toBe(SERVER_FACTORIES.length);
+
+    // The server side goes further: factories and utils are spread into ONE addImports call, so a name
+    // in both lists collides just as a repeat within one does. Checking them together covers both.
+    const server = [...SERVER_FACTORIES, ...SERVER_UTILS];
+    expect(new Set(server).size).toBe(server.length);
   });
 });

--- a/packages/nuxt/tsconfig.json
+++ b/packages/nuxt/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "extends": "./.nuxt/tsconfig.json",
-  "exclude": ["dist", "node_modules", "playground"]
+  "exclude": ["dist", "node_modules", "playground"],
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  }
 }


### PR DESCRIPTION
## Summary

Implement AcroForms into Nuxt, too!

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive “Membership form” PDF example with text fields, notes, checkbox, plan radio buttons, currency dropdown, size list selection, reset/submit controls, and signature support.
  * Added both client-rendered and server-generated views for the form example.
  * Expanded Nuxt auto-availability of PDF form components (text, checkbox, radio, dropdown, listbox, push buttons, signature).

* **Tests**
  * Added/updated auto-import checks to confirm all required components and server utilities are registered once.

* **Chores**
  * Improved Nuxt TypeScript support and module typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->