### PR TITLE
fix: bound stream decompression when reading a `PDF`

### DIFF
--- a/src/lib/edit/document.ts
+++ b/src/lib/edit/document.ts
@@ -1,5 +1,5 @@
-import { unzlibSync } from "fflate";
 import { Lexer } from "./lexer.ts";
+import { DEFAULT_MAX_STREAM_SIZE, inflateBounded, PdfStreamTooLargeError } from "./inflate.ts";
 import {
   get,
   isDict,
@@ -36,6 +36,18 @@ type XrefEntry =
 
 const EMPTY = new Uint8Array(0);
 
+/** What `PdfDocument.load` accepts. */
+export interface LoadOptions {
+  /** Ceiling on what ONE stream may inflate to, in bytes (default 64 MB). Raise it for a document that
+   *  is genuinely enormous; a stream past it throws `PdfStreamTooLargeError` rather than being read. */
+  maxStreamSize?: number;
+}
+
+/** What `PdfDocument.open` accepts - everything `load` takes, plus the password. */
+export interface OpenOptions extends LoadOptions {
+  password?: string;
+}
+
 /** Thrown when a file cannot be opened because of its encryption - always saying which of the reasons it
  *  is: no password, wrong password, or a revision we do not implement. */
 export class PdfEncryptedError extends Error {
@@ -47,10 +59,6 @@ export class PdfEncryptedError extends Error {
 /** The raw bytes of a `/Encrypt` entry that must be a string (`/U`, `/UE`). */
 const stringBytes = (o: PdfObject | undefined): Uint8Array | undefined =>
   isString(o) ? o.bytes : undefined;
-
-// `stringsIn` lives in objects.ts: the read side walks a tree to DECIPHER every string, the write side
-// to ENCIPHER every string, and the two must agree on what "every string" means. Two copies of that
-// walk is exactly how one of them ends up missing a case.
 
 export class PdfDocument {
   private readonly xref = new Map<number, XrefEntry>();
@@ -70,10 +78,14 @@ export class PdfDocument {
    *  walk the chain back. */
   usesXrefStream = false;
 
+  /** Ceiling on what one stream may inflate to; see `inflate.ts`. */
+  private maxStreamSize = DEFAULT_MAX_STREAM_SIZE;
+
   private constructor(readonly bytes: Uint8Array) {}
 
-  static load(bytes: Uint8Array): PdfDocument {
+  static load(bytes: Uint8Array, opts: LoadOptions = {}): PdfDocument {
     const doc = new PdfDocument(bytes);
+    if (opts.maxStreamSize !== undefined) doc.maxStreamSize = opts.maxStreamSize;
     try {
       doc.readXrefChain();
     } catch {
@@ -93,8 +105,8 @@ export class PdfDocument {
    * above them synchronous, which is the same trade the writer makes (`structure.ts` builds the handler
    * before the synchronous constructor).
    */
-  static async open(bytes: Uint8Array, opts: { password?: string } = {}): Promise<PdfDocument> {
-    const doc = PdfDocument.load(bytes);
+  static async open(bytes: Uint8Array, opts: OpenOptions = {}): Promise<PdfDocument> {
+    const doc = PdfDocument.load(bytes, opts);
     if (!doc.isEncrypted) return doc;
     doc.security = await doc.securityHandlerFor(opts.password);
     await doc.decryptEverything();
@@ -617,8 +629,12 @@ export class PdfDocument {
     filters.forEach((filter, i) => {
       if (filter === "FlateDecode") {
         try {
-          data = unzlibSync(data);
-        } catch {
+          // Per pass, because /Filter is a list and [/FlateDecode /FlateDecode] is a legal nested bomb.
+          data = inflateBounded(data, this.maxStreamSize);
+        } catch (e) {
+          // A stream that blew the ceiling is an attack, not a stream we failed to decode - swallowing
+          // it here would hand back silent garbage.
+          if (e instanceof PdfStreamTooLargeError) throw e;
           return; // not our data to repair; hand back what we have
         }
         data = this.undoPredictor(data, this.resolve(parms[i]));

--- a/src/lib/edit/fill.ts
+++ b/src/lib/edit/fill.ts
@@ -26,6 +26,8 @@ export type FieldValue = string | boolean | string[] | null;
 export interface FillOptions {
   /** The user password, for a document that is encrypted. Wrong or missing gives a named error. */
   password?: string;
+  /** Ceiling on what ONE stream may inflate to, in bytes (default 64 MB) - the zip-bomb guard. */
+  maxStreamSize?: number;
   /**
    * Draw the new value into the field's appearance (default `true`), the same way jasy bakes one when it
    * CREATES a field - so the value is visible in any viewer, not only in one that honours
@@ -183,8 +185,7 @@ async function bakeStatesFor(
       data: (await doc.encryptForWrite(encoded)) ?? encoded,
     });
   };
-  // The object numbers come back too, not just the dictionary text: a flatten in the same pass has to
-  // stamp ONE of these two states, and picking it out of a serialized string again would be silly.
+  // The object numbers come back too: a flatten in the same pass stamps one of these two states.
   const onNum = await write(faces.on);
   const offNum = await write(faces.off);
   return {
@@ -340,9 +341,8 @@ export async function fillForm(
   values: Record<string, FieldValue>,
   options: FillOptions = {},
 ): Promise<FillResult> {
-  // Two combinations of options describe a document nobody wants. Both are refused here, before the
-  // file is even opened, because the answer does not depend on it - and a silent nonsense result is the
-  // one outcome this module does not ship.
+  // Two option combinations describe a document nobody wants. Refused before the file is opened, since
+  // the answer does not depend on it.
   if (options.fieldAppearances === false && options.needAppearances === false) {
     throw new FillError(
       "fieldAppearances and needAppearances are both false, which leaves the values invisible: nothing " +
@@ -358,7 +358,10 @@ export async function fillForm(
 
   // Async because an encrypted document has to be deciphered before its field names mean anything, and
   // because the values written back have to be enciphered again with the same file key.
-  const doc = await PdfDocument.open(bytes, { password: options.password });
+  const doc = await PdfDocument.open(bytes, {
+    password: options.password,
+    maxStreamSize: options.maxStreamSize,
+  });
 
   if (!doc.canReEncrypt) {
     throw new FillError(
@@ -514,10 +517,8 @@ export async function fillForm(
   // When we DID draw, the flag has to go: a form that still asks for regeneration gets it, and the
   // viewer throws our drawing away and redraws from /DA - which is how PDFKit's forms kept asking for a
   // ZapfDingbats they do not ship.
-  //
-  // With a flatten following there is nothing to answer it FOR: the form loses its fields, and the
-  // flatten pass rewrites the same /AcroForm dictionary anyway - writing the flag here would only be
-  // overwritten a moment later.
+  // With a flatten following there is nothing left to answer it for, and that pass rewrites the same
+  // /AcroForm dictionary anyway.
   const needAppearances = bake && !someBakeFailed ? "false" : "true";
   if (!options.flatten && (bake || options.needAppearances !== false)) {
     if (acro !== undefined && isDict(acro)) {
@@ -537,8 +538,8 @@ export async function fillForm(
     }
   }
 
-  // Flattening rides on the SAME writer, so the whole operation stays one incremental update. It goes
-  // last because it freezes the pictures the pass above has just drawn.
+  // Same writer, so the whole operation stays one incremental update. Last, because it freezes the
+  // pictures drawn above.
   const flattened = options.flatten
     ? await flattenInto(doc, writer, form.fields, carried, fresh)
     : [];

--- a/src/lib/edit/flatten.ts
+++ b/src/lib/edit/flatten.ts
@@ -36,6 +36,8 @@ import {
 export interface FlattenOptions {
   /** The user password, for a document that is encrypted. */
   password?: string;
+  /** Ceiling on what ONE stream may inflate to, in bytes (default 64 MB) - the zip-bomb guard. */
+  maxStreamSize?: number;
   /** Flatten only these fields (fully qualified names). Omit for all of them. */
   fields?: string[];
 }
@@ -343,12 +345,10 @@ function withEntries(
 /**
  * The appearance streams a fill has just written, keyed by widget object number.
  *
- * Flattening freezes the picture a widget currently shows, and it reads that picture out of the
- * document. In the same pass as a fill the new picture is not in the document yet - it is in the
- * writer, appended but not saved - so without this map a filled-and-flattened form would stamp the
- * value the field had BEFORE the fill. It applies to both kinds of widget, which go stale for two
- * different reasons: a text field's `/AP` is replaced outright, and a button's `/AP` keeps all its
- * states while `/AS` moves to pick a different one.
+ * Flattening reads the picture a widget shows out of the DOCUMENT, but mid-pass the new one is still in
+ * the writer - without this map a filled-and-flattened form freezes the value from before the fill.
+ * Both widget kinds go stale, for different reasons: a text field's `/AP` is replaced, a button's `/AP`
+ * keeps every state and only `/AS` moves.
  */
 export type FreshAppearances = ReadonlyMap<number, PdfRef>;
 
@@ -371,15 +371,9 @@ export async function flattenInto(
   for (const s of stamps)
     (byPage.get(s.pageNum) ?? byPage.set(s.pageNum, []).get(s.pageNum)!).push(s);
 
-  // In an encrypted document every string in a rewritten object has to be enciphered again, or
-  // `serialize` writes it back in the clear - ISSUE-7, one object at a time. The caller's map (a fill
-  // flattening in the same pass) is the seed; the pages are what only this pass touches.
-  //
-  // NOT reachable today, and therefore not covered by a test: we can only write R6, so the only
-  // encrypted files we can flatten are our own, and ours reference every annotation as its own object -
-  // a page dictionary of ours holds no string at all. It matters the moment a producer inlines an
-  // annotation (its /Contents and /URI are strings), which is why it is wired rather than left as a
-  // trap. Same reasoning as the `alsoRewritten` pass in `fill.ts`.
+  // Strings in the objects rewritten below have to be enciphered again; the caller's map is the seed.
+  // Untested because unreachable today: we can only flatten our own R6 files, and our page dictionaries
+  // hold no strings. It bites the moment a producer inlines an annotation (/Contents, /URI).
   const acroDict = doc.resolve(get(doc.catalog, "AcroForm"));
   const cipher = await carryStrings(
     doc,
@@ -467,10 +461,8 @@ export async function flattenInto(
     const gone = new Set(fields.map((f) => f.objNum).filter((n): n is number => n !== undefined));
     // A flattened field may hang in a PARENT's /Kids rather than in the form's /Fields. Dropping it only
     // from the root leaves it reachable, so `readAcroForm` still reports a field with no widget left.
-    //
-    // Planned first, written after: a surviving parent is rewritten WHOLE, so it carries its own /T,
-    // /TU and /DA along - and those are strings that have to be enciphered like any other. Collecting
-    // them needs an await, which is why the walk itself stays synchronous and only plans.
+    // Planned first, written after: a surviving parent is rewritten whole, carrying its own /T, /TU
+    // and /DA, and enciphering those needs an await the sync walk cannot do.
     const prunes = pruneKids(doc, get(acro, "Fields"), gone);
     await carryStrings(
       doc,
@@ -555,7 +547,10 @@ export async function flattenForm(
   bytes: Uint8Array,
   options: FlattenOptions = {},
 ): Promise<FlattenResult> {
-  const doc = await PdfDocument.open(bytes, { password: options.password });
+  const doc = await PdfDocument.open(bytes, {
+    password: options.password,
+    maxStreamSize: options.maxStreamSize,
+  });
   if (!doc.canReEncrypt) {
     throw new FlattenError(
       "this PDF is encrypted with RC4 or AES-128; jasy can open it but writes only AES-256, so " +

--- a/src/lib/edit/index.ts
+++ b/src/lib/edit/index.ts
@@ -18,6 +18,9 @@ export type { FlattenOptions, FlattenResult } from "./flatten.ts";
 export type { FieldValue, FillOptions, FillResult } from "./fill.ts";
 
 // The document itself, for callers who want to look further than the form.
-// PdfEncryptedError is what a caller catches to tell "wrong password" apart from a broken file.
+// PdfEncryptedError is what a caller catches to tell "wrong password" apart from a broken file;
+// PdfStreamTooLargeError tells "this file is attacking me" apart from both.
 export { PdfDocument, PdfEncryptedError } from "./document.ts";
+export type { LoadOptions, OpenOptions } from "./document.ts";
+export { DEFAULT_MAX_STREAM_SIZE, PdfStreamTooLargeError } from "./inflate.ts";
 export type { PdfDict, PdfName, PdfObject, PdfRef, PdfStream, PdfString } from "./objects.ts";

--- a/src/lib/edit/inflate.ts
+++ b/src/lib/edit/inflate.ts
@@ -1,0 +1,62 @@
+import { Unzlib, unzlibSync } from "fflate";
+
+/**
+ * Inflating a stream with a ceiling, so a zip bomb cannot exhaust memory.
+ *
+ * fflate's `unzlibSync(data, { out })` is NOT usable for this: it truncates silently instead of failing.
+ * Hence the streamed form - input in slices, so the total can be checked while it grows.
+ */
+
+/** Thrown when a stream expands past the ceiling; distinct from a stream that simply will not decode. */
+export class PdfStreamTooLargeError extends Error {
+  constructor(
+    readonly limit: number,
+    message: string,
+  ) {
+    super(`@jasy/pdf: ${message}`);
+  }
+}
+
+export const DEFAULT_MAX_STREAM_SIZE = 64 * 1024 * 1024;
+
+/** Only the granularity of the check: fflate buffers internally, so the abort lands one block past. */
+const INPUT_SLICE = 16 * 1024;
+
+/** DEFLATE's maximum expansion (a 258-byte match in its shortest encoding). A format property. */
+const MAX_DEFLATE_RATIO = 1032;
+
+export function inflateBounded(data: Uint8Array, limit: number): Uint8Array {
+  // Too small to reach the ceiling even at maximum compression, so checking as it grows is pointless.
+  // Nearly every stream in a real PDF lands here, which is why the guard costs nothing.
+  if (data.length <= limit / MAX_DEFLATE_RATIO) return unzlibSync(data);
+
+  const parts: Uint8Array[] = [];
+  let total = 0;
+
+  const inflater = new Unzlib();
+  inflater.ondata = (chunk: Uint8Array) => {
+    total += chunk.length;
+    if (total > limit) {
+      throw new PdfStreamTooLargeError(
+        limit,
+        `a stream in this PDF expands past the ${limit} byte limit for a single stream; if the file is ` +
+          `genuinely that large, raise it with { maxStreamSize }`,
+      );
+    }
+    parts.push(chunk);
+  };
+
+  for (let at = 0; at < data.length; at += INPUT_SLICE) {
+    const end = Math.min(at + INPUT_SLICE, data.length);
+    inflater.push(data.subarray(at, end), end >= data.length);
+  }
+
+  if (parts.length === 1) return parts[0];
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const part of parts) {
+    out.set(part, at);
+    at += part.length;
+  }
+  return out;
+}

--- a/src/lib/edit/objects.ts
+++ b/src/lib/edit/objects.ts
@@ -121,15 +121,13 @@ export function textOf(o: PdfObject | undefined): string | undefined {
 }
 
 /**
- * Every string inside an object, however deep. Used before rewriting one into an ENCRYPTED document:
- * the strings carried over unchanged were deciphered on open, so each has to be enciphered again or it
- * goes back into the file in the clear - which is ISSUE-7 all over again, one object at a time.
+ * Every string inside an object, however deep. Both sides of the crypto seam use it: strings are
+ * deciphered on open and must be enciphered again before an object is written back.
  */
 export function stringsIn(o: PdfObject | undefined, out: PdfString[] = [], depth = 0): PdfString[] {
   if (o === undefined || o === null) return out;
-  // Depth is bounded because the walk does NOT follow references - only containers written inline. Past
-  // the limit we THROW rather than return what we have: both callers use the result to decide which
-  // strings get enciphered or deciphered, so a silently short list is a string written in the clear.
+  // Throws rather than returning a short list: a missed string is one written back in the clear.
+  // Bounded at all only because the walk does not follow references, just inline containers.
   if (depth > MAX_NESTING) {
     throw new Error(
       `@jasy/pdf: this PDF nests objects more than ${MAX_NESTING} deep, which no legitimate producer ` +
@@ -138,7 +136,7 @@ export function stringsIn(o: PdfObject | undefined, out: PdfString[] = [], depth
   }
   if (isString(o)) out.push(o);
   else if (Array.isArray(o)) for (const e of o) stringsIn(e, out, depth + 1);
-  // A stream's own dictionary holds strings too; its DATA is covered by the stream's own encryption.
+  // The dictionary only - a stream's DATA is covered by the stream's own encryption.
   else if (isStream(o)) stringsIn(o.dict, out, depth + 1);
   else if (isDict(o)) for (const v of o.map.values()) stringsIn(v, out, depth + 1);
   return out;

--- a/src/lib/edit/writer.ts
+++ b/src/lib/edit/writer.ts
@@ -303,11 +303,10 @@ const hexString = (b: Uint8Array): string =>
   `<${Array.from(b, (x) => x.toString(16).padStart(2, "0").toUpperCase()).join("")}>`;
 
 /**
- * Encipher every string the given objects carry, into a cipher map `serialize` then consults.
+ * Encipher every string the given objects carry, into the cipher map `serialize` consults.
  *
- * A no-op on an unencrypted document. On an encrypted one it is not optional: `serialize` writes any
- * string it cannot find in the map as PLAINTEXT, so an object rewritten without this pass leaks
- * whatever it holds - a link URL, an annotation's note, a form-level /DA.
+ * Not optional on an encrypted document: `serialize` writes any string missing from the map as
+ * PLAINTEXT, so an object rewritten without this pass leaks whatever it holds.
  */
 export async function carryStrings(
   doc: PdfDocument,

--- a/tests/unit/edit/inflate.test.ts
+++ b/tests/unit/edit/inflate.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { zlibSync } from "fflate";
+import {
+  DEFAULT_MAX_STREAM_SIZE,
+  inflateBounded,
+  PdfStreamTooLargeError,
+} from "../../../src/lib/edit/inflate.ts";
+import { PdfDocument } from "../../../src/lib/edit/document.ts";
+import { get, isStream } from "../../../src/lib/edit/objects.ts";
+
+// A PDF stream declares its COMPRESSED length and says nothing about what it expands to, so a few
+// kilobytes of crafted input can expand until the process dies. The bomb below is BUILT here rather than
+// committed: a fixture that inflates to hundreds of megabytes is not something to keep in a repository,
+// and generating it is three lines.
+
+/** A zlib stream of `size` zero bytes - a few hundred KB of input, `size` bytes of output. */
+const bomb = (size: number) => zlibSync(new Uint8Array(size));
+
+describe("inflateBounded", () => {
+  it("inflates an ordinary stream untouched", () => {
+    const text = "the quick brown fox".repeat(100);
+    const out = inflateBounded(zlibSync(new TextEncoder().encode(text)), DEFAULT_MAX_STREAM_SIZE);
+    expect(new TextDecoder().decode(out)).toBe(text);
+  });
+
+  it("refuses a stream that expands past the ceiling", () => {
+    // 48 MB from a few hundred KB. Without a ceiling this is the whole attack.
+    const attack = bomb(48 * 1024 * 1024);
+    expect(attack.length).toBeLessThan(256 * 1024);
+    expect(() => inflateBounded(attack, 1024 * 1024)).toThrow(PdfStreamTooLargeError);
+  });
+
+  it("says WHICH limit was hit and how to raise it", () => {
+    // The error a caller sees decides whether they can act on it. "Invalid stream" would not.
+    const err = (() => {
+      try {
+        inflateBounded(bomb(48 * 1024 * 1024), 1024);
+        return undefined;
+      } catch (e) {
+        return e as PdfStreamTooLargeError;
+      }
+    })();
+    expect(err).toBeInstanceOf(PdfStreamTooLargeError);
+    expect(err!.limit).toBe(1024);
+    expect(err!.message).toMatch(/maxStreamSize/);
+  });
+
+  it("is off by no more than fflate's own block, not by a factor", () => {
+    // The check runs per emitted block, so the abort lands slightly PAST the ceiling - it has to be
+    // bounded, or the ceiling is decorative. A stream just under it must still come through whole.
+    const justUnder = zlibSync(new Uint8Array(500 * 1024));
+    expect(inflateBounded(justUnder, 1024 * 1024).length).toBe(500 * 1024);
+  });
+});
+
+describe("the reader refuses a bomb rather than reading it", () => {
+  /** A minimal one-page PDF whose single content stream is the given (already deflated) payload. */
+  const pdfWithStream = (payload: Uint8Array): Uint8Array => {
+    const head = "%PDF-1.7\n";
+    const objs = [
+      "<< /Type /Catalog /Pages 2 0 R >>",
+      "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+      "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 200] /Contents 4 0 R >>",
+    ];
+    const parts: Uint8Array[] = [];
+    const enc = (s: string) => new TextEncoder().encode(s);
+    let at = head.length;
+    const offsets: number[] = [];
+    parts.push(enc(head));
+    objs.forEach((o, i) => {
+      offsets.push(at);
+      const chunk = enc(`${i + 1} 0 obj\n${o}\nendobj\n`);
+      parts.push(chunk);
+      at += chunk.length;
+    });
+    offsets.push(at);
+    const dict = enc(`4 0 obj\n<< /Length ${payload.length} /Filter /FlateDecode >>\nstream\n`);
+    parts.push(dict, payload, enc("\nendstream\nendobj\n"));
+    at += dict.length + payload.length + "\nendstream\nendobj\n".length;
+
+    let tail = `xref\n0 5\n0000000000 65535 f \n`;
+    for (const off of offsets) tail += `${String(off).padStart(10, "0")} 00000 n \n`;
+    tail += `trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n${at}\n%%EOF\n`;
+    parts.push(enc(tail));
+
+    const total = parts.reduce((n, p) => n + p.length, 0);
+    const out = new Uint8Array(total);
+    let w = 0;
+    for (const p of parts) {
+      out.set(p, w);
+      w += p.length;
+    }
+    return out;
+  };
+
+  const contentStream = (doc: PdfDocument) => {
+    const kids = doc.lookup(doc.lookup(doc.catalog, "Pages"), "Kids");
+    const page = doc.resolve(Array.isArray(kids) ? kids[0] : undefined);
+    const s = doc.resolve(get(page, "Contents"));
+    if (!isStream(s)) throw new Error("no content stream in the test document");
+    return s;
+  };
+
+  it("throws instead of handing back silently truncated data", () => {
+    // The important half. fflate does NOT throw on an over-long inflate - it TRUNCATES - and the
+    // surrounding catch in `streamData` is there to swallow a stream that will not decode. Getting this
+    // wrong turns "this file is attacking you" into "here, have some garbage", which is worse than the
+    // original bug because it looks like it worked.
+    const doc = PdfDocument.load(pdfWithStream(bomb(48 * 1024 * 1024)), {
+      maxStreamSize: 1024 * 1024,
+    });
+    expect(() => doc.streamData(contentStream(doc))).toThrow(PdfStreamTooLargeError);
+  });
+
+  it("still reads a legitimate stream of the same shape", () => {
+    const doc = PdfDocument.load(pdfWithStream(zlibSync(new TextEncoder().encode("BT ET"))));
+    expect(new TextDecoder().decode(doc.streamData(contentStream(doc)))).toBe("BT ET");
+  });
+
+  it("keeps swallowing a stream that is merely corrupt", () => {
+    // Not every failure is an attack: a stream that will not decode is not ours to repair, and the
+    // reader hands back what it has. That behaviour has to survive the new throw.
+    const doc = PdfDocument.load(pdfWithStream(new Uint8Array([1, 2, 3, 4, 5])));
+    expect(() => doc.streamData(contentStream(doc))).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

`streamData` called `unzlibSync` with no ceiling, so a crafted stream of a few KB could expand to gigabytes and exhaust memory. That hits any server-side use of `@jasy/pdf/edit` on an uploaded file.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [ ] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `maxStreamSize` parameter to PDF loading, opening, form filling, and flattening operations to control stream inflation limits (default: 64 MB).
  * New `PdfStreamTooLargeError` exception thrown when PDF streams exceed configured size limits.

* **Tests**
  * Added comprehensive test coverage for stream inflation behavior and size-limit enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->