### PR TITLE
feat: add aspect ration function

### DIFF
--- a/src/lib/api/content.ts
+++ b/src/lib/api/content.ts
@@ -10,7 +10,7 @@ import {
 import { PDFElement } from "../elements/pdf-element.ts";
 import { ColorInput, toColor } from "./color.ts";
 import { Insets, toEdges } from "./insets.ts";
-import { SizeInput, toDimension } from "./dimension.ts";
+import { BoundsInput, SizeInput, toBounds, toDimension } from "./dimension.ts";
 
 /** A horizontal rule (locked §4). */
 export interface DividerOptions {
@@ -58,7 +58,7 @@ const FIT: Record<ImageFit, BoxFit> = {
   fill: BoxFit.fill,
 };
 
-export interface ImageOptions {
+export interface ImageOptions extends BoundsInput {
   /** Size on each axis: points (fixed) or a percentage string like `"50%"` (a fraction of the offered
    *  space). Pin exactly ONE axis and the other follows the image's aspect ratio (CSS `height: auto`). */
   width?: SizeInput;
@@ -79,9 +79,11 @@ export interface ImageOptions {
 export function Image(src: ImageSource, opts: ImageOptions = {}): ImageElement {
   const w = opts.width !== undefined ? toDimension(opts.width) : undefined;
   const h = opts.height !== undefined ? toDimension(opts.height) : undefined;
-  // Exactly one axis pinned -> the other is derived from the aspect ratio, so scale the image to the
-  // resulting box (fit: fill). Both or neither pinned keeps the default fit (none).
-  const autoScale = (opts.width !== undefined) !== (opts.height !== undefined);
+  // The box was derived rather than given outright - from the image's own ratio (exactly one axis
+  // pinned) or from an explicit `aspectRatio` - so scale the image into it (fit: fill). Two pinned axes
+  // and no ratio keep the default fit (none).
+  const autoScale =
+    (opts.width !== undefined) !== (opts.height !== undefined) || opts.aspectRatio !== undefined;
   const fit = opts.fit ? FIT[opts.fit] : autoScale ? BoxFit.fill : undefined;
 
   return new ImageElement({
@@ -95,6 +97,7 @@ export function Image(src: ImageSource, opts: ImageOptions = {}): ImageElement {
     height: h?.points,
     widthFactor: w?.factor,
     heightFactor: h?.factor,
+    ...toBounds(opts),
     fit,
     radius: opts.radius,
     alt: opts.alt,

--- a/src/lib/api/content.ts
+++ b/src/lib/api/content.ts
@@ -63,7 +63,8 @@ export interface ImageOptions extends BoundsInput {
    *  space). Pin exactly ONE axis and the other follows the image's aspect ratio (CSS `height: auto`). */
   width?: SizeInput;
   height?: SizeInput;
-  /** Fit within the box (default `none`; `fill` when exactly one axis is pinned so it scales to fit). */
+  /** Fit within the box. Default `none`, except where the box was DERIVED rather than given outright -
+   *  exactly one axis pinned, or an `aspectRatio` - which defaults to `fill` so the image scales into it. */
   fit?: ImageFit;
   /** Corner radius in points (rounds the image box). */
   radius?: number;

--- a/src/lib/api/dimension.ts
+++ b/src/lib/api/dimension.ts
@@ -30,3 +30,38 @@ export function toDimension(value: SizeInput): Dimension {
   if (m) return { factor: parseFloat(m[1]) / 100 };
   throw new Error(`Invalid size "${value}": use a number of points or a percentage like "50%".`);
 }
+
+/** The bound and ratio options every sized factory accepts, in the public `SizeInput` form. */
+export interface BoundsInput {
+  minWidth?: SizeInput;
+  maxWidth?: SizeInput;
+  minHeight?: SizeInput;
+  maxHeight?: SizeInput;
+  /**
+   * width / height (CSS `aspect-ratio`). Fills in whichever axis you leave open, and sizes the box
+   * from the offered width when you leave both open. An explicit `min`/`max` still wins over it.
+   */
+  aspectRatio?: number;
+}
+
+/** Split `BoundsInput` into the points-and-factors form the elements take. */
+export function toBounds(o: BoundsInput) {
+  const d = (v: SizeInput | undefined) => (v !== undefined ? toDimension(v) : undefined);
+  const [minW, maxW, minH, maxH] = [d(o.minWidth), d(o.maxWidth), d(o.minHeight), d(o.maxHeight)];
+  if (o.aspectRatio !== undefined && !(o.aspectRatio > 0)) {
+    throw new Error(
+      `Invalid aspectRatio ${o.aspectRatio}: it is width / height and must be above 0.`,
+    );
+  }
+  return {
+    minWidth: minW?.points,
+    maxWidth: maxW?.points,
+    minHeight: minH?.points,
+    maxHeight: maxH?.points,
+    minWidthFactor: minW?.factor,
+    maxWidthFactor: maxW?.factor,
+    minHeightFactor: minH?.factor,
+    maxHeightFactor: maxH?.factor,
+    aspectRatio: o.aspectRatio,
+  };
+}

--- a/src/lib/api/layout.ts
+++ b/src/lib/api/layout.ts
@@ -15,11 +15,11 @@ import { PDFElement } from "../elements/pdf-element.ts";
 import { MainAlign, CrossAlign } from "../utils/flex-layout.ts";
 import { ColorInput, toColor } from "./color.ts";
 import { Insets, toEdges } from "./insets.ts";
-import { SizeInput, toDimension } from "./dimension.ts";
+import { BoundsInput, SizeInput, toBounds, toDimension } from "./dimension.ts";
 import { splitArgs } from "./args.ts";
 
 /** Options shared by the `Column` and `Row` stacks (locked §4). */
-export interface StackOptions {
+export interface StackOptions extends BoundsInput {
   /** Space inserted between children, in points. */
   gap?: number;
   /** Distribution along the main axis (CSS `justify-content`): start (default) · center · end ·
@@ -46,7 +46,13 @@ export interface StackOptions {
 function stackSize(opts: StackOptions) {
   const w = opts.width !== undefined ? toDimension(opts.width) : undefined;
   const h = opts.height !== undefined ? toDimension(opts.height) : undefined;
-  return { width: w?.points, height: h?.points, widthFactor: w?.factor, heightFactor: h?.factor };
+  return {
+    width: w?.points,
+    height: h?.points,
+    widthFactor: w?.factor,
+    heightFactor: h?.factor,
+    ...toBounds(opts),
+  };
 }
 
 // The public default for `cross` is `start` (locked §5) - i.e. don't stretch a child unless
@@ -111,7 +117,7 @@ export function keepTogether(children: PDFElement[]): KeepTogetherElement {
 }
 
 /** A bordered / filled box that wraps its children (locked §4). */
-export interface BoxOptions {
+export interface BoxOptions extends BoundsInput {
   /** Border (stroke) color. A box has a border only when `border` or `borderWidth` is set. */
   border?: ColorInput;
   /** Per-side border colors - override/add to `border`. Any of these makes the box draw
@@ -198,6 +204,7 @@ export function Box(a: BoxOptions | PDFElement[], b?: PDFElement[]): PDFElement 
       height: h?.points,
       widthFactor: w?.factor,
       heightFactor: h?.factor,
+      ...toBounds(opts),
       radius: opts.radius,
       sideBorders: hasPerSide
         ? {

--- a/src/lib/elements/container-element.ts
+++ b/src/lib/elements/container-element.ts
@@ -185,16 +185,17 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
       constraints,
     );
     const { width: explicitWidth, height: explicitHeight, constraints: bounds } = resolved;
+    // Fill-or-shrink-wrap is decided by the constraints we were GIVEN; a min/max only caps the result.
     const boundedWidth =
       explicitWidth !== undefined
         ? bounds.constrainWidth(explicitWidth)
-        : bounds.hasBoundedWidth
+        : constraints.hasBoundedWidth
           ? bounds.maxWidth
           : undefined;
     const boundedHeight =
       explicitHeight !== undefined
         ? bounds.constrainHeight(explicitHeight)
-        : bounds.hasBoundedHeight
+        : constraints.hasBoundedHeight
           ? bounds.maxHeight
           : undefined;
 

--- a/src/lib/elements/container-element.ts
+++ b/src/lib/elements/container-element.ts
@@ -1,5 +1,12 @@
 import { FlexLayoutHelper, VERTICAL_AXIS, MainAlign, CrossAlign } from "../utils/flex-layout.ts";
-import { BoxConstraints, Offset, Size, resolveExtent } from "../layout/box-constraints.ts";
+import {
+  BoxConstraints,
+  Offset,
+  Size,
+  SizingParams,
+  extentSpecs,
+  resolveSize,
+} from "../layout/box-constraints.ts";
 import {
   Fragmentable,
   FragmentResult,
@@ -25,6 +32,17 @@ interface ContainerElementParams extends SizedElement, WithChildren {
   /** Width/height as a fraction (0..1) of the offered box instead of `width`/`height` (relative sizing). */
   widthFactor?: number;
   heightFactor?: number;
+  /** Lower / upper bounds per axis, in points or as a fraction; see `SizingParams`. */
+  minWidth?: number;
+  maxWidth?: number;
+  minHeight?: number;
+  maxHeight?: number;
+  minWidthFactor?: number;
+  maxWidthFactor?: number;
+  minHeightFactor?: number;
+  maxHeightFactor?: number;
+  /** width / height; derives whichever axis is left open (CSS `aspect-ratio`). */
+  aspectRatio?: number;
   /** Start this stack on a fresh page (CSS `break-before: page`). */
   breakBefore?: boolean;
   /** Start everything after this stack on a fresh page (CSS `break-after: page`). */
@@ -40,12 +58,7 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
   private breakAfter: boolean;
   // The requested size, snapshot at construction so re-layouts (fragmentation measuring, which
   // mutate this.width/height) still see what the user asked for. `undefined` = fill / shrink-wrap.
-  private requested: {
-    width?: number;
-    height?: number;
-    widthFactor?: number;
-    heightFactor?: number;
-  };
+  private requested!: SizingParams;
 
   constructor({
     x,
@@ -56,10 +69,9 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
     gap,
     main,
     cross,
-    widthFactor,
-    heightFactor,
     breakBefore,
     breakAfter,
+    ...sizing
   }: ContainerElementParams) {
     super({ x, y, width, height });
 
@@ -67,7 +79,7 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
     this.gap = gap ?? 0;
     this.main = main ?? "start";
     this.cross = cross ?? "stretch";
-    this.requested = { width, height, widthFactor, heightFactor };
+    this.requested = { ...sizing, width, height };
     this.breakBefore = breakBefore ?? false;
     this.breakAfter = breakAfter ?? false;
   }
@@ -165,29 +177,25 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
     // Relative sizing: a pinned extent (fixed points or a fraction of the offered box, clamped into
     // the constraints) wins; else fill a bounded axis; else stay `undefined` and shrink-wrap below.
     // A Column nested in a Row gets unbounded width - passing 0 there would collapse children to 0.
-    const explicitWidth = resolveExtent(
-      this.requested.width,
-      this.requested.widthFactor,
-      constraints.maxWidth,
-      constraints.hasBoundedWidth,
+    const specs = extentSpecs(this.requested);
+    const resolved = resolveSize(
+      specs.width,
+      specs.height,
+      this.requested.aspectRatio,
+      constraints,
     );
-    const explicitHeight = resolveExtent(
-      this.requested.height,
-      this.requested.heightFactor,
-      constraints.maxHeight,
-      constraints.hasBoundedHeight,
-    );
+    const { width: explicitWidth, height: explicitHeight, constraints: bounds } = resolved;
     const boundedWidth =
       explicitWidth !== undefined
-        ? constraints.constrainWidth(explicitWidth)
-        : constraints.hasBoundedWidth
-          ? constraints.maxWidth
+        ? bounds.constrainWidth(explicitWidth)
+        : bounds.hasBoundedWidth
+          ? bounds.maxWidth
           : undefined;
     const boundedHeight =
       explicitHeight !== undefined
-        ? constraints.constrainHeight(explicitHeight)
-        : constraints.hasBoundedHeight
-          ? constraints.maxHeight
+        ? bounds.constrainHeight(explicitHeight)
+        : bounds.hasBoundedHeight
+          ? bounds.maxHeight
           : undefined;
 
     // Vertical stack: cross = width (children fill it), main = height (the stacking extent).

--- a/src/lib/elements/image-element.ts
+++ b/src/lib/elements/image-element.ts
@@ -1,7 +1,14 @@
 import { getImageDimensions } from "../utils/image-helper.ts";
 import { latin1FromBytes } from "../utils/bytes.ts";
 import { readFileBytesAsync } from "../platform/node-fs.ts";
-import { BoxConstraints, Offset, Size, resolveExtent } from "../layout/box-constraints.ts";
+import {
+  BoxConstraints,
+  Offset,
+  Size,
+  SizingParams,
+  extentSpecs,
+  resolveSize,
+} from "../layout/box-constraints.ts";
 import { LayoutContext, SizedPDFElement } from "./pdf-element.ts";
 
 // path.extname without node:path (browser-safe): the substring from the last dot, if it sits after the
@@ -127,6 +134,17 @@ interface ImageElementParams {
   widthFactor?: number;
   /** Height as a fraction (0..1) of the offered height; see `widthFactor`. */
   heightFactor?: number;
+  /** Lower / upper bounds per axis, in points or as a fraction; see `SizingParams`. */
+  minWidth?: number;
+  maxWidth?: number;
+  minHeight?: number;
+  maxHeight?: number;
+  minWidthFactor?: number;
+  maxWidthFactor?: number;
+  minHeightFactor?: number;
+  maxHeightFactor?: number;
+  /** width / height; overrides the image's OWN ratio (CSS `aspect-ratio`), `fit` then places it. */
+  aspectRatio?: number;
   fit?: BoxFit;
   /** Corner radius in points; rounds the image box (0 = sharp, default). */
   radius?: number;
@@ -145,6 +163,8 @@ export class ImageElement extends SizedPDFElement {
   // re-layout (fragmentation measures more than once) still resolves the factor, instead of
   // freezing to the first pass's result. Mirrors ContainerElement / RowElement.
   private requested: { width?: number; height?: number };
+  /** min/max/aspectRatio, kept as given so every layout pass re-resolves them. */
+  private sizing: SizingParams;
   // Intrinsic pixel size, resolved asynchronously before layout (see resolveIntrinsicSize). Layout
   // reads it to derive a proportional height for a width-only image (and vice versa).
   private intrinsic?: { width: number; height: number };
@@ -158,6 +178,7 @@ export class ImageElement extends SizedPDFElement {
     fit = BoxFit.none,
     radius,
     alt,
+    ...sizing
   }: ImageElementParams) {
     // Seed this.width/height from the request so getProps() reflects it before layout; calculateLayout
     // then reads `requested` (never the mutated fields) and overwrites these with the laid-out size.
@@ -168,6 +189,7 @@ export class ImageElement extends SizedPDFElement {
     this.requested = { width, height };
     this.widthFactor = widthFactor;
     this.heightFactor = heightFactor;
+    this.sizing = sizing;
     this.fit = fit;
     this.radius = radius ?? 0;
     this.alt = alt;
@@ -198,32 +220,38 @@ export class ImageElement extends SizedPDFElement {
 
     // Relative sizing: a fixed size or a fraction of the offered box (fraction only in a bounded axis).
     // Read from `requested` (not this.width/height, which we overwrite below) so every pass re-resolves.
-    let w = resolveExtent(
-      this.requested.width,
-      this.widthFactor,
-      constraints.maxWidth,
-      constraints.hasBoundedWidth,
-    );
-    let h = resolveExtent(
-      this.requested.height,
-      this.heightFactor,
-      constraints.maxHeight,
-      constraints.hasBoundedHeight,
-    );
+    const specs = extentSpecs({
+      ...this.sizing,
+      width: this.requested.width,
+      height: this.requested.height,
+      widthFactor: this.widthFactor,
+      heightFactor: this.heightFactor,
+    });
+    // An explicit `aspectRatio` wins over the image's own, as it does in CSS - and only it may size a
+    // box with NEITHER axis pinned. Left to the intrinsic ratio that would change what an unsized image
+    // has always done here (fill both axes and let `fit` sort it out).
+    const resolved = resolveSize(specs.width, specs.height, this.sizing.aspectRatio, constraints);
+    let w = resolved.width;
+    let h = resolved.height;
+    const bounds = resolved.constraints;
 
-    // Aspect auto-size: when the user pinned exactly ONE axis, derive the other from the intrinsic
-    // ratio (CSS `width: 50%; height: auto`). Only fires once the pre-pass resolved the pixel size.
-    if (this.intrinsic && this.intrinsic.width > 0 && this.intrinsic.height > 0) {
+    // Aspect auto-size: when exactly ONE axis is pinned, derive the other from the intrinsic ratio
+    // (CSS `width: 50%; height: auto`). Only fires once the pre-pass resolved the pixel size.
+    if (
+      this.sizing.aspectRatio === undefined &&
+      this.intrinsic &&
+      this.intrinsic.width > 0 &&
+      this.intrinsic.height > 0
+    ) {
       const ratio = this.intrinsic.width / this.intrinsic.height;
-      if (w !== undefined && h === undefined) h = w / ratio;
-      else if (h !== undefined && w === undefined) w = h * ratio;
+      if (w !== undefined && h === undefined) h = bounds.constrainHeight(w / ratio);
+      else if (h !== undefined && w === undefined) w = bounds.constrainWidth(h * ratio);
     }
 
     // Fall back to the prior behavior for an unpinned axis: a bounded axis fills, otherwise keep the
     // requested fixed size (or undefined). Read from `requested`, never the mutated this.width/height.
-    this.width = w ?? (constraints.hasBoundedWidth ? constraints.maxWidth : this.requested.width);
-    this.height =
-      h ?? (constraints.hasBoundedHeight ? constraints.maxHeight : this.requested.height);
+    this.width = w ?? (bounds.hasBoundedWidth ? bounds.maxWidth : this.requested.width);
+    this.height = h ?? (bounds.hasBoundedHeight ? bounds.maxHeight : this.requested.height);
 
     // Top-left coordinates; the fit logic (renderer) and the Y-flip (seam) run later.
     return { width: this.width ?? 0, height: this.height ?? 0 };

--- a/src/lib/elements/rectangle-element.ts
+++ b/src/lib/elements/rectangle-element.ts
@@ -236,23 +236,25 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
 
     // Width: an explicit size wins (clamped), else fill the offered box. (Without this a
     // fixed box would balloon to the parent's size.)
+    // Whether there is a region to fill is decided by the constraints we were GIVEN: a `maxWidth` caps
+    // a box, it does not turn a shrink-wrapping one into a filling one (CSS `max-width` does not either).
     this.width =
       explicitWidth !== undefined
         ? bounds.constrainWidth(explicitWidth)
-        : bounds.hasBoundedWidth
+        : constraints.hasBoundedWidth
           ? bounds.maxWidth
           : this.width;
     // Width shrink-wrap: no explicit width AND an unbounded region (e.g. a `Box` badge inside a
     // `Positioned`). Resolved after the children are measured, just below.
-    const shrinkWrapWidth = explicitWidth === undefined && !bounds.hasBoundedWidth;
+    const shrinkWrapWidth = explicitWidth === undefined && !constraints.hasBoundedWidth;
     // Height: explicit wins; otherwise FILL a bounded region (e.g. inside an Expanded) but
     // SHRINK-WRAP the content in an unbounded one (a note box in a stack). Shrink-wrap is
     // resolved after the children are measured, just below.
-    const shrinkWrapHeight = explicitHeight === undefined && !bounds.hasBoundedHeight;
+    const shrinkWrapHeight = explicitHeight === undefined && !constraints.hasBoundedHeight;
     this.height =
       explicitHeight !== undefined
         ? bounds.constrainHeight(explicitHeight)
-        : bounds.hasBoundedHeight
+        : constraints.hasBoundedHeight
           ? bounds.maxHeight
           : this.height;
     this.x = this.sizeMemory.x + offset.x;

--- a/src/lib/elements/rectangle-element.ts
+++ b/src/lib/elements/rectangle-element.ts
@@ -1,5 +1,12 @@
 import { Color } from "../common/color.ts";
-import { BoxConstraints, Offset, Size, resolveExtent } from "../layout/box-constraints.ts";
+import {
+  BoxConstraints,
+  Offset,
+  Size,
+  SizingParams,
+  extentSpecs,
+  resolveSize,
+} from "../layout/box-constraints.ts";
 import {
   Fragmentable,
   FragmentResult,
@@ -42,6 +49,17 @@ interface RectangleElementParams extends SizedElement, WithChildren {
   widthFactor?: number;
   /** Height as a fraction (0..1) of the offered height; see `widthFactor`. */
   heightFactor?: number;
+  /** Lower / upper bounds per axis, in points or as a fraction; see `SizingParams`. */
+  minWidth?: number;
+  maxWidth?: number;
+  minHeight?: number;
+  maxHeight?: number;
+  minWidthFactor?: number;
+  maxWidthFactor?: number;
+  minHeightFactor?: number;
+  maxHeightFactor?: number;
+  /** width / height; derives whichever axis is left open (CSS `aspect-ratio`). */
+  aspectRatio?: number;
   /** Start this box on a fresh page (CSS `break-before: page`). */
   breakBefore?: boolean;
   /** Start everything after this box on a fresh page (CSS `break-after: page`). */
@@ -60,14 +78,7 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
   private breakBefore: boolean;
   private breakAfter: boolean;
 
-  private sizeMemory!: {
-    x: number;
-    y: number;
-    width?: number;
-    height?: number;
-    widthFactor?: number;
-    heightFactor?: number;
-  };
+  private sizeMemory!: { x: number; y: number } & SizingParams;
 
   constructor({
     children = [],
@@ -80,10 +91,9 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
     sideBorders,
     relative,
     overflow,
-    widthFactor,
-    heightFactor,
     breakBefore,
     breakAfter,
+    ...sizing
   }: RectangleElementParams) {
     super({ x: 0, y: 0, width, height });
 
@@ -98,7 +108,7 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
     this.overflow = overflow ?? "visible";
     this.breakBefore = breakBefore ?? false;
     this.breakAfter = breakAfter ?? false;
-    this.sizeMemory = { x: 0, y: 0, width, height, widthFactor, heightFactor };
+    this.sizeMemory = { ...sizing, x: 0, y: 0, width, height };
   }
 
   override breaksBefore(): boolean {
@@ -212,39 +222,38 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
     // An explicit extent is a fixed point size or a fraction of the offered box (relative sizing);
     // the fraction only resolves in a bounded region. `undefined` = fill / shrink-wrap below.
-    const explicitWidth = resolveExtent(
-      this.sizeMemory.width,
-      this.sizeMemory.widthFactor,
-      constraints.maxWidth,
-      constraints.hasBoundedWidth,
+    const specs = extentSpecs(this.sizeMemory);
+    const resolved = resolveSize(
+      specs.width,
+      specs.height,
+      this.sizeMemory.aspectRatio,
+      constraints,
     );
-    const explicitHeight = resolveExtent(
-      this.sizeMemory.height,
-      this.sizeMemory.heightFactor,
-      constraints.maxHeight,
-      constraints.hasBoundedHeight,
-    );
+    const explicitWidth = resolved.width;
+    const explicitHeight = resolved.height;
+    // min/max come back as narrowed constraints, so the fill and shrink-wrap paths below obey them too.
+    const bounds = resolved.constraints;
 
     // Width: an explicit size wins (clamped), else fill the offered box. (Without this a
     // fixed box would balloon to the parent's size.)
     this.width =
       explicitWidth !== undefined
-        ? constraints.constrainWidth(explicitWidth)
-        : constraints.hasBoundedWidth
-          ? constraints.maxWidth
+        ? bounds.constrainWidth(explicitWidth)
+        : bounds.hasBoundedWidth
+          ? bounds.maxWidth
           : this.width;
     // Width shrink-wrap: no explicit width AND an unbounded region (e.g. a `Box` badge inside a
     // `Positioned`). Resolved after the children are measured, just below.
-    const shrinkWrapWidth = explicitWidth === undefined && !constraints.hasBoundedWidth;
+    const shrinkWrapWidth = explicitWidth === undefined && !bounds.hasBoundedWidth;
     // Height: explicit wins; otherwise FILL a bounded region (e.g. inside an Expanded) but
     // SHRINK-WRAP the content in an unbounded one (a note box in a stack). Shrink-wrap is
     // resolved after the children are measured, just below.
-    const shrinkWrapHeight = explicitHeight === undefined && !constraints.hasBoundedHeight;
+    const shrinkWrapHeight = explicitHeight === undefined && !bounds.hasBoundedHeight;
     this.height =
       explicitHeight !== undefined
-        ? constraints.constrainHeight(explicitHeight)
-        : constraints.hasBoundedHeight
-          ? constraints.maxHeight
+        ? bounds.constrainHeight(explicitHeight)
+        : bounds.hasBoundedHeight
+          ? bounds.maxHeight
           : this.height;
     this.x = this.sizeMemory.x + offset.x;
     this.y = this.sizeMemory.y + offset.y;
@@ -290,9 +299,17 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
     }
 
     // No explicit width and no bounded region: shrink-wrap to the widest child.
-    if (shrinkWrapWidth) this.width = contentWidth + 2 * this.borderWidth;
+    // Clamped, so a min/max still applies to a box that sized itself to its content.
+    if (shrinkWrapWidth) this.width = bounds.constrainWidth(contentWidth + 2 * this.borderWidth);
+    // A ratio on a shrink-wrapping box can only be applied HERE: before the children were measured
+    // there was no width to derive the height from.
+    const ratio = this.sizeMemory.aspectRatio;
+    const ratioSizesHeight =
+      ratio !== undefined && ratio > 0 && shrinkWrapWidth && shrinkWrapHeight;
     // No explicit height and no bounded region: the border hugs its content.
-    if (shrinkWrapHeight) this.height = contentHeight + 2 * this.borderWidth;
+    if (ratioSizesHeight) this.height = bounds.constrainHeight((this.width ?? 0) / ratio);
+    else if (shrinkWrapHeight)
+      this.height = bounds.constrainHeight(contentHeight + 2 * this.borderWidth);
 
     // The box is sized now: place any out-of-flow `Positioned` descendants against its box.
     if (frame) {

--- a/src/lib/elements/row-element.ts
+++ b/src/lib/elements/row-element.ts
@@ -1,4 +1,11 @@
-import { BoxConstraints, Offset, Size, resolveExtent } from "../layout/box-constraints.ts";
+import {
+  BoxConstraints,
+  Offset,
+  Size,
+  SizingParams,
+  extentSpecs,
+  resolveSize,
+} from "../layout/box-constraints.ts";
 import { FlexLayoutHelper, HORIZONTAL_AXIS, MainAlign, CrossAlign } from "../utils/flex-layout.ts";
 import {
   FlexiblePDFElement,
@@ -20,6 +27,17 @@ interface RowElementParams extends WithChildren {
   height?: number;
   widthFactor?: number;
   heightFactor?: number;
+  /** Lower / upper bounds per axis, in points or as a fraction; see `SizingParams`. */
+  minWidth?: number;
+  maxWidth?: number;
+  minHeight?: number;
+  maxHeight?: number;
+  minWidthFactor?: number;
+  maxWidthFactor?: number;
+  minHeightFactor?: number;
+  maxHeightFactor?: number;
+  /** width / height; derives whichever axis is left open (CSS `aspect-ratio`). */
+  aspectRatio?: number;
   /** Start this row on a fresh page (CSS `break-before: page`). */
   breakBefore?: boolean;
   /** Start everything after this row on a fresh page (CSS `break-after: page`). */
@@ -46,12 +64,7 @@ export class RowElement extends SizedPDFElement {
   private breakBefore: boolean;
   private breakAfter: boolean;
   // The requested size (fixed points or a fraction), kept separate from the laid-out this.width/height.
-  private requested: {
-    width?: number;
-    height?: number;
-    widthFactor?: number;
-    heightFactor?: number;
-  };
+  private requested!: SizingParams;
 
   constructor({
     children,
@@ -60,17 +73,16 @@ export class RowElement extends SizedPDFElement {
     cross,
     width,
     height,
-    widthFactor,
-    heightFactor,
     breakBefore,
     breakAfter,
+    ...sizing
   }: RowElementParams) {
     super({ x: 0, y: 0 });
     this.children = children;
     this.gap = gap ?? 0;
     this.main = main ?? "start";
     this.cross = cross ?? "stretch";
-    this.requested = { width, height, widthFactor, heightFactor };
+    this.requested = { ...sizing, width, height };
     this.breakBefore = breakBefore ?? false;
     this.breakAfter = breakAfter ?? false;
   }
@@ -104,29 +116,25 @@ export class RowElement extends SizedPDFElement {
 
     // Relative sizing: a pinned extent (fixed or a fraction of the offered box, clamped) wins; else
     // width fills the offered space (flex children split the leftover) and height is the tallest child.
-    const explicitWidth = resolveExtent(
-      this.requested.width,
-      this.requested.widthFactor,
-      constraints.maxWidth,
-      constraints.hasBoundedWidth,
+    const specs = extentSpecs(this.requested);
+    const resolved = resolveSize(
+      specs.width,
+      specs.height,
+      this.requested.aspectRatio,
+      constraints,
     );
-    const explicitHeight = resolveExtent(
-      this.requested.height,
-      this.requested.heightFactor,
-      constraints.maxHeight,
-      constraints.hasBoundedHeight,
-    );
+    const { width: explicitWidth, height: explicitHeight, constraints: bounds } = resolved;
     const boundedWidth =
       explicitWidth !== undefined
-        ? constraints.constrainWidth(explicitWidth)
-        : constraints.hasBoundedWidth
-          ? constraints.maxWidth
+        ? bounds.constrainWidth(explicitWidth)
+        : bounds.hasBoundedWidth
+          ? bounds.maxWidth
           : undefined;
     const boundedHeight =
       explicitHeight !== undefined
-        ? constraints.constrainHeight(explicitHeight)
-        : constraints.hasBoundedHeight
-          ? constraints.maxHeight
+        ? bounds.constrainHeight(explicitHeight)
+        : bounds.hasBoundedHeight
+          ? bounds.maxHeight
           : undefined;
 
     // Horizontal stack: main = width (children fill it), cross = height (children can stretch to it).

--- a/src/lib/elements/row-element.ts
+++ b/src/lib/elements/row-element.ts
@@ -124,16 +124,17 @@ export class RowElement extends SizedPDFElement {
       constraints,
     );
     const { width: explicitWidth, height: explicitHeight, constraints: bounds } = resolved;
+    // Fill-or-shrink-wrap is decided by the constraints we were GIVEN; a min/max only caps the result.
     const boundedWidth =
       explicitWidth !== undefined
         ? bounds.constrainWidth(explicitWidth)
-        : bounds.hasBoundedWidth
+        : constraints.hasBoundedWidth
           ? bounds.maxWidth
           : undefined;
     const boundedHeight =
       explicitHeight !== undefined
         ? bounds.constrainHeight(explicitHeight)
-        : bounds.hasBoundedHeight
+        : constraints.hasBoundedHeight
           ? bounds.maxHeight
           : undefined;
 

--- a/src/lib/layout/box-constraints.ts
+++ b/src/lib/layout/box-constraints.ts
@@ -78,6 +78,28 @@ export class BoxConstraints {
     );
   }
 
+  /**
+   * Tightens this box by an element's own `min`/`max` on either axis. A max never widens the offered
+   * room, and a min may push past it - `minHeight: 500` in a 300pt region means 500, and pagination
+   * deals with the overflow, the same answer CSS gives.
+   */
+  narrow(
+    minWidth?: number,
+    maxWidth?: number,
+    minHeight?: number,
+    maxHeight?: number,
+  ): BoxConstraints {
+    const lo = (own: number | undefined, current: number) => Math.max(current, own ?? 0);
+    const hi = (own: number | undefined, current: number) =>
+      own === undefined ? current : Math.min(current, own);
+    return new BoxConstraints(
+      lo(minWidth, this.minWidth),
+      Math.max(hi(maxWidth, this.maxWidth), lo(minWidth, this.minWidth)),
+      lo(minHeight, this.minHeight),
+      Math.max(hi(maxHeight, this.maxHeight), lo(minHeight, this.minHeight)),
+    );
+  }
+
   /** Returns the constraints clamped to lie within `parent` (Flutter's enforce). */
   enforce(parent: BoxConstraints): BoxConstraints {
     return new BoxConstraints(
@@ -105,6 +127,116 @@ export function resolveExtent(
   if (fixed !== undefined) return fixed;
   if (factor !== undefined && hasBounded) return boundedMax * factor;
   return undefined;
+}
+
+/** What one axis of a sized element was asked for: a size, plus the bounds it must stay inside. */
+export interface ExtentSpec {
+  fixed?: number;
+  factor?: number;
+  min?: number;
+  minFactor?: number;
+  max?: number;
+  maxFactor?: number;
+}
+
+/** The sizing options every sized element accepts. Each `*Factor` is the percentage form of its pair. */
+export interface SizingParams {
+  width?: number;
+  height?: number;
+  widthFactor?: number;
+  heightFactor?: number;
+  minWidth?: number;
+  maxWidth?: number;
+  minHeight?: number;
+  maxHeight?: number;
+  minWidthFactor?: number;
+  maxWidthFactor?: number;
+  minHeightFactor?: number;
+  maxHeightFactor?: number;
+  /** width / height. Derives whichever axis is left open; see `resolveSize`. */
+  aspectRatio?: number;
+}
+
+/** Split `SizingParams` into the per-axis form `resolveSize` takes. */
+export function extentSpecs(p: SizingParams): { width: ExtentSpec; height: ExtentSpec } {
+  return {
+    width: {
+      fixed: p.width,
+      factor: p.widthFactor,
+      min: p.minWidth,
+      minFactor: p.minWidthFactor,
+      max: p.maxWidth,
+      maxFactor: p.maxWidthFactor,
+    },
+    height: {
+      fixed: p.height,
+      factor: p.heightFactor,
+      min: p.minHeight,
+      minFactor: p.minHeightFactor,
+      max: p.maxHeight,
+      maxFactor: p.maxHeightFactor,
+    },
+  };
+}
+
+/**
+ * Resolve both axes of a sized element: relative sizing, then `aspectRatio`, then `min`/`max`.
+ *
+ * The order follows CSS: a ratio fills in the axis you left open, and min/max clamp afterwards - so an
+ * explicit bound wins over the ratio, exactly as `min-height` beats `aspect-ratio` in a browser.
+ *
+ * `min`/`max` also come back as NARROWED constraints, because an axis with no explicit size still has
+ * to obey them. `maxWidth` alone means "fill, but no wider than this", and the caller's own fill and
+ * shrink-wrap paths get that for free by using the returned constraints instead of the ones passed in.
+ * A `width` of `undefined` keeps its usual meaning: fill or shrink-wrap.
+ */
+export function resolveSize(
+  width: ExtentSpec,
+  height: ExtentSpec,
+  aspectRatio: number | undefined,
+  constraints: BoxConstraints,
+): { width?: number; height?: number; constraints: BoxConstraints } {
+  const bounds = constraints.narrow(
+    resolveExtent(width.min, width.minFactor, constraints.maxWidth, constraints.hasBoundedWidth),
+    resolveExtent(width.max, width.maxFactor, constraints.maxWidth, constraints.hasBoundedWidth),
+    resolveExtent(
+      height.min,
+      height.minFactor,
+      constraints.maxHeight,
+      constraints.hasBoundedHeight,
+    ),
+    resolveExtent(
+      height.max,
+      height.maxFactor,
+      constraints.maxHeight,
+      constraints.hasBoundedHeight,
+    ),
+  );
+
+  let w = resolveExtent(width.fixed, width.factor, bounds.maxWidth, bounds.hasBoundedWidth);
+  let h = resolveExtent(height.fixed, height.factor, bounds.maxHeight, bounds.hasBoundedHeight);
+
+  if (aspectRatio !== undefined && aspectRatio > 0) {
+    if (w !== undefined && h === undefined) h = w / aspectRatio;
+    else if (h !== undefined && w === undefined) w = h * aspectRatio;
+    else if (w === undefined && h === undefined) {
+      // Neither axis pinned: take the offered width and let the ratio give the height (CSS block
+      // behaviour). Falls back to the height when only that axis is bounded.
+      if (bounds.hasBoundedWidth) {
+        w = bounds.maxWidth;
+        h = w / aspectRatio;
+      } else if (bounds.hasBoundedHeight) {
+        h = bounds.maxHeight;
+        w = h * aspectRatio;
+      }
+    }
+  }
+
+  return {
+    width: w === undefined ? undefined : bounds.constrainWidth(w),
+    height: h === undefined ? undefined : bounds.constrainHeight(h),
+    constraints: bounds,
+  };
 }
 
 /** The size an element resolves to and returns UP the tree. */

--- a/src/lib/layout/box-constraints.ts
+++ b/src/lib/layout/box-constraints.ts
@@ -213,8 +213,20 @@ export function resolveSize(
     ),
   );
 
-  let w = resolveExtent(width.fixed, width.factor, bounds.maxWidth, bounds.hasBoundedWidth);
-  let h = resolveExtent(height.fixed, height.factor, bounds.maxHeight, bounds.hasBoundedHeight);
+  // Against the OFFERED box, not the narrowed one: `width: "50%"` with `maxWidth: 100` in a 400pt
+  // region is 200 capped to 100, not 50% of 100. The clamp below applies the bound.
+  let w = resolveExtent(
+    width.fixed,
+    width.factor,
+    constraints.maxWidth,
+    constraints.hasBoundedWidth,
+  );
+  let h = resolveExtent(
+    height.fixed,
+    height.factor,
+    constraints.maxHeight,
+    constraints.hasBoundedHeight,
+  );
 
   if (aspectRatio !== undefined && aspectRatio > 0) {
     if (w !== undefined && h === undefined) h = w / aspectRatio;

--- a/tests/unit/api/aspect-and-bounds.test.ts
+++ b/tests/unit/api/aspect-and-bounds.test.ts
@@ -62,6 +62,18 @@ describe("min / max through the factories", () => {
     expect(el.calculateLayout(new BoxConstraints(), { x: 0, y: 0 }, ctx).width).toBe(60);
   });
 
+  it("does NOT turn a shrink-wrapping box into a filling one", () => {
+    // The case the test above cannot see, because there the content is wider than the cap either way.
+    // A `max-width` caps a box; it never makes one grow. Deciding fill-vs-shrink-wrap from the NARROWED
+    // constraints got this wrong: an unsized box in an unbounded region expanded to exactly maxWidth.
+    const el = Box({ borderWidth: 0, maxWidth: 200 }, [Box({ borderWidth: 0, width: 50 }, [])]);
+    expect(el.calculateLayout(new BoxConstraints(), { x: 0, y: 0 }, ctx).width).toBe(50);
+  });
+
+  it("resolves a percentage against the offered box, then caps it", () => {
+    expect(lay(box({ width: "50%", maxWidth: 100 }), 400).width).toBe(100);
+  });
+
   it("accepts percentages", () => {
     expect(lay(box({ width: 400, maxWidth: "25%" }), 400).width).toBe(100);
   });

--- a/tests/unit/api/aspect-and-bounds.test.ts
+++ b/tests/unit/api/aspect-and-bounds.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { Box, Column, Row } from "../../../src/lib/api/layout.ts";
+import { Image } from "../../../src/lib/api/content.ts";
+import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
+import { LayoutContext } from "../../../src/lib/elements/pdf-element.ts";
+
+// `aspectRatio`, `minWidth` / `maxWidth` / `minHeight` / `maxHeight` through the public factories.
+// The resolver itself is covered in layout/resolve-size.test.ts; what matters here is that all four
+// sized factories reach it and that the props survive the api -> element hop.
+
+const ctx = {} as LayoutContext;
+const lay = (el: ReturnType<typeof Box>, w = 400, h = 600) =>
+  el.calculateLayout(BoxConstraints.loose(w, h), { x: 0, y: 0 }, ctx);
+
+const box = (opts: Record<string, unknown>) => Box({ borderWidth: 0, ...opts }, []);
+
+describe("aspectRatio reaches every sized factory", () => {
+  it("Box: a pinned width gives the height", () => {
+    expect(lay(box({ width: 300, aspectRatio: 3 / 2 })).height).toBe(200);
+  });
+
+  it("Box: neither axis pinned takes the offered width", () => {
+    const size = lay(box({ aspectRatio: 2 }), 300, 600);
+    expect([size.width, size.height]).toEqual([300, 150]);
+  });
+
+  it("Column and Row take it too", () => {
+    expect(lay(Column({ width: 200, aspectRatio: 2 }, [])).height).toBe(100);
+    expect(lay(Row({ width: 200, aspectRatio: 4 }, [])).height).toBe(50);
+  });
+
+  it("Image: an explicit ratio overrides the image's own", () => {
+    // No intrinsic size is resolved here (that needs the async pre-pass), so this also proves the
+    // explicit ratio does not depend on it.
+    expect(lay(Image("x.png", { width: 240, aspectRatio: 3 })).height).toBe(80);
+  });
+
+  it("rejects a ratio that is not a positive number", () => {
+    expect(() => box({ aspectRatio: 0 })).toThrow(/aspectRatio/);
+    expect(() => box({ aspectRatio: -2 })).toThrow(/width \/ height/);
+  });
+});
+
+describe("min / max through the factories", () => {
+  it("caps an explicit size", () => {
+    expect(lay(box({ width: 380, maxWidth: 200 })).width).toBe(200);
+  });
+
+  it("raises one below the minimum", () => {
+    expect(lay(box({ width: 40, minWidth: 120 })).width).toBe(120);
+  });
+
+  it("caps a box that would otherwise FILL the offered width", () => {
+    // The case that needs the narrowed constraints rather than a clamped value: with no width at all
+    // a Box fills, and `maxWidth` has to survive that path.
+    expect(lay(box({ maxWidth: 150 }), 400).width).toBe(150);
+  });
+
+  it("caps a box that shrink-wraps its content", () => {
+    // Unbounded width: the box sizes to its children, and the bound still applies.
+    const el = Box({ borderWidth: 0, maxWidth: 60 }, [Box({ borderWidth: 0, width: 300 }, [])]);
+    expect(el.calculateLayout(new BoxConstraints(), { x: 0, y: 0 }, ctx).width).toBe(60);
+  });
+
+  it("accepts percentages", () => {
+    expect(lay(box({ width: 400, maxWidth: "25%" }), 400).width).toBe(100);
+  });
+
+  it("beats the ratio, the way an explicit bound does in CSS", () => {
+    expect(lay(box({ width: 300, aspectRatio: 3, minHeight: 250 })).height).toBe(250);
+  });
+});
+
+describe("nothing asked for changes nothing", () => {
+  it("a plain Box still fills the offered width", () => {
+    expect(lay(box({})).width).toBe(400);
+  });
+});

--- a/tests/unit/layout/resolve-size.test.ts
+++ b/tests/unit/layout/resolve-size.test.ts
@@ -56,6 +56,18 @@ describe("min / max", () => {
     expect(r.constraints.maxWidth).toBe(250); // ... but no further than this
   });
 
+  it("caps a percentage instead of resolving it against the cap", () => {
+    // CSS order: `width: 50%` is 50% of the OFFERED box, and `max-width` clamps the result. Resolving
+    // the percentage against the capped width instead gives 50 here, which is half of the right answer.
+    expect(resolveSize({ factor: 0.5, max: 100 }, none, undefined, box(400)).width).toBe(100);
+    // ... and below the cap it is untouched.
+    expect(resolveSize({ factor: 0.5, max: 300 }, none, undefined, box(400)).width).toBe(200);
+  });
+
+  it("still applies a min to a percentage", () => {
+    expect(resolveSize({ factor: 0.5, min: 300 }, none, undefined, box(400)).width).toBe(300);
+  });
+
   it("takes min and max as percentages too", () => {
     expect(resolveSize({ fixed: 400, maxFactor: 0.5 }, none, undefined, box(400)).width).toBe(200);
   });

--- a/tests/unit/layout/resolve-size.test.ts
+++ b/tests/unit/layout/resolve-size.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { BoxConstraints, resolveSize } from "../../../src/lib/layout/box-constraints.ts";
+
+// The shared resolver behind `width` / `height` / `aspectRatio` / `min*` / `max*` on Box, Column, Row
+// and Image. The order it applies them in is the contract: ratio fills an open axis, min/max clamp
+// afterwards, so an explicit bound beats the ratio the way it does in CSS.
+
+const box = (w = 400, h = 600) => BoxConstraints.loose(w, h);
+const none = {};
+
+describe("aspectRatio", () => {
+  it("derives the axis that was left open", () => {
+    expect(resolveSize({ fixed: 300 }, none, 3 / 2, box()).height).toBe(200);
+    expect(resolveSize(none, { fixed: 200 }, 3 / 2, box()).width).toBe(300);
+  });
+
+  it("fills the offered width and takes the height from the ratio when neither is pinned", () => {
+    const r = resolveSize(none, none, 16 / 9, box(320, 600));
+    expect(r.width).toBe(320);
+    expect(r.height).toBeCloseTo(180, 5);
+  });
+
+  it("is ignored when both axes are pinned", () => {
+    const r = resolveSize({ fixed: 300 }, { fixed: 300 }, 16 / 9, box());
+    expect([r.width, r.height]).toEqual([300, 300]);
+  });
+
+  it("does nothing on a fully unbounded box, rather than guessing", () => {
+    const r = resolveSize(none, none, 2, new BoxConstraints());
+    expect([r.width, r.height]).toEqual([undefined, undefined]);
+  });
+
+  it("combines with a percentage width", () => {
+    const r = resolveSize({ factor: 0.5 }, none, 2, box(400, 600));
+    expect([r.width, r.height]).toEqual([200, 100]);
+  });
+});
+
+describe("min / max", () => {
+  it("clamps an explicit size", () => {
+    expect(resolveSize({ fixed: 500, max: 300 }, none, undefined, box()).width).toBe(300);
+    expect(resolveSize({ fixed: 50, min: 120 }, none, undefined, box()).width).toBe(120);
+  });
+
+  it("beats the ratio, as an explicit bound does in CSS", () => {
+    // 300 wide at 3:1 wants 100 tall; a minHeight of 150 wins and the ratio is broken.
+    const r = resolveSize({ fixed: 300 }, { min: 150 }, 3, box());
+    expect([r.width, r.height]).toEqual([300, 150]);
+  });
+
+  it("caps a FILLING axis through the narrowed constraints", () => {
+    // The point of returning constraints: with no width at all the element fills, and "fill" has to
+    // respect maxWidth or the bound would silently do nothing.
+    const r = resolveSize({ max: 250 }, none, undefined, box(400, 600));
+    expect(r.width).toBeUndefined(); // still "fill"
+    expect(r.constraints.maxWidth).toBe(250); // ... but no further than this
+  });
+
+  it("takes min and max as percentages too", () => {
+    expect(resolveSize({ fixed: 400, maxFactor: 0.5 }, none, undefined, box(400)).width).toBe(200);
+  });
+
+  it("lets a min push past the offered room", () => {
+    // Overflow is pagination's problem, not a reason to silently shrink - the CSS answer.
+    const r = resolveSize(none, { min: 900 }, undefined, box(400, 600));
+    expect(r.constraints.minHeight).toBe(900);
+    expect(r.constraints.maxHeight).toBeGreaterThanOrEqual(900);
+  });
+
+  it("ignores a percentage bound on an unbounded axis", () => {
+    // Same rule percentages already follow: a fraction of "unbounded" has no meaning.
+    const r = resolveSize({ maxFactor: 0.5 }, none, undefined, new BoxConstraints());
+    expect(r.constraints.maxWidth).toBe(Infinity);
+  });
+});
+
+describe("nothing asked for", () => {
+  it("stays undefined so the caller still fills or shrink-wraps", () => {
+    const r = resolveSize(none, none, undefined, box());
+    expect([r.width, r.height]).toEqual([undefined, undefined]);
+    expect(r.constraints.maxWidth).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

Add aspect ration function to Box, Column, Row and Image

## Related issue(s)

Closes #

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added minimum and maximum width and height constraints for boxes, stacks, rows, columns, and images.
  * Added aspect-ratio-based sizing with automatic dimension calculation.
  * Added fixed and percentage-based sizing bounds.
  * Improved layout behavior when content exceeds available space or dimensions are unbounded.

* **Bug Fixes**
  * Ensured sizing constraints are consistently applied across layout elements and images.
  * Added validation for invalid aspect-ratio values.
  * Improved constraint handling when minimum sizes exceed available space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->