### PR TITLE
feat: fill options (flatten)

### DIFF
--- a/src/lib/edit/document.ts
+++ b/src/lib/edit/document.ts
@@ -8,10 +8,10 @@ import {
   isString,
   nameOf,
   numberOf,
+  stringsIn,
   type PdfDict,
   type PdfObject,
   type PdfStream,
-  type PdfString,
 } from "./objects.ts";
 import { StandardAes256, type SecurityHandler } from "../crypto/security-handler.ts";
 import { StandardLegacy } from "../crypto/legacy-handler.ts";
@@ -48,15 +48,9 @@ export class PdfEncryptedError extends Error {
 const stringBytes = (o: PdfObject | undefined): Uint8Array | undefined =>
   isString(o) ? o.bytes : undefined;
 
-/** Every string reachable inside an object, so the whole tree can be decrypted in one walk. */
-function stringsIn(o: PdfObject | undefined, out: PdfString[] = [], depth = 0): PdfString[] {
-  if (o === undefined || o === null || depth > 64) return out;
-  if (isString(o)) out.push(o);
-  else if (Array.isArray(o)) for (const e of o) stringsIn(e, out, depth + 1);
-  else if (isStream(o)) stringsIn(o.dict, out, depth + 1);
-  else if (isDict(o)) for (const v of o.map.values()) stringsIn(v, out, depth + 1);
-  return out;
-}
+// `stringsIn` lives in objects.ts: the read side walks a tree to DECIPHER every string, the write side
+// to ENCIPHER every string, and the two must agree on what "every string" means. Two copies of that
+// walk is exactly how one of them ends up missing a case.
 
 export class PdfDocument {
   private readonly xref = new Map<number, XrefEntry>();

--- a/src/lib/edit/fill.ts
+++ b/src/lib/edit/fill.ts
@@ -1,18 +1,11 @@
 import { PdfDocument } from "./document.ts";
 import { readAcroForm, type ReadField } from "./acroform-reader.ts";
-import { IncrementalWriter, serialize, type StringCipher } from "./writer.ts";
+import { carryStrings, IncrementalWriter, serialize, type StringCipher } from "./writer.ts";
 import { bakeAppearance, bakeButtonStates, fontMetrics, readLook } from "./appearance.ts";
+import { flattenInto } from "./flatten.ts";
 import type { PDFObjectManager } from "../utils/pdf-object-manager.ts";
 import { getArrayBuffer } from "../utils/utf8-to-windows1252-encoder.ts";
-import {
-  get,
-  isDict,
-  isRef,
-  isString,
-  type PdfDict,
-  type PdfObject,
-  type PdfString,
-} from "./objects.ts";
+import { get, isDict, isRef, type PdfDict, type PdfObject, type PdfRef } from "./objects.ts";
 
 /**
  * Filling the form of an EXISTING PDF.
@@ -40,10 +33,23 @@ export interface FillOptions {
    */
   fieldAppearances?: boolean;
   /**
-   * Leave the drawing of the values to the viewer by setting `/NeedAppearances`, instead of generating
-   * appearance streams. Default `true` today - baking them is the next step.
+   * Ask the viewer to draw the values itself, by setting `/NeedAppearances true` (default `true`).
+   *
+   * The two options answer the same question and exactly one of them ends up applying: when we DID
+   * bake, the flag is written as `false`, because a form that still asks for regeneration gets it and
+   * the viewer throws our drawing away. Turning BOTH off is refused - see `fillForm`.
    */
   needAppearances?: boolean;
+  /**
+   * Flatten the form after filling it (default `false`): the values become ordinary page content and
+   * the fields stop being editable. The whole form is flattened, not only the names in `values` - a
+   * document where some fields are frozen and others are not is the surprising outcome, and
+   * `flattenForm(bytes, { fields })` is there for anyone who wants that on purpose.
+   *
+   * Filling and flattening in one call produces ONE incremental update rather than two, so the file
+   * stays smaller than calling them in sequence - and the result is identical either way.
+   */
+  flatten?: boolean;
 }
 
 export interface FillResult {
@@ -52,6 +58,8 @@ export interface FillResult {
   warnings: string[];
   /** The names actually written. */
   filled: string[];
+  /** The names turned into page content, when `flatten` was asked for. Empty otherwise. */
+  flattened: string[];
 }
 
 /** Field flags we have to honour when filling (see `forms/acroform.ts` for the writer's side). */
@@ -125,14 +133,6 @@ function withEntries(
 }
 
 /** Every string reachable inside an object, so a dictionary can be re-enciphered in one walk. */
-function stringsIn(o: PdfObject | undefined, out: PdfString[] = [], depth = 0): PdfString[] {
-  if (o === undefined || o === null || depth > 64) return out;
-  if (isString(o)) out.push(o);
-  else if (Array.isArray(o)) for (const e of o) stringsIn(e, out, depth + 1);
-  else if (isDict(o)) for (const v of o.map.values()) stringsIn(v, out, depth + 1);
-  return out;
-}
-
 /**
  * Draw the field again for its NEW value and append the XObject, returning its object number. Falls back
  * to `undefined` when the widget does not say enough about itself to draw it - then the caller drops the
@@ -169,7 +169,7 @@ async function bakeStatesFor(
   field: ReadField,
   widgetNum: number,
   state: string,
-): Promise<string | undefined> {
+): Promise<{ ap: string; states: Map<string, number> } | undefined> {
   const look = readLook(doc, doc.getObject(widgetNum), field);
   if (look === undefined || look.width <= 0 || look.height <= 0) return undefined;
   const radio = (field.flags & FF_RADIO) !== 0;
@@ -183,7 +183,25 @@ async function bakeStatesFor(
       data: (await doc.encryptForWrite(encoded)) ?? encoded,
     });
   };
-  return `<< /N << /${escName(on)} ${await write(faces.on)} 0 R /Off ${await write(faces.off)} 0 R >> >>`;
+  // The object numbers come back too, not just the dictionary text: a flatten in the same pass has to
+  // stamp ONE of these two states, and picking it out of a serialized string again would be silly.
+  const onNum = await write(faces.on);
+  const offNum = await write(faces.off);
+  return {
+    ap: `<< /N << /${escName(on)} ${onNum} 0 R /Off ${offNum} 0 R >> >>`,
+    states: new Map([
+      [on, onNum],
+      ["Off", offNum],
+    ]),
+  };
+}
+
+/** The appearance a widget ALREADY carries for one of its states, from `/AP /N /<state>`. */
+function stateAppearance(doc: PdfDocument, widgetNum: number, state: string): PdfRef | undefined {
+  const states = doc.resolve(get(doc.resolve(get(doc.getObject(widgetNum), "AP")), "N"));
+  if (states === undefined || !isDict(states)) return undefined;
+  const chosen = states.map.get(state);
+  return isRef(chosen) ? chosen : undefined;
 }
 
 class FillError extends Error {}
@@ -322,6 +340,22 @@ export async function fillForm(
   values: Record<string, FieldValue>,
   options: FillOptions = {},
 ): Promise<FillResult> {
+  // Two combinations of options describe a document nobody wants. Both are refused here, before the
+  // file is even opened, because the answer does not depend on it - and a silent nonsense result is the
+  // one outcome this module does not ship.
+  if (options.fieldAppearances === false && options.needAppearances === false) {
+    throw new FillError(
+      "fieldAppearances and needAppearances are both false, which leaves the values invisible: nothing " +
+        "is drawn by jasy and the viewer is not asked to draw anything either. Turn one of them on",
+    );
+  }
+  if (options.flatten === true && options.fieldAppearances === false) {
+    throw new FillError(
+      "flatten needs fieldAppearances: flattening freezes the picture a field shows, and with " +
+        "fieldAppearances false there is no picture of the new value to freeze",
+    );
+  }
+
   // Async because an encrypted document has to be deciphered before its field names mean anything, and
   // because the values written back have to be enciphered again with the same file key.
   const doc = await PdfDocument.open(bytes, { password: options.password });
@@ -375,6 +409,8 @@ export async function fillForm(
   const bake = options.fieldAppearances !== false;
   // One metrics instance for the whole fill, not one per field and not one at module scope.
   const metrics = bake ? fontMetrics() : undefined;
+  // Only collected when a flatten follows in this same pass; see `FreshAppearances` for why it exists.
+  const fresh = options.flatten ? new Map<number, PdfRef>() : undefined;
   // A widget we could not draw has no picture at all, so the viewer must be asked after all.
   let someBakeFailed = false;
   const filled: string[] = [];
@@ -425,6 +461,7 @@ export async function fillForm(
           bake && metrics ? await bakeFor(doc, writer, field, w.num, change, metrics) : undefined;
         if (bake && baked === undefined) someBakeFailed = true;
         editsFor(w.num).AP = baked !== undefined ? `<< /N ${baked} 0 R >>` : undefined;
+        if (baked !== undefined) fresh?.set(w.num, { kind: "ref", num: baked, gen: 0 });
       }
     }
     for (const [widgetNum, state] of change.as ?? []) {
@@ -432,8 +469,17 @@ export async function fillForm(
       // A button whose widget ships NO state pictures (PDFKit, react-pdf write none) stays an empty box
       // in anything that does not redraw - and cannot be flattened at all. Draw the two states once.
       if (bake && !field.widgets.find((w) => w.num === widgetNum)?.hasAppearance) {
-        const ap = await bakeStatesFor(doc, writer, field, widgetNum, state);
-        if (ap !== undefined) editsFor(widgetNum).AP = ap;
+        const drawn = await bakeStatesFor(doc, writer, field, widgetNum, state);
+        if (drawn !== undefined) {
+          editsFor(widgetNum).AP = drawn.ap;
+          const num = drawn.states.get(state);
+          if (num !== undefined) fresh?.set(widgetNum, { kind: "ref", num, gen: 0 });
+        }
+      } else {
+        // The widget keeps its own pictures and only /AS moves, so the state to stamp is the NEW one -
+        // reading /AS back out of the document would give the state before this fill.
+        const ref = stateAppearance(doc, widgetNum, state);
+        if (ref !== undefined) fresh?.set(widgetNum, ref);
       }
     }
 
@@ -459,16 +505,7 @@ export async function fillForm(
 
   // One pass over every string that will be carried over unchanged. Without this a preserved tooltip or
   // a /DA would be written back in the clear, into a file where nothing else is.
-  const carried: StringCipher = new Map();
-  if (doc.isEncrypted) {
-    for (const target of [...pending.map((p) => p.target), ...alsoRewritten]) {
-      for (const str of stringsIn(target)) {
-        if (carried.has(str)) continue;
-        const cipher = await doc.encryptForWrite(str.bytes);
-        if (cipher) carried.set(str, hex(cipher));
-      }
-    }
-  }
+  const carried = await carryStrings(doc, [...pending.map((p) => p.target), ...alsoRewritten]);
   for (const { objNum, target, changes } of pending) {
     writer.update(objNum, withEntries(target, changes, carried));
   }
@@ -477,8 +514,12 @@ export async function fillForm(
   // When we DID draw, the flag has to go: a form that still asks for regeneration gets it, and the
   // viewer throws our drawing away and redraws from /DA - which is how PDFKit's forms kept asking for a
   // ZapfDingbats they do not ship.
+  //
+  // With a flatten following there is nothing to answer it FOR: the form loses its fields, and the
+  // flatten pass rewrites the same /AcroForm dictionary anyway - writing the flag here would only be
+  // overwritten a moment later.
   const needAppearances = bake && !someBakeFailed ? "false" : "true";
-  if (bake || options.needAppearances !== false) {
+  if (!options.flatten && (bake || options.needAppearances !== false)) {
     if (acro !== undefined && isDict(acro)) {
       if (isRef(acroRef)) {
         writer.update(
@@ -496,7 +537,13 @@ export async function fillForm(
     }
   }
 
-  return { bytes: writer.save(), warnings, filled };
+  // Flattening rides on the SAME writer, so the whole operation stays one incremental update. It goes
+  // last because it freezes the pictures the pass above has just drawn.
+  const flattened = options.flatten
+    ? await flattenInto(doc, writer, form.fields, carried, fresh)
+    : [];
+
+  return { bytes: writer.save(), warnings, filled, flattened };
 }
 
 export { FillError };

--- a/src/lib/edit/flatten.ts
+++ b/src/lib/edit/flatten.ts
@@ -3,7 +3,7 @@ import { readAcroForm, type ReadField } from "./acroform-reader.ts";
 import { bakeAppearance, bakeButtonStates, readLook } from "./appearance.ts";
 import { getArrayBuffer } from "../utils/utf8-to-windows1252-encoder.ts";
 import { latin1FromBytes } from "../utils/bytes.ts";
-import { IncrementalWriter, serialize, type StringCipher } from "./writer.ts";
+import { carryStrings, IncrementalWriter, serialize, type StringCipher } from "./writer.ts";
 import {
   get,
   isDict,
@@ -155,11 +155,15 @@ function appearanceOf(doc: PdfDocument, widget: PdfObject | undefined): PdfRef |
  * Collect what has to happen. A widget that ships NO appearance gets one drawn now, from its own style
  * and current value - the same drawing the fill path bakes. Without that, flattening a form from a
  * producer that writes no appearances (PDFKit, react-pdf) could only ever refuse.
+ *
+ * `fresh` overrides where a widget's picture comes from. It is empty for a plain `flattenForm`, and
+ * carries the just-baked appearances when a fill flattens in the same pass - see `FreshAppearances`.
  */
 async function planStamps(
   doc: PdfDocument,
   writer: IncrementalWriter,
   fields: ReadField[],
+  fresh?: FreshAppearances,
 ): Promise<{ stamps: Stamp[]; removeOnly: Map<number, number> }> {
   const pages = widgetPages(doc);
   const stamps: Stamp[] = [];
@@ -174,7 +178,9 @@ async function planStamps(
     for (const w of field.widgets) {
       if (w.num === undefined) continue;
       const widget = doc.getObject(w.num);
-      let appearance = appearanceOf(doc, widget);
+      // A picture written during THIS pass wins: it lives in the writer, not in `doc`, so reading the
+      // document would freeze the value the field had BEFORE the fill.
+      let appearance = fresh?.get(w.num) ?? appearanceOf(doc, widget);
       if (appearance === undefined) {
         const drawnNum = await drawMissing(doc, writer, field, w.num);
         if (drawnNum === undefined) {
@@ -335,6 +341,18 @@ function withEntries(
 }
 
 /**
+ * The appearance streams a fill has just written, keyed by widget object number.
+ *
+ * Flattening freezes the picture a widget currently shows, and it reads that picture out of the
+ * document. In the same pass as a fill the new picture is not in the document yet - it is in the
+ * writer, appended but not saved - so without this map a filled-and-flattened form would stamp the
+ * value the field had BEFORE the fill. It applies to both kinds of widget, which go stale for two
+ * different reasons: a text field's `/AP` is replaced outright, and a button's `/AP` keeps all its
+ * states while `/AS` moves to pick a different one.
+ */
+export type FreshAppearances = ReadonlyMap<number, PdfRef>;
+
+/**
  * Stamp the fields into their pages and take the widgets away. Shared by `flattenForm` and
  * `fillForm(..., { flatten: true })`, so filling and flattening produce ONE incremental update.
  */
@@ -342,15 +360,32 @@ export async function flattenInto(
   doc: PdfDocument,
   writer: IncrementalWriter,
   fields: ReadField[],
-  cipher?: StringCipher,
+  carriedIn?: StringCipher,
+  fresh?: FreshAppearances,
 ): Promise<string[]> {
   if (fields.length === 0) return [];
-  const { stamps, removeOnly } = await planStamps(doc, writer, fields);
+  const { stamps, removeOnly } = await planStamps(doc, writer, fields, fresh);
 
   // Group by page: one appended content stream per page, not one per widget.
   const byPage = new Map<number, Stamp[]>();
   for (const s of stamps)
     (byPage.get(s.pageNum) ?? byPage.set(s.pageNum, []).get(s.pageNum)!).push(s);
+
+  // In an encrypted document every string in a rewritten object has to be enciphered again, or
+  // `serialize` writes it back in the clear - ISSUE-7, one object at a time. The caller's map (a fill
+  // flattening in the same pass) is the seed; the pages are what only this pass touches.
+  //
+  // NOT reachable today, and therefore not covered by a test: we can only write R6, so the only
+  // encrypted files we can flatten are our own, and ours reference every annotation as its own object -
+  // a page dictionary of ours holds no string at all. It matters the moment a producer inlines an
+  // annotation (its /Contents and /URI are strings), which is why it is wired rather than left as a
+  // trap. Same reasoning as the `alsoRewritten` pass in `fill.ts`.
+  const acroDict = doc.resolve(get(doc.catalog, "AcroForm"));
+  const cipher = await carryStrings(
+    doc,
+    [...[...byPage.keys()].map((n) => doc.getObject(n)), acroDict, doc.catalog],
+    new Map(carriedIn ?? []),
+  );
 
   for (const [pageNum, pageStamps] of byPage) {
     const page = doc.getObject(pageNum);
@@ -437,7 +472,12 @@ export async function flattenInto(
     const kept = Array.isArray(roots) ? roots.filter((r) => !(isRef(r) && gone.has(r.num))) : [];
     const newAcro = withEntries(
       acro,
-      { Fields: `[${kept.map((r) => serialize(r, cipher)).join(" ")}]` },
+      {
+        Fields: `[${kept.map((r) => serialize(r, cipher)).join(" ")}]`,
+        // A form with nothing left in it asking a viewer to regenerate appearances is a document
+        // contradicting itself, so the flag goes with the last field.
+        ...(kept.length === 0 ? { NeedAppearances: undefined } : {}),
+      },
       cipher,
     );
     if (isRef(acroRef)) {

--- a/src/lib/edit/flatten.ts
+++ b/src/lib/edit/flatten.ts
@@ -467,7 +467,26 @@ export async function flattenInto(
     const gone = new Set(fields.map((f) => f.objNum).filter((n): n is number => n !== undefined));
     // A flattened field may hang in a PARENT's /Kids rather than in the form's /Fields. Dropping it only
     // from the root leaves it reachable, so `readAcroForm` still reports a field with no widget left.
-    pruneKids(doc, writer, get(acro, "Fields"), gone, cipher);
+    //
+    // Planned first, written after: a surviving parent is rewritten WHOLE, so it carries its own /T,
+    // /TU and /DA along - and those are strings that have to be enciphered like any other. Collecting
+    // them needs an await, which is why the walk itself stays synchronous and only plans.
+    const prunes = pruneKids(doc, get(acro, "Fields"), gone);
+    await carryStrings(
+      doc,
+      prunes.map((p) => p.node),
+      cipher,
+    );
+    for (const p of prunes) {
+      writer.update(
+        p.num,
+        withEntries(
+          p.node,
+          { Kids: `[${p.kept.map((k) => serialize(k, cipher)).join(" ")}]` },
+          cipher,
+        ),
+      );
+    }
     const roots = doc.resolve(get(acro, "Fields"));
     const kept = Array.isArray(roots) ? roots.filter((r) => !(isRef(r) && gone.has(r.num))) : [];
     const newAcro = withEntries(
@@ -503,22 +522,21 @@ export async function flattenInto(
  */
 function pruneKids(
   doc: PdfDocument,
-  writer: IncrementalWriter,
   list: PdfObject | undefined,
   gone: Set<number>,
-  cipher?: StringCipher,
+  out: Array<{ num: number; node: PdfDict; kept: PdfObject[] }> = [],
   depth = 0,
-): void {
-  if (depth > 32) return;
+): Array<{ num: number; node: PdfDict; kept: PdfObject[] }> {
+  if (depth > 32) return out;
   const entries = doc.resolve(list);
-  if (!Array.isArray(entries)) return;
+  if (!Array.isArray(entries)) return out;
   for (const ref of entries) {
     if (!isRef(ref) || gone.has(ref.num)) continue;
     const node = doc.resolve(ref);
     if (node === undefined || !isDict(node)) continue;
     const kids = get(node, "Kids");
     if (kids === undefined) continue;
-    pruneKids(doc, writer, kids, gone, cipher, depth + 1);
+    pruneKids(doc, kids, gone, out, depth + 1);
     const resolved = doc.resolve(kids);
     if (!Array.isArray(resolved)) continue;
     const kept = resolved.filter((k) => !(isRef(k) && gone.has(k.num)));
@@ -527,11 +545,9 @@ function pruneKids(
       gone.add(ref.num); // an empty branch is a field with nothing left to show
       continue;
     }
-    writer.update(
-      ref.num,
-      withEntries(node, { Kids: `[${kept.map((k) => serialize(k, cipher)).join(" ")}]` }, cipher),
-    );
+    out.push({ num: ref.num, node, kept });
   }
+  return out;
 }
 
 /** Flatten an existing form: its values become page content and stop being editable. */

--- a/src/lib/edit/objects.ts
+++ b/src/lib/edit/objects.ts
@@ -119,3 +119,16 @@ export function textOf(o: PdfObject | undefined): string | undefined {
   // value round-trippable, which is what a reader that may write the string back needs.
   return latin1FromBytes(b);
 }
+
+/**
+ * Every string inside an object, however deep. Used before rewriting one into an ENCRYPTED document:
+ * the strings carried over unchanged were deciphered on open, so each has to be enciphered again or it
+ * goes back into the file in the clear - which is ISSUE-7 all over again, one object at a time.
+ */
+export function stringsIn(o: PdfObject | undefined, out: PdfString[] = [], depth = 0): PdfString[] {
+  if (o === undefined || o === null || depth > 64) return out;
+  if (isString(o)) out.push(o);
+  else if (Array.isArray(o)) for (const e of o) stringsIn(e, out, depth + 1);
+  else if (isDict(o)) for (const v of o.map.values()) stringsIn(v, out, depth + 1);
+  return out;
+}

--- a/src/lib/edit/objects.ts
+++ b/src/lib/edit/objects.ts
@@ -126,9 +126,22 @@ export function textOf(o: PdfObject | undefined): string | undefined {
  * goes back into the file in the clear - which is ISSUE-7 all over again, one object at a time.
  */
 export function stringsIn(o: PdfObject | undefined, out: PdfString[] = [], depth = 0): PdfString[] {
-  if (o === undefined || o === null || depth > 64) return out;
+  if (o === undefined || o === null) return out;
+  // Depth is bounded because the walk does NOT follow references - only containers written inline. Past
+  // the limit we THROW rather than return what we have: both callers use the result to decide which
+  // strings get enciphered or deciphered, so a silently short list is a string written in the clear.
+  if (depth > MAX_NESTING) {
+    throw new Error(
+      `@jasy/pdf: this PDF nests objects more than ${MAX_NESTING} deep, which no legitimate producer ` +
+        `does; refusing to walk it`,
+    );
+  }
   if (isString(o)) out.push(o);
   else if (Array.isArray(o)) for (const e of o) stringsIn(e, out, depth + 1);
+  // A stream's own dictionary holds strings too; its DATA is covered by the stream's own encryption.
+  else if (isStream(o)) stringsIn(o.dict, out, depth + 1);
   else if (isDict(o)) for (const v of o.map.values()) stringsIn(v, out, depth + 1);
   return out;
 }
+
+const MAX_NESTING = 64;

--- a/src/lib/edit/writer.ts
+++ b/src/lib/edit/writer.ts
@@ -1,5 +1,13 @@
 import type { PdfDocument } from "./document.ts";
-import { isDict, isRef, isStream, isString, type PdfObject, type PdfString } from "./objects.ts";
+import {
+  isDict,
+  isRef,
+  isStream,
+  isString,
+  stringsIn,
+  type PdfObject,
+  type PdfString,
+} from "./objects.ts";
 
 /** Strings already enciphered for write-back, keyed by the very object they replace. */
 export type StringCipher = Map<PdfString, string>;
@@ -288,4 +296,31 @@ export class IncrementalWriter {
     const m = /startxref\s+(\d+)/.exec(tail.slice(at));
     return m ? Number(m[1]) : undefined;
   }
+}
+
+/** Bytes as an enciphered PDF hex string, the form every rewritten string takes in an encrypted file. */
+const hexString = (b: Uint8Array): string =>
+  `<${Array.from(b, (x) => x.toString(16).padStart(2, "0").toUpperCase()).join("")}>`;
+
+/**
+ * Encipher every string the given objects carry, into a cipher map `serialize` then consults.
+ *
+ * A no-op on an unencrypted document. On an encrypted one it is not optional: `serialize` writes any
+ * string it cannot find in the map as PLAINTEXT, so an object rewritten without this pass leaks
+ * whatever it holds - a link URL, an annotation's note, a form-level /DA.
+ */
+export async function carryStrings(
+  doc: PdfDocument,
+  objects: Array<PdfObject | undefined>,
+  into: Map<PdfString, string> = new Map(),
+): Promise<StringCipher> {
+  if (!doc.isEncrypted) return into;
+  for (const o of objects) {
+    for (const str of stringsIn(o)) {
+      if (into.has(str)) continue;
+      const cipher = await doc.encryptForWrite(str.bytes);
+      if (cipher) into.set(str, hexString(cipher));
+    }
+  }
+  return into;
 }

--- a/tests/unit/edit/fill.test.ts
+++ b/tests/unit/edit/fill.test.ts
@@ -579,3 +579,38 @@ describe("fillForm - the file stays valid", () => {
     expect(readAcroForm(doc)!.fields.length).toBe(6);
   });
 });
+
+describe("options that describe a document nobody wants", () => {
+  // Both switches answer the same question - "who draws the value?" - so turning both off answers it
+  // with "nobody". The file comes back looking filled and shows nothing. Named, not silently produced.
+  it("refuses to make the values invisible", async () => {
+    const err = await fillForm(
+      fixture("jasy-form"),
+      { full_name: "Grace" },
+      { fieldAppearances: false, needAppearances: false },
+    ).catch((e) => e);
+    expect(err).toBeInstanceOf(FillError);
+    expect(String(err.message)).toMatch(/both false|invisible/);
+  });
+
+  it("refuses to flatten a picture it was told not to draw", async () => {
+    // Flattening freezes what a field shows. With fieldAppearances off there is no picture of the NEW
+    // value to freeze, so it would silently stamp the old one.
+    const err = await fillForm(
+      fixture("jasy-form"),
+      { full_name: "Grace" },
+      { flatten: true, fieldAppearances: false },
+    ).catch((e) => e);
+    expect(err).toBeInstanceOf(FillError);
+    expect(String(err.message)).toMatch(/flatten needs fieldAppearances/);
+  });
+
+  it("still allows either one on its own", async () => {
+    await expect(
+      fillForm(fixture("jasy-form"), { full_name: "Grace" }, { fieldAppearances: false }),
+    ).resolves.toBeDefined();
+    await expect(
+      fillForm(fixture("jasy-form"), { full_name: "Grace" }, { needAppearances: false }),
+    ).resolves.toBeDefined();
+  });
+});

--- a/tests/unit/edit/flatten.test.ts
+++ b/tests/unit/edit/flatten.test.ts
@@ -249,15 +249,45 @@ describe("fillForm(..., { flatten: true })", () => {
 
   it("drops /NeedAppearances with the last field", async () => {
     // A form with nothing left in it asking a viewer to regenerate appearances contradicts itself.
-    const { bytes } = await fillForm(fixture("jasy-form"), values, { flatten: true });
-    const doc = PdfDocument.load(bytes);
-    const acro = doc.resolve(get(doc.catalog, "AcroForm"));
-    expect(get(acro, "NeedAppearances")).toBeUndefined();
+    //
+    // The flag has to be PRESENT first or this proves nothing: the fixture as built carries no
+    // /NeedAppearances at all, so asserting its absence afterwards passed even with the code removed.
+    // An ordinary fill is what puts it there, so that is the starting point.
+    const needing = (await fillForm(fixture("jasy-form"), values)).bytes;
+    const acroOf = (bytes: Uint8Array) =>
+      PdfDocument.load(bytes).resolve(get(PdfDocument.load(bytes).catalog, "AcroForm"));
+    expect(get(acroOf(needing), "NeedAppearances")).toBeDefined();
+
+    const { bytes } = await fillForm(needing, values, { flatten: true });
+    expect(get(acroOf(bytes), "NeedAppearances")).toBeUndefined();
   });
 
   it("leaves the form alone when flatten is not asked for", async () => {
     const { bytes, flattened } = await fillForm(fixture("jasy-form"), values);
     expect(flattened).toEqual([]);
     expect(readAcroForm(PdfDocument.load(bytes))?.fields.length ?? 0).toBeGreaterThan(0);
+  });
+});
+
+describe("partial flatten with nested fields", () => {
+  // The W-9 is the only fixture with a real field HIERARCHY (23 dotted names under shared parents), so
+  // it is the one that exercises pruneKids: flatten some leaves and a parent survives with fewer /Kids,
+  // which means the parent is rewritten WHOLE - carrying its own /T, /TU and /DA along.
+  const w9 = () => fixture("gov-w9");
+
+  it("keeps the surviving siblings of a flattened field", async () => {
+    const before = readAcroForm(PdfDocument.load(w9()))!.fields;
+    const nested = before.filter((f) => f.name.includes("."));
+    expect(nested.length).toBeGreaterThan(1);
+
+    // One leaf out of a shared parent, so the parent has to be rewritten rather than dropped.
+    const victim = nested[0].name;
+    const { bytes, flattened } = await flattenForm(w9(), { fields: [victim] });
+    expect(flattened).toEqual([victim]);
+
+    const after = readAcroForm(PdfDocument.load(bytes))!.fields.map((f) => f.name);
+    expect(after).not.toContain(victim);
+    // Every other field survived, names intact - a parent rewritten badly loses its whole branch.
+    for (const f of before) if (f.name !== victim) expect(after).toContain(f.name);
   });
 });

--- a/tests/unit/edit/flatten.test.ts
+++ b/tests/unit/edit/flatten.test.ts
@@ -4,7 +4,7 @@ import { flattenForm, FlattenError } from "../../../src/lib/edit/flatten.ts";
 import { fillForm } from "../../../src/lib/edit/fill.ts";
 import { PdfDocument } from "../../../src/lib/edit/document.ts";
 import { readAcroForm } from "../../../src/lib/edit/acroform-reader.ts";
-import { get, isStream } from "../../../src/lib/edit/objects.ts";
+import { get, isDict, isStream } from "../../../src/lib/edit/objects.ts";
 
 // Flattening: the values become page content and stop being fields.
 //
@@ -177,5 +177,87 @@ describe("flattenForm - the contract", () => {
     const doc = PdfDocument.load(flat);
     const xobjects = doc.lookup(doc.lookup(pageOf(doc), "Resources"), "XObject");
     expect(xobjects).toBeDefined();
+  });
+});
+
+/**
+ * What is actually stamped on the page, in page order: each `... cm /JasyFlatN Do` resolved to the
+ * drawing it invokes, prefixed by where it lands.
+ *
+ * Deliberately NOT a set of the page's XObjects. A radio group's two states are the same two pictures
+ * whichever button is on, so comparing the SET cannot tell "basic is checked" from "pro is checked" -
+ * the first version of this helper did exactly that and a broken button bridge passed it.
+ */
+const stampedDrawings = (doc: PdfDocument): string[] => {
+  const xobjects = doc.lookup(doc.lookup(pageOf(doc), "Resources"), "XObject");
+  if (!isDict(xobjects)) return [];
+  const content = pageContent(doc);
+  const out: string[] = [];
+  for (const m of content.matchAll(/([\d.\-\s]*?)cm\s*\/(\S+)\s+Do/g)) {
+    const target = doc.resolve(xobjects.map.get(m[2]));
+    const drawing = isStream(target)
+      ? new TextDecoder("latin1").decode(doc.streamData(target))
+      : "";
+    out.push(`${m[1].trim()} | ${drawing}`);
+  }
+  return out;
+};
+
+describe("fillForm(..., { flatten: true })", () => {
+  const values = { full_name: "Grace Hopper", plan: "basic" };
+
+  it("stamps the value it just wrote, not the one in the file", async () => {
+    // The whole point of the option, and the one thing it can plausibly get wrong: flattening freezes
+    // the picture a widget shows, and it reads that picture out of the DOCUMENT - where, mid-pass, the
+    // old one still sits. The new appearance exists only in the writer.
+    const { bytes, filled, flattened } = await fillForm(fixture("jasy-form"), values, {
+      flatten: true,
+    });
+    expect(filled).toEqual(["full_name", "plan"]);
+    expect(flattened).toContain("full_name");
+
+    const doc = PdfDocument.load(bytes);
+    expect(readAcroForm(doc)?.fields.length ?? 0).toBe(0);
+    const drawn = stampedDrawings(doc).join("\n");
+    expect(drawn).toContain("Grace Hopper");
+    // "Ada Lovelace" is what the fixture holds, so its presence would mean the stale picture was frozen.
+    expect(drawn).not.toContain("Ada Lovelace");
+  });
+
+  it("produces the same document as filling and flattening in two calls", async () => {
+    // The option is a convenience, so it has to be exactly that: doing it by hand must not be better.
+    // This is also what catches the button half of the staleness problem - a radio keeps all its state
+    // pictures and only /AS moves, so reading the document gives the state BEFORE the fill.
+    const original = fixture("jasy-form");
+    const oneCall = (await fillForm(original, values, { flatten: true })).bytes;
+    const twoCalls = (await flattenForm((await fillForm(original, values)).bytes)).bytes;
+
+    expect(stampedDrawings(PdfDocument.load(oneCall))).toEqual(
+      stampedDrawings(PdfDocument.load(twoCalls)),
+    );
+  });
+
+  it("is one incremental update, so it stays smaller than the two-call route", async () => {
+    const original = fixture("jasy-form");
+    const oneCall = (await fillForm(original, values, { flatten: true })).bytes;
+    const twoCalls = (await flattenForm((await fillForm(original, values)).bytes)).bytes;
+
+    expect(oneCall.length).toBeLessThan(twoCalls.length);
+    // ... and the original is still a literal prefix, the invariant the whole edit path keeps.
+    expect(Array.from(oneCall.subarray(0, original.length))).toEqual(Array.from(original));
+  });
+
+  it("drops /NeedAppearances with the last field", async () => {
+    // A form with nothing left in it asking a viewer to regenerate appearances contradicts itself.
+    const { bytes } = await fillForm(fixture("jasy-form"), values, { flatten: true });
+    const doc = PdfDocument.load(bytes);
+    const acro = doc.resolve(get(doc.catalog, "AcroForm"));
+    expect(get(acro, "NeedAppearances")).toBeUndefined();
+  });
+
+  it("leaves the form alone when flatten is not asked for", async () => {
+    const { bytes, flattened } = await fillForm(fixture("jasy-form"), values);
+    expect(flattened).toEqual([]);
+    expect(readAcroForm(PdfDocument.load(bytes))?.fields.length ?? 0).toBeGreaterThan(0);
   });
 });

--- a/tests/unit/edit/objects.test.ts
+++ b/tests/unit/edit/objects.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { stringsIn, type PdfObject, type PdfString } from "../../../src/lib/edit/objects.ts";
+
+// `stringsIn` decides which strings get deciphered on the way in and enciphered on the way out. Both
+// sides of the crypto seam depend on it seeing EVERY string, so the interesting cases are the ones
+// where it might quietly see fewer than all of them.
+
+const str = (text: string): PdfString => ({
+  kind: "string",
+  bytes: Uint8Array.from(text, (c) => c.charCodeAt(0)),
+  hex: false,
+});
+
+const dict = (entries: Record<string, PdfObject>): PdfObject => ({
+  kind: "dict",
+  map: new Map(Object.entries(entries)),
+});
+
+describe("stringsIn", () => {
+  it("finds strings in dictionaries, arrays and a stream's own dictionary", () => {
+    const found = stringsIn(
+      dict({
+        T: str("field name"),
+        Kids: [dict({ TU: str("tooltip") })],
+        // A stream's DATA is covered by the stream's own encryption; its dictionary is not, and it can
+        // carry a string like any other dictionary.
+        Body: {
+          kind: "stream",
+          dict: dict({ Author: str("Ada") }) as never,
+          start: 0,
+          raw: undefined,
+        } as unknown as PdfObject,
+      }),
+    );
+    expect(found.map((s) => new TextDecoder().decode(s.bytes)).sort()).toEqual([
+      "Ada",
+      "field name",
+      "tooltip",
+    ]);
+  });
+
+  it("refuses an absurdly nested object instead of returning a short list", () => {
+    // Returning what it had found so far is the dangerous answer: the caller would encipher the strings
+    // it was given and write the rest back in the clear, which is the ISSUE-7 failure mode again. The
+    // walk never follows references, so 65 levels of INLINE nesting is not something a producer does.
+    let deep: PdfObject = str("buried");
+    for (let i = 0; i < 65; i++) deep = [deep];
+    expect(() => stringsIn(deep)).toThrow(/nests objects more than 64 deep/);
+
+    // ... and one level under the limit still works, so the boundary is where it claims to be.
+    let ok: PdfObject = str("reachable");
+    for (let i = 0; i < 60; i++) ok = [ok];
+    expect(stringsIn(ok).length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

fillForm has now a new option: `flatten`

## Related issue(s)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional form flattening during form filling.
  - Filled field appearances can now be baked and flattened in a single update.
  - Results identify which fields were flattened.
  - Button-state appearances are generated more reliably.

- **Bug Fixes**
  - Preserved correct appearance data for newly filled fields.
  - Improved encrypted document handling during form updates.
  - Cleared obsolete appearance settings after flattening forms.

- **Validation**
  - Added safeguards for incompatible rendering options and expanded coverage for flattening workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->