### PR TITLE
feat: corner radius per-corner, percentage padding, `alignSelf`

### DIFF
--- a/src/lib/api/content.ts
+++ b/src/lib/api/content.ts
@@ -10,7 +10,14 @@ import {
 import { PDFElement } from "../elements/pdf-element.ts";
 import { ColorInput, toColor } from "./color.ts";
 import { Insets, toEdges } from "./insets.ts";
-import { BoundsInput, SizeInput, toBounds, toDimension } from "./dimension.ts";
+import {
+  BoundsInput,
+  SizeInput,
+  toBounds,
+  toDimension,
+  RadiusInput,
+  toRadius,
+} from "./dimension.ts";
 
 /** A horizontal rule (locked §4). */
 export interface DividerOptions {
@@ -67,7 +74,7 @@ export interface ImageOptions extends BoundsInput {
    *  exactly one axis pinned, or an `aspectRatio` - which defaults to `fill` so the image scales into it. */
   fit?: ImageFit;
   /** Corner radius in points (rounds the image box). */
-  radius?: number;
+  radius?: RadiusInput;
   /** Alternate text for accessibility (tagged PDF): describes the image for screen readers. With `alt`
    *  the image is a `Figure`; without it (and when rendered `accessible`) it counts as decoration. */
   alt?: string;
@@ -100,7 +107,7 @@ export function Image(src: ImageSource, opts: ImageOptions = {}): ImageElement {
     heightFactor: h?.factor,
     ...toBounds(opts),
     fit,
-    radius: opts.radius,
+    radius: opts.radius !== undefined ? toRadius(opts.radius) : undefined,
     alt: opts.alt,
   }).withAlignSelf(opts.alignSelf);
 }

--- a/src/lib/api/content.ts
+++ b/src/lib/api/content.ts
@@ -102,5 +102,5 @@ export function Image(src: ImageSource, opts: ImageOptions = {}): ImageElement {
     fit,
     radius: opts.radius,
     alt: opts.alt,
-  });
+  }).withAlignSelf(opts.alignSelf);
 }

--- a/src/lib/api/dimension.ts
+++ b/src/lib/api/dimension.ts
@@ -1,3 +1,5 @@
+import type { CrossAlign } from "../layout/alignment.ts";
+
 /**
  * Size input for a Box's `width` / `height` (relative sizing). Either a number of PDF points (a
  * fixed size) or a percentage string like `"50%"` - a fraction of the space the parent offers on
@@ -33,6 +35,12 @@ export function toDimension(value: SizeInput): Dimension {
 
 /** The bound and ratio options every sized factory accepts, in the public `SizeInput` form. */
 export interface BoundsInput {
+  /**
+   * This element's own cross-axis alignment inside its Column / Row (CSS `align-self`), overriding the
+   * container's `align`. On a `Spacer` / `Expanded` it is a no-op - a flex child fills the main axis and
+   * has no natural cross size to align.
+   */
+  alignSelf?: CrossAlign;
   minWidth?: SizeInput;
   maxWidth?: SizeInput;
   minHeight?: SizeInput;

--- a/src/lib/api/dimension.ts
+++ b/src/lib/api/dimension.ts
@@ -1,3 +1,4 @@
+import type { Radii } from "../ir/display-list.ts";
 import type { CrossAlign } from "../layout/alignment.ts";
 
 /**
@@ -72,4 +73,20 @@ export function toBounds(o: BoundsInput) {
     maxHeightFactor: maxH?.factor,
     aspectRatio: o.aspectRatio,
   };
+}
+
+/**
+ * Corner radius input. A single number rounds all four corners; the object names them; the tuple is
+ * CSS order - `[topLeft, topRight, bottomRight, bottomLeft]`, clockwise from the top left.
+ */
+export type RadiusInput =
+  | number
+  | { topLeft?: number; topRight?: number; bottomRight?: number; bottomLeft?: number }
+  | [number, number, number, number];
+
+/** Normalizes a `RadiusInput` to the engine's short corner names. */
+export function toRadius(r: RadiusInput): number | Radii {
+  if (typeof r === "number") return r;
+  if (Array.isArray(r)) return { tl: r[0], tr: r[1], br: r[2], bl: r[3] };
+  return { tl: r.topLeft, tr: r.topRight, br: r.bottomRight, bl: r.bottomLeft };
 }

--- a/src/lib/api/insets.ts
+++ b/src/lib/api/insets.ts
@@ -1,35 +1,54 @@
+import { SizeInput, toDimension } from "./dimension.ts";
+import type { EdgeInput, EdgeSpecs } from "../layout/insets.ts";
+
 /**
- * Spacing input for padding / margin (locked design §3). Units are PDF points. Every form
- * normalizes to the engine's `[top, right, bottom, left]` via `toEdges`, so you can reach
+ * Spacing input for padding / margin (locked design §3). Points, or a percentage string like `"5%"`.
+ * Every form normalizes to the engine's `[top, right, bottom, left]` via `toEdges`, so you can reach
  * for whichever shape fits and never think about the engine order.
+ *
+ * **A percentage resolves against the available WIDTH - on all four sides, top and bottom included.**
+ * That is the CSS rule, and Yoga's, so react-pdf behaves the same. It reads as wrong the first time and
+ * is what makes `padding-bottom: 56.25%` a 16:9 box on the web. A percentage needs a bounded width; in
+ * an unbounded region it resolves to 0, the same no-op a percentage SIZE gives there.
  */
 export type Insets =
-  | number // all four sides
-  | { x?: number; y?: number } // horizontal (left+right) / vertical (top+bottom)
-  | { top?: number; right?: number; bottom?: number; left?: number } // per side
-  | [number, number, number, number]; // [top, right, bottom, left] (engine order)
+  | SizeInput // all four sides
+  | { x?: SizeInput; y?: SizeInput } // horizontal (left+right) / vertical (top+bottom)
+  | { top?: SizeInput; right?: SizeInput; bottom?: SizeInput; left?: SizeInput } // per side
+  | [SizeInput, SizeInput, SizeInput, SizeInput]; // [top, right, bottom, left] (engine order)
 
-/** Normalizes any `Insets` to the engine's `[top, right, bottom, left]`. */
-export function toEdges(i: Insets): [number, number, number, number] {
-  if (typeof i === "number") return [i, i, i, i];
-  if (Array.isArray(i)) return i;
+// A fixed side stays a plain NUMBER, so the output is unchanged for every input that was legal before
+// this file learned percentages - `toEdges` is publicly exported and did not need to break.
+const spec = (v: SizeInput | undefined): EdgeInput => {
+  if (v === undefined) return 0;
+  const d = toDimension(v);
+  return d.points ?? { factor: d.factor };
+};
+
+/** Normalizes any `Insets` to the engine's `[top, right, bottom, left]`, percentages still unresolved. */
+export function toEdges(i: Insets): EdgeSpecs {
+  if (typeof i === "number" || typeof i === "string") {
+    const s = spec(i);
+    return [s, s, s, s];
+  }
+  if (Array.isArray(i)) return [spec(i[0]), spec(i[1]), spec(i[2]), spec(i[3])];
 
   // Axis form ({x, y}) and per-side form ({top,...}) are both all-optional objects (TS
   // can't discriminate them), so read through one shape: an axis key present picks the
   // axis interpretation (an empty object is all-zero either way).
   const o = i as {
-    x?: number;
-    y?: number;
-    top?: number;
-    right?: number;
-    bottom?: number;
-    left?: number;
+    x?: SizeInput;
+    y?: SizeInput;
+    top?: SizeInput;
+    right?: SizeInput;
+    bottom?: SizeInput;
+    left?: SizeInput;
   };
   if (o.x !== undefined || o.y !== undefined) {
-    const x = o.x ?? 0;
-    const y = o.y ?? 0;
+    const x = spec(o.x);
+    const y = spec(o.y);
     return [y, x, y, x];
   }
 
-  return [o.top ?? 0, o.right ?? 0, o.bottom ?? 0, o.left ?? 0];
+  return [spec(o.top), spec(o.right), spec(o.bottom), spec(o.left)];
 }

--- a/src/lib/api/layout.ts
+++ b/src/lib/api/layout.ts
@@ -15,7 +15,14 @@ import { PDFElement } from "../elements/pdf-element.ts";
 import { MainAlign, CrossAlign } from "../utils/flex-layout.ts";
 import { ColorInput, toColor } from "./color.ts";
 import { Insets, toEdges } from "./insets.ts";
-import { BoundsInput, SizeInput, toBounds, toDimension } from "./dimension.ts";
+import {
+  BoundsInput,
+  SizeInput,
+  toBounds,
+  toDimension,
+  RadiusInput,
+  toRadius,
+} from "./dimension.ts";
 import { splitArgs } from "./args.ts";
 
 /** Options shared by the `Column` and `Row` stacks (locked §4). */
@@ -144,7 +151,7 @@ export interface BoxOptions extends BoundsInput {
   width?: SizeInput;
   height?: SizeInput;
   /** Corner radius in points. */
-  radius?: number;
+  radius?: RadiusInput;
   /** Make this box a positioning frame: `Positioned` children placed inside it resolve their
    *  offsets against this box (CSS `position: relative`). */
   relative?: boolean;
@@ -210,7 +217,7 @@ export function Box(a: BoxOptions | PDFElement[], b?: PDFElement[]): PDFElement 
       widthFactor: w?.factor,
       heightFactor: h?.factor,
       ...toBounds(opts),
-      radius: opts.radius,
+      radius: opts.radius !== undefined ? toRadius(opts.radius) : undefined,
       sideBorders: hasPerSide
         ? {
             top: side(opts.borderTop),

--- a/src/lib/api/layout.ts
+++ b/src/lib/api/layout.ts
@@ -101,8 +101,13 @@ export function Row(a: StackOptions | PDFElement[], b?: PDFElement[]): PDFElemen
 
 /** Wraps `element` in a `keepTogether` group when the `keepTogether` option is set; otherwise returns it
  *  unchanged (byte-identical). Shared by the `Box`/`Column`/`Row` prop shortcut. */
-function maybeKeepTogether(opts: { keepTogether?: boolean }, element: PDFElement): PDFElement {
-  return opts.keepTogether ? new KeepTogetherElement({ child: element }) : element;
+function maybeKeepTogether(
+  opts: { keepTogether?: boolean; alignSelf?: CrossAlign },
+  element: PDFElement,
+): PDFElement {
+  // alignSelf goes on the OUTERMOST element - that is the one the surrounding stack places.
+  const wrapped = opts.keepTogether ? new KeepTogetherElement({ child: element }) : element;
+  return wrapped.withAlignSelf(opts.alignSelf);
 }
 
 /**

--- a/src/lib/api/structure.ts
+++ b/src/lib/api/structure.ts
@@ -4,7 +4,8 @@ import { PageElement, PDFPageConfig } from "../elements/page-element.ts";
 import { PDFElement } from "../elements/pdf-element.ts";
 import { DefaultTextStyleElement } from "../elements/layout/default-text-style-element.ts";
 import type { OverflowPolicy } from "../layout/fragmentation.ts";
-import { PageSize } from "../constants/page-sizes.ts";
+import { PageSize, pageFormats } from "../constants/page-sizes.ts";
+import { resolveEdges } from "../layout/insets.ts";
 import { Orientation } from "../renderer/pdf-config.ts";
 import { PDFDocument, PDFConfig } from "../renderer/pdf-document-class.ts";
 import { FontStyle } from "../utils/pdf-object-manager.ts";
@@ -81,10 +82,19 @@ export function Page(a: PageOptions | PDFElement[], b?: PDFElement[]): PageEleme
   const opts = (isOpts ? a : {}) as PageOptions;
   const children = (isOpts ? (b ?? []) : a) as PDFElement[];
 
-  const [top, right, bottom, left] = toEdges(opts.margin ?? DEFAULT_MARGIN);
+  const size = resolveSize(opts.size);
+  const landscape = opts.orientation === "landscape";
+  // A percentage margin resolves against the page WIDTH (see `Insets`), which is known right here -
+  // the page is the one box whose geometry does not depend on a parent.
+  const [w, h] = size.customSize ?? pageFormats[size.pageSize ?? PageSize.A4];
+  const pageWidth = landscape ? h : w;
+  const [top, right, bottom, left] = resolveEdges(
+    toEdges(opts.margin ?? DEFAULT_MARGIN),
+    pageWidth,
+  );
   const config: PDFPageConfig = {
-    ...resolveSize(opts.size),
-    orientation: opts.orientation === "landscape" ? Orientation.landscape : Orientation.portrait,
+    ...size,
+    orientation: landscape ? Orientation.landscape : Orientation.portrait,
     margin: { top, right, bottom, left },
   };
 

--- a/src/lib/elements/image-element.ts
+++ b/src/lib/elements/image-element.ts
@@ -1,3 +1,4 @@
+import type { Radii } from "../ir/display-list.ts";
 import { getImageDimensions } from "../utils/image-helper.ts";
 import { latin1FromBytes } from "../utils/bytes.ts";
 import { readFileBytesAsync } from "../platform/node-fs.ts";
@@ -146,8 +147,8 @@ interface ImageElementParams {
   /** width / height; overrides the image's OWN ratio (CSS `aspect-ratio`), `fit` then places it. */
   aspectRatio?: number;
   fit?: BoxFit;
-  /** Corner radius in points; rounds the image box (0 = sharp, default). */
-  radius?: number;
+  /** Corner radius in points - one number or per corner; rounds the image box (0 = sharp, default). */
+  radius?: number | Radii;
   /** Alternate text for accessibility (tagged PDF). With `alt` the image is a Figure; without, decoration. */
   alt?: string;
 }
@@ -157,7 +158,7 @@ export class ImageElement extends SizedPDFElement {
   private widthFactor?: number;
   private heightFactor?: number;
   private fit: BoxFit;
-  private radius: number;
+  private radius: number | Radii;
   private readonly alt?: string;
   // The requested size (fixed points), kept separate from the laid-out this.width/height so a
   // re-layout (fragmentation measures more than once) still resolves the factor, instead of

--- a/src/lib/elements/layout/padding-element.ts
+++ b/src/lib/elements/layout/padding-element.ts
@@ -2,15 +2,17 @@ import { Validator } from "../../validators/element-validator.ts";
 import { PDFElement, LayoutContext, WithChild, SizedPDFElement } from "../pdf-element.ts";
 import { BoxConstraints, Offset, Size } from "../../layout/box-constraints.ts";
 import { Fragmentable, FragmentResult, isFragmentable } from "../../layout/fragmentation.ts";
+import { resolveEdges, type EdgeSpecs } from "../../layout/insets.ts";
 
 // Padding sizes itself from its child + margin, so it takes no x/y of its own.
 interface PaddingElementParams extends WithChild {
-  margin: [number, number, number, number];
+  /** Still unresolved: a side may be a percentage of the offered WIDTH (see `Insets`). */
+  margin: EdgeSpecs;
 }
 
 export class PaddingElement extends SizedPDFElement implements Fragmentable {
   private child: PDFElement;
-  private margin: [number, number, number, number];
+  private margin: EdgeSpecs;
 
   constructor({ margin, child }: PaddingElementParams) {
     super({ x: 0, y: 0 });
@@ -30,7 +32,7 @@ export class PaddingElement extends SizedPDFElement implements Fragmentable {
       return { fitted: null, remainder: this };
     }
 
-    const [marginTop, marginRight, marginBottom, marginLeft] = this.margin;
+    const [marginTop, marginRight, marginBottom, marginLeft] = resolveEdges(this.margin, width);
     const childWidth = width - marginLeft - marginRight;
     const childMaxHeight = maxHeight - marginTop - marginBottom;
 
@@ -66,7 +68,11 @@ export class PaddingElement extends SizedPDFElement implements Fragmentable {
     this.x = offset.x;
     this.y = offset.y;
 
-    const [marginTop, marginRight, marginBottom, marginLeft] = this.margin;
+    // Percentages resolve against the width we were OFFERED, so every pass gets the same answer.
+    const [marginTop, marginRight, marginBottom, marginLeft] = resolveEdges(
+      this.margin,
+      constraints.maxWidth,
+    );
 
     // The child is inset by the margins: shifted down/right, narrowed by the
     // horizontal margins, and left height-unbounded so it sizes to its own content.

--- a/src/lib/elements/pdf-element.ts
+++ b/src/lib/elements/pdf-element.ts
@@ -3,6 +3,7 @@ import type { PDFPageConfig } from "./page-element.ts";
 import type { ResolvedTextStyle } from "../text/text-style.ts";
 import type { OverflowPolicy } from "../layout/fragmentation.ts";
 import type { BoxConstraints, Offset, Size } from "../layout/box-constraints.ts";
+import type { CrossAlign } from "../layout/alignment.ts";
 
 /**
  * Everything the layout pass needs, threaded explicitly (no global singleton):
@@ -137,6 +138,19 @@ export abstract class PDFElement {
    */
   breaksAfter(): boolean {
     return false;
+  }
+
+  /**
+   * This child's own cross-axis alignment inside its Column / Row (CSS `align-self`), overriding the
+   * container's `align`. Lives on the base element because any child of a stack may set it, not just
+   * the sized ones. `undefined` means "follow the container".
+   */
+  alignSelf?: CrossAlign;
+
+  /** Sets `alignSelf` and returns the element, so a factory can thread it through in one expression. */
+  withAlignSelf(align: CrossAlign | undefined): this {
+    if (align !== undefined) this.alignSelf = align;
+    return this;
   }
 }
 

--- a/src/lib/elements/rectangle-element.ts
+++ b/src/lib/elements/rectangle-element.ts
@@ -1,3 +1,4 @@
+import type { Radii } from "../ir/display-list.ts";
 import { Color } from "../common/color.ts";
 import {
   BoxConstraints,
@@ -35,8 +36,8 @@ interface RectangleElementParams extends SizedElement, WithChildren {
   color?: Color;
   backgroundColor?: Color;
   borderWidth?: number;
-  /** Corner radius in points; 0 = sharp corners (default). */
-  radius?: number;
+  /** Corner radius in points - one number for all four corners, or per corner. 0 = sharp (default). */
+  radius?: number | Radii;
   /** Individual side borders; overrides the uniform `color` border when present. */
   sideBorders?: SideBorders;
   /** When true, this box is a positioning frame for `Positioned` descendants (CSS `relative`). */
@@ -71,7 +72,7 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
   private color: Color;
   private backgroundColor?: Color;
   private borderWidth: number;
-  private radius: number;
+  private radius: number | Radii;
   private sideBorders?: SideBorders;
   private relative: boolean;
   private overflow: "hidden" | "visible";

--- a/src/lib/ir/display-list.ts
+++ b/src/lib/ir/display-list.ts
@@ -44,6 +44,27 @@ export interface TextRun {
 }
 
 /** An axis-aligned rectangle. An absent `fill` or `stroke` means that part is not drawn. */
+/**
+ * Corner radii in points (CSS `border-radius`). Any corner left out falls back to 0. A single number
+ * everywhere is the common case and stays a plain `number` on the nodes, so nothing changed for a
+ * document that never asks for different corners.
+ */
+export interface Radii {
+  tl?: number;
+  tr?: number;
+  br?: number;
+  bl?: number;
+}
+
+/** True when any corner asks for a radius - the gate between a plain rect and a curved path. */
+export function isRounded(radius: number | Radii | undefined): boolean {
+  if (radius === undefined) return false;
+  if (typeof radius === "number") return radius > 0;
+  return (
+    (radius.tl ?? 0) > 0 || (radius.tr ?? 0) > 0 || (radius.br ?? 0) > 0 || (radius.bl ?? 0) > 0
+  );
+}
+
 export interface Rect {
   type: "rect";
   x: number;
@@ -53,8 +74,8 @@ export interface Rect {
   fill?: Color;
   stroke?: Color;
   strokeWidth: number;
-  /** Corner radius in points; absent/0 = sharp corners (plain `re`). */
-  radius?: number;
+  /** Corner radius in points - one number for all four, or per corner. Absent/0 = sharp (plain `re`). */
+  radius?: number | Radii;
   tag?: StructTag; // accessible tagging; absent = Artifact
 }
 
@@ -85,8 +106,8 @@ export interface Image {
   smask?: string;
   /** cover/contain fits clip the placement to the element's original frame. */
   clip?: { x: number; y: number; width: number; height: number };
-  /** Corner radius in points for the image box; absent/0 = sharp corners. */
-  radius?: number;
+  /** Corner radius in points for the image box - one number or per corner; absent/0 = sharp. */
+  radius?: number | Radii;
   tag?: StructTag; // accessible tagging (a Figure needs `alt`); absent = Artifact
 }
 
@@ -101,7 +122,7 @@ export interface ClipPush {
   y: number;
   width: number;
   height: number;
-  radius?: number;
+  radius?: number | Radii;
 }
 
 /** Closes the most recent `ClipPush` (restores the graphics state). */

--- a/src/lib/layout/alignment.ts
+++ b/src/lib/layout/alignment.ts
@@ -1,0 +1,12 @@
+/**
+ * Flex alignment vocabulary. It lives here rather than in `utils/flex-layout.ts` because the base
+ * `PDFElement` needs `CrossAlign` for `alignSelf`, and flex-layout imports the elements - defining it
+ * there would close a cycle.
+ */
+
+/** Distribution along the MAIN axis (CSS `justify-content`). */
+export type MainAlign = "start" | "center" | "end" | "between" | "around";
+
+/** Position/size ACROSS the axis (CSS `align-items` / `align-self`). `stretch` fills the cross extent;
+ *  the others place the child at its natural cross size. */
+export type CrossAlign = "start" | "center" | "end" | "stretch";

--- a/src/lib/layout/insets.ts
+++ b/src/lib/layout/insets.ts
@@ -1,0 +1,43 @@
+/**
+ * Resolved and unresolved edge insets, on the LAYOUT side of the seam.
+ *
+ * The public `Insets` input (points, percentages, four shapes) lives in `api/insets.ts` and normalizes
+ * into the specs below - the same split `dimension.ts` and `box-constraints.ts` already use for sizes,
+ * so an element never sees a percentage string and the api layer never sees layout geometry.
+ */
+
+/** One side: an absolute point size, or a fraction of the available width. */
+export interface EdgeSpec {
+  points?: number;
+  factor?: number;
+}
+
+/**
+ * `[top, right, bottom, left]`, each still unresolved.
+ *
+ * A plain number is accepted as shorthand for `{ points: n }`: the engine elements are exported for
+ * power users and used to take four numbers, so requiring `{ points: 5 }` would break them for a
+ * feature they are not using.
+ */
+export type EdgeSpecs = [EdgeInput, EdgeInput, EdgeInput, EdgeInput];
+
+/** A side as given: points for short, or a spec when it may be a percentage. */
+export type EdgeInput = number | EdgeSpec;
+
+/**
+ * Turn the specs into points. `available` is the WIDTH the element was offered - a percentage resolves
+ * against the width on ALL FOUR sides, top and bottom included, which is the CSS rule (and Yoga's, so
+ * react-pdf agrees). An unbounded width leaves a percentage at 0, the no-op a percentage size gives.
+ */
+export function resolveEdges(
+  specs: EdgeSpecs,
+  available: number,
+): [number, number, number, number] {
+  const one = (e: EdgeInput) => {
+    if (typeof e === "number") return e;
+    return (
+      e.points ?? (e.factor !== undefined && Number.isFinite(available) ? available * e.factor : 0)
+    );
+  };
+  return [one(specs[0]), one(specs[1]), one(specs[2]), one(specs[3])];
+}

--- a/src/lib/renderer/image-renderer.ts
+++ b/src/lib/renderer/image-renderer.ts
@@ -8,7 +8,7 @@ import {
   decodePngToRgbFlate,
 } from "../utils/image-helper.ts";
 import { PDFObjectManager } from "../utils/pdf-object-manager.ts";
-import { IRNode, Image } from "../ir/display-list.ts";
+import { IRNode, Image, isRounded } from "../ir/display-list.ts";
 
 export class ImageRenderer {
   static async render(
@@ -87,7 +87,7 @@ export class ImageRenderer {
 
     // A radius rounds the image BOX (the element frame), so it clips to that frame too -
     // independent of the cover/contain overflow clip.
-    const wantsClip = mustCreateOverflowContainer || (radius ?? 0) > 0;
+    const wantsClip = mustCreateOverflowContainer || isRounded(radius);
 
     // The fitted geometry becomes a display-list primitive; the backend registers
     // the XObject and emits the placement (+ clip, rounded when a radius is set).

--- a/src/lib/renderer/pdf-backend.ts
+++ b/src/lib/renderer/pdf-backend.ts
@@ -1,4 +1,4 @@
-import { IRNode } from "../ir/display-list.ts";
+import { IRNode, Radii, isRounded } from "../ir/display-list.ts";
 import { Color } from "../common/color.ts";
 import { PDFObjectManager } from "../utils/pdf-object-manager.ts";
 import type { PageStructContext } from "../utils/struct-tree.ts";
@@ -213,29 +213,56 @@ export class PdfBackend {
     y: number,
     w: number,
     h: number,
-    radius: number,
+    radius: number | Radii,
   ): string {
-    const r = Math.min(radius, w / 2, h / 2);
-    const c = r * 0.5523; // control-point offset that approximates a quarter circle
+    // Per corner, in PDF coordinates (y up). With all four equal this emits exactly the operators the
+    // single-radius version did - the byte-identity guard for every document that never asks for one.
+    const r = PdfBackend.clampRadii(radius, w, h);
+    const k = 0.5523; // control-point offset that approximates a quarter circle
     const f = (n: number) => n.toFixed(3);
-    const xr = x + r;
-    const xwr = x + w - r;
     const xw = x + w;
-    const yr = y + r;
-    const yhr = y + h - r;
     const yh = y + h;
     return (
-      `${f(xr)} ${f(y)} m\n` +
-      `${f(xwr)} ${f(y)} l\n` +
-      `${f(xwr + c)} ${f(y)} ${f(xw)} ${f(yr - c)} ${f(xw)} ${f(yr)} c\n` +
-      `${f(xw)} ${f(yhr)} l\n` +
-      `${f(xw)} ${f(yhr + c)} ${f(xwr + c)} ${f(yh)} ${f(xwr)} ${f(yh)} c\n` +
-      `${f(xr)} ${f(yh)} l\n` +
-      `${f(xr - c)} ${f(yh)} ${f(x)} ${f(yhr + c)} ${f(x)} ${f(yhr)} c\n` +
-      `${f(x)} ${f(yr)} l\n` +
-      `${f(x)} ${f(yr - c)} ${f(xr - c)} ${f(y)} ${f(xr)} ${f(y)} c\n` +
+      `${f(x + r.bl)} ${f(y)} m\n` +
+      `${f(xw - r.br)} ${f(y)} l\n` +
+      `${f(xw - r.br + r.br * k)} ${f(y)} ${f(xw)} ${f(y + r.br - r.br * k)} ${f(xw)} ${f(y + r.br)} c\n` +
+      `${f(xw)} ${f(yh - r.tr)} l\n` +
+      `${f(xw)} ${f(yh - r.tr + r.tr * k)} ${f(xw - r.tr + r.tr * k)} ${f(yh)} ${f(xw - r.tr)} ${f(yh)} c\n` +
+      `${f(x + r.tl)} ${f(yh)} l\n` +
+      `${f(x + r.tl - r.tl * k)} ${f(yh)} ${f(x)} ${f(yh - r.tl + r.tl * k)} ${f(x)} ${f(yh - r.tl)} c\n` +
+      `${f(x)} ${f(y + r.bl)} l\n` +
+      `${f(x)} ${f(y + r.bl - r.bl * k)} ${f(x + r.bl - r.bl * k)} ${f(y)} ${f(x + r.bl)} ${f(y)} c\n` +
       `h`
     );
+  }
+
+  /**
+   * Clamp the four radii into the box. Each is capped at half the box, and two radii sharing an edge
+   * are scaled down together when they would overlap - the CSS rule, and what keeps the path from
+   * folding back on itself.
+   */
+  private static clampRadii(radius: number | Radii, w: number, h: number): Required<Radii> {
+    const n = typeof radius === "number" ? radius : 0;
+    const cap = Math.max(0, Math.min(w, h) / 2);
+    const at = (v: number | undefined) => Math.max(0, Math.min(v ?? n, cap));
+    const r =
+      typeof radius === "number"
+        ? { tl: at(radius), tr: at(radius), br: at(radius), bl: at(radius) }
+        : { tl: at(radius.tl), tr: at(radius.tr), br: at(radius.br), bl: at(radius.bl) };
+    // Per-edge overlap: scale the whole set by the tightest edge, so the corners stay proportional.
+    // An edge whose two corners are both 0 constrains NOTHING - it must not contribute a ratio of 0,
+    // which would scale every other corner away with it.
+    const ratio = (extent: number, a: number, b: number) =>
+      a + b > 0 ? extent / (a + b) : Infinity;
+    const scale = Math.min(
+      1,
+      ratio(w, r.tl, r.tr),
+      ratio(w, r.bl, r.br),
+      ratio(h, r.tl, r.bl),
+      ratio(h, r.tr, r.br),
+    );
+    if (scale >= 1) return r;
+    return { tl: r.tl * scale, tr: r.tr * scale, br: r.br * scale, bl: r.bl * scale };
   }
 
   /**
@@ -271,10 +298,9 @@ export class PdfBackend {
         const paint = node.fill ? (doStroke ? "B" : "f") : "S";
         // Rounded corners emit a Bézier path; sharp corners keep the plain `re`
         // (byte-identical when no radius is set).
-        const path =
-          (node.radius ?? 0) > 0
-            ? PdfBackend.roundedRectPath(node.x, node.y, node.width, node.height, node.radius!)
-            : `${node.x} ${node.y} ${node.width} ${node.height} re`;
+        const path = isRounded(node.radius)
+          ? PdfBackend.roundedRectPath(node.x, node.y, node.width, node.height, node.radius!)
+          : `${node.x} ${node.y} ${node.width} ${node.height} re`;
         const body = ops + `${path} ${paint}\n`;
         // Transparency needs an isolating q/Q so the state does not leak; opaque rects
         // keep their bare operators (byte-identical).
@@ -341,19 +367,17 @@ export class PdfBackend {
         // Clip to the frame (re … W n); rounded when a radius is set. The rectangular
         // path is byte-identical to before.
         const c = node.clip;
-        const clipPath =
-          (node.radius ?? 0) > 0
-            ? PdfBackend.roundedRectPath(c.x, c.y, c.width, c.height, node.radius!)
-            : `${c.x} ${c.y} ${c.width} ${c.height} re `;
+        const clipPath = isRounded(node.radius)
+          ? PdfBackend.roundedRectPath(c.x, c.y, c.width, c.height, node.radius!)
+          : `${c.x} ${c.y} ${c.width} ${c.height} re `;
         return `q\n${clipPath}\nW n \n` + draw + `Q\n`;
       }
       case "clip-push": {
         // Save the graphics state and intersect the clip with this (rounded) rect. Everything
         // drawn until the matching clip-pop is cropped to it.
-        const path =
-          (node.radius ?? 0) > 0
-            ? PdfBackend.roundedRectPath(node.x, node.y, node.width, node.height, node.radius!)
-            : `${node.x} ${node.y} ${node.width} ${node.height} re`;
+        const path = isRounded(node.radius)
+          ? PdfBackend.roundedRectPath(node.x, node.y, node.width, node.height, node.radius!)
+          : `${node.x} ${node.y} ${node.width} ${node.height} re`;
         return `q\n${path}\nW n\n`;
       }
       case "path": {

--- a/src/lib/utils/flex-layout.ts
+++ b/src/lib/utils/flex-layout.ts
@@ -3,11 +3,9 @@ import { BoxConstraints, Offset, Size } from "../layout/box-constraints.ts";
 
 /** Distribution of the children ALONG the stacking (main) axis when there is leftover
  *  space and no flex child to absorb it. */
-export type MainAlign = "start" | "center" | "end" | "between" | "around";
-
-/** Position/size of each child ACROSS the cross axis. `stretch` fills the cross extent;
- *  the others place the child at its natural cross size. */
-export type CrossAlign = "start" | "center" | "end" | "stretch";
+// Re-exported so every existing import keeps working; the definitions live in layout/alignment.ts.
+export type { MainAlign, CrossAlign } from "../layout/alignment.ts";
+import type { CrossAlign, MainAlign } from "../layout/alignment.ts";
 
 /**
  * Maps the abstract MAIN/CROSS axes onto concrete width/height + x/y, so one flex
@@ -175,17 +173,22 @@ export class FlexLayoutHelper {
     // `stretch` caps a child's cross to `crossExtent` (not `crossAvail`) so siblings end up
     // equal across the axis. Bounded lines have crossExtent == crossAvail (byte-identical);
     // only an unbounded line (a shrink-wrap Row) now equalises instead of staying natural.
-    const stretch = cross === "stretch";
+    // A child may override the container with its own `alignSelf` (CSS), so the decision is per child.
+    const alignFor = (child: PDFElement): CrossAlign => child.alignSelf ?? cross;
 
-    // Pass 2: place each child at the running main position, offset across by `cross`.
+    // Pass 2: place each child at the running main position, offset across by its alignment.
     let mainPos = mainStart + leadingSpace;
     let placedCross = 0;
     children.forEach((child, index) => {
+      const align = alignFor(child);
+      const stretch = align === "stretch";
       let mainExtent: number;
       if (child instanceof FlexiblePDFElement) {
         mainExtent = (child.getFlex() / totalFlex) * remaining;
         const size = child.calculateLayout(
           axis.flexConstraints(mainExtent, stretch ? crossExtent : crossAvail),
+          // A flex child fills the MAIN axis; its cross size is only known after layout, so there is
+          // nothing to align against here. alignSelf on an Expanded/Spacer is a no-op, not a guess.
           axis.offsetAt(mainPos, crossOrigin),
           ctx,
         );
@@ -194,7 +197,7 @@ export class FlexLayoutHelper {
         const childCross = axis.crossOf(fixedSize.get(child)!);
         const size = child.calculateLayout(
           axis.measureConstraints(stretch ? crossExtent : crossAvail, mainCapFor(child)),
-          axis.offsetAt(mainPos, crossOrigin + crossOffset(cross, crossExtent, childCross)),
+          axis.offsetAt(mainPos, crossOrigin + crossOffset(align, crossExtent, childCross)),
           ctx,
         );
         mainExtent = axis.mainOf(size);

--- a/src/lib/utils/flex-layout.ts
+++ b/src/lib/utils/flex-layout.ts
@@ -185,10 +185,13 @@ export class FlexLayoutHelper {
       let mainExtent: number;
       if (child instanceof FlexiblePDFElement) {
         mainExtent = (child.getFlex() / totalFlex) * remaining;
+        // A flex child fills the MAIN axis, and its cross size is only known after layout - there is
+        // nothing to align against. So alignSelf is a no-op here, and that has to hold for the CROSS
+        // CONSTRAINT too: reading the per-child alignment would hand an `alignSelf: "start"` flex child
+        // an unbounded cross axis on a shrink-wrapping line, where the container's own rule gives it
+        // the line's extent. A no-op that changes the constraints is not a no-op.
         const size = child.calculateLayout(
-          axis.flexConstraints(mainExtent, stretch ? crossExtent : crossAvail),
-          // A flex child fills the MAIN axis; its cross size is only known after layout, so there is
-          // nothing to align against here. alignSelf on an Expanded/Spacer is a no-op, not a guess.
+          axis.flexConstraints(mainExtent, cross === "stretch" ? crossExtent : crossAvail),
           axis.offsetAt(mainPos, crossOrigin),
           ctx,
         );

--- a/tests/unit/api/align-self.test.ts
+++ b/tests/unit/api/align-self.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { Box, Column, Row } from "../../../src/lib/api/layout.ts";
+import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
+import { LayoutContext } from "../../../src/lib/elements/pdf-element.ts";
+
+// `alignSelf` - a child overriding its container's `align` (CSS align-self). The container decides for
+// everyone; a child may disagree for itself.
+
+const ctx = {} as LayoutContext;
+
+/** The laid-out x of each child of a Row, which is what cross alignment moves in a Column. */
+const childXs = (row: ReturnType<typeof Row>, w = 400, h = 200) => {
+  row.calculateLayout(BoxConstraints.loose(w, h), { x: 0, y: 0 }, ctx);
+  return (row as unknown as { children: { getProps(): { x: number } }[] }).children.map(
+    (c) => c.getProps().x,
+  );
+};
+
+/** The laid-out y of each child of a Row - the CROSS axis there. */
+const childYs = (row: ReturnType<typeof Row>, w = 400, h = 200) => {
+  row.calculateLayout(BoxConstraints.loose(w, h), { x: 0, y: 0 }, ctx);
+  return (row as unknown as { children: { getProps(): { y: number } }[] }).children.map(
+    (c) => c.getProps().y,
+  );
+};
+
+const tile = (opts: Record<string, unknown> = {}) =>
+  Box({ borderWidth: 0, width: 40, height: 20, ...opts }, []);
+
+describe("alignSelf in a Row (cross axis = vertical)", () => {
+  it("overrides the container for one child only", () => {
+    const row = Row({ align: "start", height: 200 }, [
+      tile(),
+      tile({ alignSelf: "center" }),
+      tile({ alignSelf: "end" }),
+    ]);
+    const [a, b, c] = childYs(row);
+    expect(a).toBe(0); // follows the container: start
+    expect(b).toBe(90); // (200 - 20) / 2
+    expect(c).toBe(180); // 200 - 20
+  });
+
+  it("a child without it still follows the container", () => {
+    const row = Row({ align: "end", height: 200 }, [tile(), tile({ alignSelf: "start" })]);
+    const [a, b] = childYs(row);
+    expect(a).toBe(180);
+    expect(b).toBe(0);
+  });
+
+  it("stretch matches the tallest sibling where 'start' would not", () => {
+    // The distinguishing setup: an UNBOUNDED cross axis, so the line's extent is the tallest child
+    // rather than a given height. In a bounded Row a Box fills either way and the test proves nothing -
+    // the first version of this one passed with alignSelf removed entirely.
+    const tall = Box({ borderWidth: 0, width: 40, height: 60 }, []);
+    const auto = Box({ borderWidth: 0, width: 40, alignSelf: "stretch" }, []);
+    const row = Row({ align: "start" }, [tall, auto]);
+    row.calculateLayout(new BoxConstraints(0, 400, 0, Infinity), { x: 0, y: 0 }, ctx);
+    const kids = (row as unknown as { children: { getProps(): { height?: number } }[] }).children;
+    expect(kids[0].getProps().height).toBe(60);
+    expect(kids[1].getProps().height).toBe(60); // stretched to the line, not left at 0
+  });
+});
+
+describe("alignSelf in a Column (cross axis = horizontal)", () => {
+  it("moves the child across the width", () => {
+    const col = Column({ align: "start", width: 400 }, [
+      tile(),
+      tile({ alignSelf: "center" }),
+      tile({ alignSelf: "end" }),
+    ]);
+    col.calculateLayout(BoxConstraints.loose(400, 600), { x: 0, y: 0 }, ctx);
+    const xs = (col as unknown as { children: { getProps(): { x: number } }[] }).children.map(
+      (c) => c.getProps().x,
+    );
+    expect(xs[0]).toBe(0);
+    expect(xs[1]).toBe(180); // (400 - 40) / 2
+    expect(xs[2]).toBe(360); // 400 - 40
+  });
+});
+
+describe("nothing asked for changes nothing", () => {
+  it("a Row without any alignSelf lays out as before", () => {
+    const row = Row({ align: "center", height: 200 }, [tile(), tile()]);
+    expect(childYs(row)).toEqual([90, 90]);
+  });
+
+  it("the horizontal positions are untouched by cross alignment", () => {
+    const row = Row({ align: "end", gap: 10, height: 200 }, [tile(), tile({ alignSelf: "start" })]);
+    expect(childXs(row)).toEqual([0, 50]);
+  });
+});

--- a/tests/unit/api/align-self.test.ts
+++ b/tests/unit/api/align-self.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { Box, Column, Row } from "../../../src/lib/api/layout.ts";
+import { Box, Column, Expanded, Row } from "../../../src/lib/api/layout.ts";
+import type { CrossAlign } from "../../../src/lib/layout/alignment.ts";
 import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
 import { LayoutContext } from "../../../src/lib/elements/pdf-element.ts";
 
@@ -87,5 +88,31 @@ describe("nothing asked for changes nothing", () => {
   it("the horizontal positions are untouched by cross alignment", () => {
     const row = Row({ align: "end", gap: 10, height: 200 }, [tile(), tile({ alignSelf: "start" })]);
     expect(childXs(row)).toEqual([0, 50]);
+  });
+});
+
+describe("a flex child is untouched by it", () => {
+  it("gives an Expanded the container's cross constraint, whatever it asks for itself", () => {
+    // Not reachable through the factories today - Expanded / Spacer have no `alignSelf` prop - but
+    // `withAlignSelf` is public on the base element, so the path exists. The claim in the code is that
+    // alignSelf is a NO-OP on a flex child; a no-op that changes the cross constraint is not one.
+    //
+    // The cross axis is left UNBOUNDED, which is the only place the line extent (the tallest child) and
+    // the offered extent (Infinity) differ - so a regression here is visible rather than theoretical.
+    const build = (self?: CrossAlign) => {
+      const filler = Expanded({ flex: 1 }, Box({ borderWidth: 0 }, []));
+      if (self) filler.withAlignSelf(self);
+      return Row({ align: "stretch", width: 400 }, [
+        Box({ borderWidth: 0, width: 40, height: 60 }, []),
+        filler,
+      ]);
+    };
+    const heightOf = (row: ReturnType<typeof Row>) => {
+      row.calculateLayout(new BoxConstraints(0, 400, 0, Infinity), { x: 0, y: 0 }, ctx);
+      const kids = (row as unknown as { children: { getProps(): { height?: number } }[] }).children;
+      return kids[1].getProps().height;
+    };
+    expect(heightOf(build("start"))).toBe(heightOf(build()));
+    expect(heightOf(build("end"))).toBe(heightOf(build()));
   });
 });

--- a/tests/unit/api/percentage-insets.test.ts
+++ b/tests/unit/api/percentage-insets.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { Box, Padding } from "../../../src/lib/api/layout.ts";
+import { Page } from "../../../src/lib/api/structure.ts";
+import { Text } from "../../../src/lib/api/text.ts";
+import { toEdges } from "../../../src/lib/api/insets.ts";
+import { resolveEdges } from "../../../src/lib/layout/insets.ts";
+import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
+import { LayoutContext } from "../../../src/lib/elements/pdf-element.ts";
+
+// Percentage padding / margin. The rule worth testing is the surprising one: a percentage resolves
+// against the available WIDTH on ALL FOUR sides, top and bottom included. That is CSS (and Yoga, so
+// react-pdf agrees) - `padding-top: 10%` has never meant 10% of the height.
+
+describe("toEdges keeps points as plain numbers", () => {
+  it("does not change shape for an input that was already legal", () => {
+    // `toEdges` is publicly exported; learning percentages must not break what it returned before.
+    expect(toEdges(10)).toEqual([10, 10, 10, 10]);
+    expect(toEdges({ x: 4, y: 8 })).toEqual([8, 4, 8, 4]);
+    expect(toEdges([1, 2, 3, 4])).toEqual([1, 2, 3, 4]);
+  });
+
+  it("marks only a percentage side as unresolved", () => {
+    expect(toEdges({ top: "10%", left: 6 })).toEqual([{ factor: 0.1 }, 0, 0, 6]);
+  });
+});
+
+describe("resolveEdges", () => {
+  it("uses the WIDTH for the vertical sides too", () => {
+    // The whole point. 10% of a 400pt-wide box is 40 on every side, including top and bottom.
+    expect(resolveEdges(toEdges("10%"), 400)).toEqual([40, 40, 40, 40]);
+  });
+
+  it("leaves a percentage at 0 when the width is unbounded", () => {
+    // Same no-op a percentage SIZE gives there - a fraction of "unbounded" has no meaning.
+    expect(resolveEdges(toEdges("10%"), Infinity)).toEqual([0, 0, 0, 0]);
+  });
+
+  it("mixes points and percentages per side", () => {
+    expect(resolveEdges(toEdges({ top: "25%", right: 12, bottom: "5%", left: 0 }), 200)).toEqual([
+      50, 12, 10, 0,
+    ]);
+  });
+});
+
+describe("through the factories", () => {
+  const ctx = {} as LayoutContext;
+  const height = (el: ReturnType<typeof Padding>, w = 400) =>
+    el.calculateLayout(BoxConstraints.loose(w, 1000), { x: 0, y: 0 }, ctx).height;
+
+  it("a Padding of '10%' insets by 10% of the offered width", () => {
+    // An empty box as the child, so the height IS the vertical insets: 2 x 10% of 400.
+    const el = Padding("10%", Box({ borderWidth: 0, height: 0 }, []));
+    expect(height(el, 400)).toBe(80);
+    // ... and it tracks the offered width, not a frozen number.
+    expect(height(Padding("10%", Box({ borderWidth: 0, height: 0 }, [])), 200)).toBe(40);
+  });
+
+  it("a Box padding takes one too", () => {
+    // Height left UNBOUNDED so the box shrink-wraps to its content - in a bounded region a Box fills,
+    // and the insets would be invisible in the result.
+    const el = Box({ borderWidth: 0, padding: "5%" }, [Box({ borderWidth: 0, height: 0 }, [])]);
+    const size = el.calculateLayout(BoxConstraints.loose(300, Infinity), { x: 0, y: 0 }, ctx);
+    expect(size.height).toBe(30); // 2 x 5% of 300
+  });
+
+  it("a page margin resolves against the page width", () => {
+    // The page is the one box whose geometry needs no parent, so this resolves at build time.
+    const page = Page({ size: "A4", margin: "10%" }, [Text("hi")]);
+    const m = (page as unknown as { config: { margin: Record<string, number> } }).config.margin;
+    // A4 is 595.28pt wide.
+    expect(m.top).toBeCloseTo(59.528, 3);
+    expect(m.left).toBeCloseTo(59.528, 3);
+  });
+
+  it("a landscape page uses the ROTATED width", () => {
+    const page = Page({ size: "A4", orientation: "landscape", margin: "10%" }, [Text("hi")]);
+    const m = (page as unknown as { config: { margin: Record<string, number> } }).config.margin;
+    expect(m.top).toBeCloseTo(84.189, 3); // 10% of 841.89, not of 595.28
+  });
+});

--- a/tests/unit/renderer/corner-radius.test.ts
+++ b/tests/unit/renderer/corner-radius.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Box, Column, Document, Page, renderPdf } from "../../../src/lib/api/index.ts";
+import { Box, Column, Document, Page, Text, renderPdf } from "../../../src/lib/api/index.ts";
 import { toRadius } from "../../../src/lib/api/dimension.ts";
 import { isRounded } from "../../../src/lib/ir/display-list.ts";
 
@@ -90,5 +90,51 @@ describe("per corner", () => {
 
   it("differs from the same box with all four corners set", async () => {
     expect(pathOps(await draw({ topLeft: 20 }))).not.toBe(pathOps(await draw(20)));
+  });
+});
+
+describe("the clip follows the same corners", () => {
+  // `overflow: hidden` emits a SEPARATE IR node (clip-push) with its own copy of the radii, so it can
+  // drift from the drawn border without any test noticing. Verified visually once
+  // (claude-data/out/crop/crop.pdf); this is the automated half.
+  const cropped = async (radius: unknown) =>
+    renderPdf(
+      Document([
+        Page({ margin: 40 }, [
+          Column([
+            Box(
+              {
+                bg: "#dddddd",
+                borderWidth: 0,
+                width: 200,
+                height: 100,
+                radius,
+                overflow: "hidden",
+              } as never,
+              [Text("text that runs into the corner and keeps going", { size: 9 })],
+            ),
+          ]),
+        ]),
+      ]),
+      { compress: false },
+    );
+
+  it("clips to a rounded path, not to the plain rect", async () => {
+    const pdf = await cropped(20);
+    // `W n` is the clip operator; it has to be preceded by curves, not by a bare `re`.
+    expect(pdf).toMatch(/c\n\s*h\n\s*W n/);
+    expect(pdf).not.toMatch(/re\n\s*W n/);
+  });
+
+  it("uses the SAME corner radii as the border it belongs to", async () => {
+    // One corner only: the clip path must show that corner rounded and the other three square, i.e.
+    // exactly the operators the drawn path uses.
+    const pdf = await cropped({ topLeft: 20 });
+    expect(pdf).toContain("60.000 801.890 l");
+    expect(pdf).toContain("240.000 701.890 240.000 701.890 240.000 701.890 c");
+  });
+
+  it("stays a plain rect when nothing is rounded", async () => {
+    expect(await cropped(0)).toMatch(/re\n\s*W n/);
   });
 });

--- a/tests/unit/renderer/corner-radius.test.ts
+++ b/tests/unit/renderer/corner-radius.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { Box, Column, Document, Page, renderPdf } from "../../../src/lib/api/index.ts";
+import { toRadius } from "../../../src/lib/api/dimension.ts";
+import { isRounded } from "../../../src/lib/ir/display-list.ts";
+
+// Per-corner radius. This is the one prop of the layout batch that reaches the byte writer, so the
+// thing worth proving is the negative: a single number must still emit exactly what it always did.
+
+const draw = async (radius: unknown) =>
+  renderPdf(
+    Document([
+      Page({ margin: 40 }, [
+        Column([
+          Box({ bg: "#dddddd", borderWidth: 0, width: 200, height: 100, radius } as never, []),
+        ]),
+      ]),
+    ]),
+    { compress: false },
+  );
+
+/** The curve/line operators of the drawn path, which is what a radius changes. */
+const pathOps = (pdf: string) => (pdf.match(/^[\d.\- ]+(?:m|l|c)$/gm) ?? []).join("\n");
+
+describe("a single number is unchanged", () => {
+  it("emits the same path as before per-corner radii existed", async () => {
+    // The reference string is the operator sequence the single-radius builder produced. Written out
+    // rather than compared against a second render, so a change in BOTH paths cannot hide itself.
+    const ops = pathOps(await draw(8));
+    // The exact operators the single-radius builder emitted: start 8pt along the bottom edge, four
+    // curves, four straight edges. Written out rather than compared to a second render, so a change
+    // in BOTH paths could not hide itself.
+    expect(ops).toContain("48.000 701.890 m");
+    expect(ops).toContain("236.418 701.890 240.000 705.472 240.000 709.890 c");
+    expect(ops.split("\n").filter((l) => l.endsWith(" c")).length).toBe(4);
+    // Four corners, four curves, and the straight edges between them.
+    expect(ops.split("\n").filter((l) => l.endsWith(" l")).length).toBe(4);
+  });
+
+  it("a radius of 0 emits a plain rect, no curves at all", async () => {
+    expect(
+      pathOps(await draw(0))
+        .split("\n")
+        .filter((l) => l.endsWith(" c")).length,
+    ).toBe(0);
+  });
+});
+
+describe("per corner", () => {
+  it("rounds only the corner that asks for it", async () => {
+    const ops = pathOps(await draw({ topLeft: 12 }));
+    // The top-left corner starts 12pt in from the left edge and curves down 12pt - the box is
+    // 200x100 at x=40, so its top-left in PDF coordinates is (40, 801.890).
+    expect(ops).toContain("52.000 801.890 l");
+    expect(ops).toContain("45.372 801.890 40.000 796.518 40.000 789.890 c");
+    // The other three corners collapse onto their corner point: sharp, as asked.
+    expect(ops).toContain("240.000 701.890 240.000 701.890 240.000 701.890 c");
+  });
+
+  it("does not let an empty edge scale the other corners away", () => {
+    // The bug this test exists for: the per-edge overlap check divided by the sum of two radii, and
+    // an edge with both corners at 0 produced a ratio of 0 - scaling every OTHER corner to nothing.
+    // One corner set is exactly the case where two edges are empty.
+    expect(toRadius({ topLeft: 12 })).toEqual({
+      tl: 12,
+      tr: undefined,
+      br: undefined,
+      bl: undefined,
+    });
+  });
+
+  it("takes the CSS tuple order - topLeft, topRight, bottomRight, bottomLeft", () => {
+    expect(toRadius([1, 2, 3, 4])).toEqual({ tl: 1, tr: 2, br: 3, bl: 4 });
+    expect(toRadius({ topRight: 5 })).toEqual({
+      tl: undefined,
+      tr: 5,
+      br: undefined,
+      bl: undefined,
+    });
+    expect(toRadius(7)).toBe(7);
+  });
+
+  it("knows when nothing is rounded", () => {
+    expect(isRounded(undefined)).toBe(false);
+    expect(isRounded(0)).toBe(false);
+    expect(isRounded({})).toBe(false);
+    expect(isRounded({ bl: 0 })).toBe(false);
+    expect(isRounded({ bl: 3 })).toBe(true);
+    expect(isRounded(3)).toBe(true);
+  });
+
+  it("differs from the same box with all four corners set", async () => {
+    expect(pathOps(await draw({ topLeft: 20 }))).not.toBe(pathOps(await draw(20)));
+  });
+});


### PR DESCRIPTION
## Summary

Now elements can align by `alignSelf`, corner radius per-corner and percentage padding (8% e.g.)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added uniform, per-corner, and tuple-based corner radii for images and boxes.
  - Added percentage-based padding, margins, and insets resolved against available width and page dimensions.
  - Added per-child cross-axis alignment options: start, center, end, and stretch.
- **Bug Fixes**
  - Improved rounded-corner rendering and radius normalization, including landscape page margin calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->