### PR TITLE
feat: make gradient background possible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,6 +445,44 @@ agree: true })` → declarative values, not object mutation. Save is an **increm
   producers that DRAW their fields (jasy, pdf-lib) leave a stale picture of the old value; we wrote a new `/V`
   and kept the old drawing, a self-contradicting document. Fix: drop `/AP` for `Tx`/`Ch` on fill; a BUTTON's
   `/AP` holds its on/off STATES and is kept, only `/AS` moves.
+  **Flatten + the fill options** (2026-07-31): `flattenForm(bytes, { fields })` stamps a field's appearance
+  onto the page and drops the widget, and `fillForm(bytes, values, { flatten: true })` does both in ONE
+  incremental update. The trap that pass had to solve: flatten reads the picture a widget shows out of the
+  DOCUMENT, but mid-pass the new one is only in the WRITER - so a filled-and-flattened form would freeze the
+  value from BEFORE the fill. Both widget kinds go stale for different reasons (a text field's `/AP` is
+  replaced; a button's `/AP` keeps every state and only `/AS` moves), hence `FreshAppearances`. Two option
+  combinations are refused by name: `fieldAppearances` + `needAppearances` both false (nobody draws the
+  value), and `flatten` with `fieldAppearances: false` (nothing to freeze).
+
+- ✅ **The layout knobs** (2026-08-01) — `aspectRatio`, `minWidth`/`maxWidth`/`minHeight`/`maxHeight` (points
+  or a percentage), `%` on padding/margin, `alignSelf`, and a **per-corner** `radius`. One shared resolver
+  `resolveSize` (`layout/box-constraints.ts`) serves Box · Column · Row · Image, and the ORDER is the
+  contract, following CSS: relative sizing → the ratio fills whichever axis was left open → min/max clamp.
+  So an explicit bound beats the ratio, the way `min-height` beats `aspect-ratio` in a browser.
+  Two things that are easy to get wrong and are pinned by tests: min/max come back as **narrowed
+  CONSTRAINTS**, not a clamped number (an axis with no explicit size still has to obey them), but the
+  **fill-vs-shrink-wrap DECISION** stays on the constraints we were HANDED - a `max-width` caps a box, it
+  never makes one grow. And a percentage resolves against the OFFERED box, then gets clamped: `width: "50%"`
+  with `maxWidth: 100` in a 400pt region is 200 capped to 100, not 50% of 100.
+  `%` insets follow the CSS quirk on purpose: **a percentage resolves against the WIDTH on all four sides**,
+  top and bottom included (`layout/insets.ts`; Yoga does the same, so react-pdf agrees). The per-corner
+  radius scales two radii sharing an edge down TOGETHER when they would overlap, which react-pdf does not -
+  it clamps each corner alone. The `overflow: hidden` clip follows the same four corners.
+- ✅ **Gradients** (2026-08-01) — `Box({ bg: linearGradient(…) })` / `radialGradient(…)`, written
+  BOX-RELATIVE (an angle and stops) and resolved against the box by the renderer, which is the first place
+  its geometry is known (`api/gradient.ts` `resolveGradient`). Angles follow CSS: 0 points up, clockwise.
+  Cheap because the backend already emitted axial and radial shadings for COLR v1 colour emoji - only the
+  public prop and the plumbing were missing. **PDF has no gradient fill colour**: `sh` floods the current
+  clip, so a gradient box becomes the clip, the shading is painted inside it, and a border is stroked
+  afterwards on its own. A solid colour keeps the plain `rg`/`f` operators, so old output stays byte-identical.
+  `flipY` flips the gradient's page-space anchors WITH the rect, exactly as it already did for `Path`.
+- ✅ **The reader refuses a zip bomb** (2026-07-31, ISSUE-8) — `inflateBounded` (`edit/inflate.ts`) plus
+  `maxStreamSize` on `PdfDocument.load`/`open`, `fillForm` and `flattenForm` (default 64 MB), throwing a
+  named `PdfStreamTooLargeError`. Worth remembering because the obvious fix is wrong: **fflate does NOT
+  throw on an over-long inflate, it TRUNCATES silently**, so `unzlibSync(data, { out })` would have replaced
+  an OOM with quiet data corruption. The working shape streams the input in slices and checks the total as
+  it grows. It costs nothing because a stream too small to reach the ceiling at DEFLATE's maximum expansion
+  (1032:1) skips the check - which is nearly every stream in a real PDF.
 
 Genuine remaining gaps / deferred:
 

--- a/src/lib/api/gradient.ts
+++ b/src/lib/api/gradient.ts
@@ -1,0 +1,120 @@
+import { toColor, type ColorInput } from "./color.ts";
+import type { Gradient, GradientStop } from "../ir/display-list.ts";
+
+/**
+ * Gradients for a box background.
+ *
+ * The public form is BOX-RELATIVE - an angle and some stops - because that is what an author knows
+ * when writing the document. The engine's `Gradient` wants absolute page coordinates, so the renderer
+ * resolves one against the box it is painting; see `resolveGradient`.
+ */
+
+/** A stop as written: a colour, optionally pinned to a position 0..1 along the axis. */
+export type StopInput = ColorInput | { color: ColorInput; at: number };
+
+export interface LinearGradientInput {
+  kind: "linear";
+  /** Direction in degrees, CSS convention: 0 = to the top, 90 = to the right (default 180, downwards). */
+  angle: number;
+  stops: StopInput[];
+}
+
+export interface RadialGradientInput {
+  kind: "radial";
+  /** Centre as a fraction of the box, `[0.5, 0.5]` being the middle (the default). */
+  center: [number, number];
+  /** Outer radius as a fraction of the box's larger side (default 0.5, i.e. it touches the edges). */
+  radius: number;
+  stops: StopInput[];
+}
+
+export type GradientInput = LinearGradientInput | RadialGradientInput;
+
+export const isGradientInput = (v: unknown): v is GradientInput =>
+  typeof v === "object" && v !== null && "kind" in v && "stops" in v;
+
+/**
+ * A linear gradient. `linearGradient("#fff", "#000")` runs top to bottom; pass `{ angle }` for any
+ * other direction, and `{ color, at }` for a stop that is not evenly spaced.
+ */
+export function linearGradient(
+  ...args: [...StopInput[]] | [{ angle?: number; stops: StopInput[] }]
+): LinearGradientInput {
+  const first = args[0];
+  if (args.length === 1 && typeof first === "object" && first !== null && "stops" in first) {
+    return { kind: "linear", angle: first.angle ?? 180, stops: first.stops };
+  }
+  return { kind: "linear", angle: 180, stops: args as StopInput[] };
+}
+
+/** A radial gradient, centred by default and reaching the edges. */
+export function radialGradient(
+  ...args: [...StopInput[]] | [{ center?: [number, number]; radius?: number; stops: StopInput[] }]
+): RadialGradientInput {
+  const first = args[0];
+  if (args.length === 1 && typeof first === "object" && first !== null && "stops" in first) {
+    return {
+      kind: "radial",
+      center: first.center ?? [0.5, 0.5],
+      radius: first.radius ?? 0.5,
+      stops: first.stops,
+    };
+  }
+  return { kind: "radial", center: [0.5, 0.5], radius: 0.5, stops: args as StopInput[] };
+}
+
+/** Spread the stops that carry no `at` evenly, first to last, the way CSS does. */
+function toStops(stops: StopInput[]): GradientStop[] {
+  if (stops.length < 2) {
+    throw new Error("A gradient needs at least two colour stops.");
+  }
+  const last = stops.length - 1;
+  return stops.map((s, i) => {
+    const pinned = typeof s === "object" && s !== null && "at" in s;
+    return {
+      offset: pinned ? (s as { at: number }).at : i / last,
+      color: toColor(pinned ? (s as { color: ColorInput }).color : (s as ColorInput)),
+    };
+  });
+}
+
+/**
+ * Resolve a box-relative gradient against the box it paints, into the absolute page coordinates the
+ * IR wants. Called by the renderer, which is the first place the box's geometry is known.
+ *
+ * The angle follows CSS: 0 points to the top and it turns clockwise, so 90 goes to the right. The
+ * axis runs through the box centre and is scaled so it spans the box on that diagonal - which is why
+ * a 45-degree gradient reaches the corners rather than stopping short of them.
+ */
+export function resolveGradient(
+  g: GradientInput,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): Gradient {
+  const stops = toStops(g.stops);
+  if (g.kind === "radial") {
+    const cx = x + g.center[0] * width;
+    const cy = y + g.center[1] * height;
+    const r = g.radius * Math.max(width, height);
+    return { type: "radial", x0: cx, y0: cy, r0: 0, x1: cx, y1: cy, r1: r, stops, extend: "pad" };
+  }
+  const rad = ((g.angle % 360) * Math.PI) / 180;
+  // CSS angles: 0 = up, clockwise. The engine lays out top-left down, so "up" is -y here.
+  const dx = Math.sin(rad);
+  const dy = -Math.cos(rad);
+  // Half the box's extent along the axis, so the line covers the whole box for any angle.
+  const half = (Math.abs(dx) * width + Math.abs(dy) * height) / 2;
+  const cx = x + width / 2;
+  const cy = y + height / 2;
+  return {
+    type: "linear",
+    x0: cx - dx * half,
+    y0: cy - dy * half,
+    x1: cx + dx * half,
+    y1: cy + dy * half,
+    stops,
+    extend: "pad",
+  };
+}

--- a/src/lib/api/gradient.ts
+++ b/src/lib/api/gradient.ts
@@ -63,19 +63,44 @@ export function radialGradient(
   return { kind: "radial", center: [0.5, 0.5], radius: 0.5, stops: args as StopInput[] };
 }
 
-/** Spread the stops that carry no `at` evenly, first to last, the way CSS does. */
+/**
+ * Spread the stops that carry no `at` evenly, first to last, the way CSS does - and check the pinned
+ * ones, because they end up in a PDF stitching function's `/Bounds`, which the format requires to be
+ * strictly increasing inside the domain. A bad offset there is not a wrong-looking gradient, it is a
+ * malformed file, so it is refused by name here rather than emitted.
+ */
 function toStops(stops: StopInput[]): GradientStop[] {
   if (stops.length < 2) {
     throw new Error("A gradient needs at least two colour stops.");
   }
   const last = stops.length - 1;
-  return stops.map((s, i) => {
+  const out: GradientStop[] = stops.map((s, i) => {
     const pinned = typeof s === "object" && s !== null && "at" in s;
+    const at = pinned ? (s as { at: number }).at : i / last;
+    if (!Number.isFinite(at) || at < 0 || at > 1) {
+      throw new Error(`Invalid gradient stop position ${at}: it must be a number between 0 and 1.`);
+    }
     return {
-      offset: pinned ? (s as { at: number }).at : i / last,
+      offset: at,
       color: toColor(pinned ? (s as { color: ColorInput }).color : (s as ColorInput)),
     };
   });
+
+  for (let i = 1; i < out.length; i++) {
+    if (out[i].offset <= out[i - 1].offset) {
+      throw new Error(
+        `Gradient stops must move forward: stop ${i} sits at ${out[i].offset}, which is not after ` +
+          `${out[i - 1].offset}. (Two stops at the SAME position would be a hard colour edge in CSS; ` +
+          `PDF cannot express that in one shading, so it is refused rather than drawn wrongly.)`,
+      );
+    }
+  }
+
+  // A pinned first or last stop would otherwise be IGNORED - the shading's domain is always 0..1 and
+  // only the INTERIOR offsets reach /Bounds. Carrying the edge colour outwards is what CSS does.
+  if (out[0].offset > 0) out.unshift({ offset: 0, color: out[0].color });
+  if (out[out.length - 1].offset < 1) out.push({ offset: 1, color: out[out.length - 1].color });
+  return out;
 }
 
 /**

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -3,6 +3,7 @@
 // core classes stay untouched and remain exported for power users.
 export * from "./color.ts";
 export * from "./insets.ts";
+export * from "./gradient.ts";
 export * from "./dimension.ts";
 export * from "./text.ts";
 export * from "./layout.ts";

--- a/src/lib/api/layout.ts
+++ b/src/lib/api/layout.ts
@@ -14,6 +14,7 @@ import { RotatedBoxElement } from "../elements/layout/rotated-box-element.ts";
 import { PDFElement } from "../elements/pdf-element.ts";
 import { MainAlign, CrossAlign } from "../utils/flex-layout.ts";
 import { ColorInput, toColor } from "./color.ts";
+import { isGradientInput, type GradientInput } from "./gradient.ts";
 import { Insets, toEdges } from "./insets.ts";
 import {
   BoundsInput,
@@ -141,8 +142,8 @@ export interface BoxOptions extends BoundsInput {
   borderLeft?: ColorInput;
   /** Border thickness in points (default 1 when a border is present). */
   borderWidth?: number;
-  /** Background fill color. */
-  bg?: ColorInput;
+  /** Background: a colour, or a gradient from `linearGradient()` / `radialGradient()`. */
+  bg?: ColorInput | GradientInput;
   /** Inner padding between the border and the children. */
   padding?: Insets;
   /** Size on each axis: a number of points (fixed) or a percentage string like `"50%"` (a fraction
@@ -210,7 +211,8 @@ export function Box(a: BoxOptions | PDFElement[], b?: PDFElement[]): PDFElement 
       y: 0,
       children: content,
       color: opts.border !== undefined ? toColor(opts.border) : undefined,
-      backgroundColor: opts.bg !== undefined ? toColor(opts.bg) : undefined,
+      backgroundColor:
+        opts.bg === undefined ? undefined : isGradientInput(opts.bg) ? opts.bg : toColor(opts.bg),
       borderWidth: hasBorder ? (opts.borderWidth ?? 1) : 0,
       width: w?.points,
       height: h?.points,

--- a/src/lib/elements/rectangle-element.ts
+++ b/src/lib/elements/rectangle-element.ts
@@ -1,4 +1,5 @@
 import type { Radii } from "../ir/display-list.ts";
+import type { GradientInput } from "../api/gradient.ts";
 import { Color } from "../common/color.ts";
 import {
   BoxConstraints,
@@ -34,7 +35,8 @@ export interface SideBorders {
 
 interface RectangleElementParams extends SizedElement, WithChildren {
   color?: Color;
-  backgroundColor?: Color;
+  /** Solid colour, or a box-relative gradient the renderer resolves against this box. */
+  backgroundColor?: Color | GradientInput;
   borderWidth?: number;
   /** Corner radius in points - one number for all four corners, or per corner. 0 = sharp (default). */
   radius?: number | Radii;
@@ -70,7 +72,7 @@ interface RectangleElementParams extends SizedElement, WithChildren {
 export class RectangleElement extends SizedPDFElement implements Fragmentable {
   private children: PDFElement[] = [];
   private color: Color;
-  private backgroundColor?: Color;
+  private backgroundColor?: Color | GradientInput;
   private borderWidth: number;
   private radius: number | Radii;
   private sideBorders?: SideBorders;

--- a/src/lib/ir/display-list.ts
+++ b/src/lib/ir/display-list.ts
@@ -71,7 +71,8 @@ export interface Rect {
   y: number;
   width: number;
   height: number;
-  fill?: Color;
+  /** Solid colour, or a gradient whose anchor points are in absolute page coordinates. */
+  fill?: Color | Gradient;
   stroke?: Color;
   strokeWidth: number;
   /** Corner radius in points - one number for all four, or per corner. Absent/0 = sharp (plain `re`). */

--- a/src/lib/renderer/pdf-backend.ts
+++ b/src/lib/renderer/pdf-backend.ts
@@ -22,8 +22,14 @@ export class PdfBackend {
   static flipY(nodes: IRNode[], pageHeight: number): IRNode[] {
     return nodes.map((node) => {
       switch (node.type) {
-        case "rect":
-          return { ...node, y: pageHeight - node.y - node.height };
+        case "rect": {
+          // A gradient fill carries its own page-space anchors; flip them with the box (see "path").
+          const fill =
+            node.fill === undefined || node.fill instanceof Color
+              ? node.fill
+              : { ...node.fill, y0: pageHeight - node.fill.y0, y1: pageHeight - node.fill.y1 };
+          return { ...node, y: pageHeight - node.y - node.height, fill };
+        }
         case "line":
           return {
             ...node,
@@ -290,23 +296,42 @@ export class PdfBackend {
         // fill, no border) draws nothing. Paint: B = fill+stroke, f = fill, S = stroke.
         const doStroke = !!node.stroke && (node.strokeWidth ?? 0) > 0;
         if (!node.fill && !doStroke) return "";
-        let ops = "";
-        if (doStroke) {
-          ops += `${node.strokeWidth} w\n${node.stroke!.toPDFColorString()} RG\n`;
-        }
-        if (node.fill) ops += `${node.fill.toPDFColorString()} rg\n`;
-        const paint = node.fill ? (doStroke ? "B" : "f") : "S";
         // Rounded corners emit a Bézier path; sharp corners keep the plain `re`
         // (byte-identical when no radius is set).
         const path = isRounded(node.radius)
           ? PdfBackend.roundedRectPath(node.x, node.y, node.width, node.height, node.radius!)
           : `${node.x} ${node.y} ${node.width} ${node.height} re`;
+
+        // A gradient cannot be a fill COLOUR - PDF paints one with `sh`, which floods the current
+        // clip. So the box becomes the clip, the shading is painted inside it, and a border is
+        // stroked afterwards on its own. Solid fills keep the plain operators, byte for byte.
+        const gradient =
+          node.fill !== undefined && !(node.fill instanceof Color) ? node.fill : undefined;
+        if (gradient) {
+          const shading = om.registerShading(gradient);
+          let out = `q\n${path} W n\n/${shading} sh\nQ\n`;
+          if (doStroke) {
+            const gsStroke = PdfBackend.alphaPrefix(om, 1, node.stroke!.getAlpha());
+            const stroke =
+              `${node.strokeWidth} w\n${node.stroke!.toPDFColorString()} RG\n` + `${path} S\n`;
+            out += gsStroke ? `q\n${gsStroke}${stroke}Q\n` : stroke;
+          }
+          return out;
+        }
+
+        const fill = node.fill as Color | undefined;
+        let ops = "";
+        if (doStroke) {
+          ops += `${node.strokeWidth} w\n${node.stroke!.toPDFColorString()} RG\n`;
+        }
+        if (fill) ops += `${fill.toPDFColorString()} rg\n`;
+        const paint = fill ? (doStroke ? "B" : "f") : "S";
         const body = ops + `${path} ${paint}\n`;
         // Transparency needs an isolating q/Q so the state does not leak; opaque rects
         // keep their bare operators (byte-identical).
         const gs = PdfBackend.alphaPrefix(
           om,
-          node.fill?.getAlpha() ?? 1,
+          fill?.getAlpha() ?? 1,
           doStroke ? node.stroke!.getAlpha() : 1,
         );
         return gs ? `q\n${gs}${body}Q\n` : body;

--- a/src/lib/renderer/rectangle-renderer.ts
+++ b/src/lib/renderer/rectangle-renderer.ts
@@ -3,6 +3,7 @@ import { PDFObjectManager } from "../utils/pdf-object-manager.ts";
 import { RectangleElement, SideBorders } from "../elements/rectangle-element.ts";
 import { RendererRegistry } from "../utils/renderer-registry.ts";
 import { IRNode, Rect, Line } from "../ir/display-list.ts";
+import { isGradientInput, resolveGradient } from "../api/gradient.ts";
 import { Color } from "../common/color.ts";
 
 export class RectangleRenderer {
@@ -27,11 +28,18 @@ export class RectangleRenderer {
     const h = height!;
     const nodes: IRNode[] = [];
 
+    // A gradient is written box-relative (an angle and stops); this is the first place the box is
+    // known, so it is resolved into the absolute page coordinates the IR wants.
+    const fill =
+      backgroundColor !== undefined && isGradientInput(backgroundColor)
+        ? resolveGradient(backgroundColor, x, y, width, h)
+        : backgroundColor;
+
     if (sideBorders) {
       // Per-side borders: a fill-only box (no stroke), then a line per present side
       // (sharp corners). This is what lets cells draw grid lines.
       if (backgroundColor) {
-        nodes.push({ type: "rect", x, y, width, height: h, strokeWidth: 0, fill: backgroundColor });
+        nodes.push({ type: "rect", x, y, width, height: h, strokeWidth: 0, fill });
       }
       nodes.push(...RectangleRenderer.sideLines(x, y, width, h, borderWidth!, sideBorders));
     } else {
@@ -45,7 +53,7 @@ export class RectangleRenderer {
         height: h,
         stroke: color,
         strokeWidth: borderWidth!,
-        ...(backgroundColor ? { fill: backgroundColor } : {}),
+        ...(fill ? { fill } : {}),
         ...(radius ? { radius } : {}),
       };
       nodes.push(node);

--- a/tests/unit/api/gradient.test.ts
+++ b/tests/unit/api/gradient.test.ts
@@ -70,6 +70,51 @@ describe("stops", () => {
   it("refuses a gradient with fewer than two colours", () => {
     expect(() => box(linearGradient("#000"))).toThrow(/two colour stops/);
   });
+
+  it("refuses a position outside 0..1, or one that is not a number", () => {
+    // These end up in a PDF stitching function's /Bounds, which the format requires to sit strictly
+    // inside the domain. A bad one is a MALFORMED FILE, not a wrong-looking gradient.
+    for (const at of [2, -0.5, NaN, Infinity]) {
+      expect(() => box(linearGradient({ stops: ["#000", { color: "#fff", at }, "#111"] }))).toThrow(
+        /between 0 and 1/,
+      );
+    }
+  });
+
+  it("refuses stops that do not move forward", () => {
+    // /Bounds must be STRICTLY increasing. Equal offsets are a hard colour edge in CSS and cannot be
+    // expressed in one PDF shading, so they are named rather than drawn wrongly.
+    expect(() =>
+      box(
+        linearGradient({
+          stops: ["#000", { color: "#f00", at: 0.5 }, { color: "#0f0", at: 0.5 }, "#fff"],
+        }),
+      ),
+    ).toThrow(/must move forward/);
+    expect(() =>
+      box(
+        linearGradient({
+          stops: ["#000", { color: "#f00", at: 0.8 }, { color: "#0f0", at: 0.3 }, "#fff"],
+        }),
+      ),
+    ).toThrow(/must move forward/);
+  });
+
+  it("carries the edge colour outwards when the first or last stop is pinned inside", () => {
+    // Only the INTERIOR offsets reach /Bounds - the domain is always 0..1 - so a first stop pinned at
+    // 0.3 would silently do nothing. CSS extends the edge colour instead, and so do we.
+    const g = box(
+      linearGradient({
+        stops: [
+          { color: "#000000", at: 0.3 },
+          { color: "#ffffff", at: 0.7 },
+        ],
+      }),
+    );
+    expect(g.stops.map((s) => s.offset)).toEqual([0, 0.3, 0.7, 1]);
+    expect(g.stops[0].color.toPDFColorString()).toBe(g.stops[1].color.toPDFColorString());
+    expect(g.stops[3].color.toPDFColorString()).toBe(g.stops[2].color.toPDFColorString());
+  });
 });
 
 describe("radial", () => {

--- a/tests/unit/api/gradient.test.ts
+++ b/tests/unit/api/gradient.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import { linearGradient, radialGradient, resolveGradient } from "../../../src/lib/api/gradient.ts";
+import { Box, Column, Document, Page, renderPdf } from "../../../src/lib/api/index.ts";
+
+// Gradients are written BOX-RELATIVE (an angle and stops) and resolved against the box by the
+// renderer. Two things are worth pinning down: the angle convention, and that a solid colour still
+// takes the old path - `sh` floods the clip, so a gradient box is painted completely differently.
+
+const box = (g: unknown) => resolveGradient(g as never, 0, 0, 200, 100);
+
+describe("the angle follows CSS: 0 points up, clockwise", () => {
+  it("90 runs left to right, along the horizontal centre line", () => {
+    const g = box(linearGradient({ angle: 90, stops: ["#000", "#fff"] })) as {
+      x0: number;
+      y0: number;
+      x1: number;
+      y1: number;
+    };
+    expect(g.y0).toBeCloseTo(50, 6);
+    expect(g.y1).toBeCloseTo(50, 6);
+    expect(g.x0).toBeLessThan(g.x1);
+  });
+
+  it("the default (180) runs top to bottom", () => {
+    const g = box(linearGradient("#000", "#fff")) as { x0: number; y0: number; y1: number };
+    expect(g.x0).toBeCloseTo(100, 6);
+    expect(g.y0).toBeLessThan(g.y1); // engine coordinates run downwards
+  });
+
+  it("0 runs bottom to top - the opposite of the default", () => {
+    const up = box(linearGradient({ angle: 0, stops: ["#000", "#fff"] })) as {
+      y0: number;
+      y1: number;
+    };
+    const down = box(linearGradient({ angle: 180, stops: ["#000", "#fff"] })) as {
+      y0: number;
+      y1: number;
+    };
+    expect(up.y0).toBeCloseTo(down.y1, 6);
+    expect(up.y1).toBeCloseTo(down.y0, 6);
+  });
+
+  it("a diagonal spans the whole box, not just the shorter side", () => {
+    // Half the box's extent along the axis - which is why 45 degrees reaches into the corners
+    // instead of stopping short of them.
+    const g = box(linearGradient({ angle: 45, stops: ["#000", "#fff"] })) as {
+      x0: number;
+      y0: number;
+      x1: number;
+      y1: number;
+    };
+    const span = Math.hypot(g.x1 - g.x0, g.y1 - g.y0);
+    expect(span).toBeCloseTo((200 + 100) / Math.SQRT2, 4);
+  });
+});
+
+describe("stops", () => {
+  it("spreads them evenly when nothing is pinned", () => {
+    const g = box(linearGradient("#000", "#888", "#fff"));
+    expect(g.stops.map((s) => s.offset)).toEqual([0, 0.5, 1]);
+  });
+
+  it("honours a pinned position", () => {
+    const g = box(
+      linearGradient({ angle: 90, stops: ["#000", { color: "#f3dc29", at: 0.8 }, "#fff"] }),
+    );
+    expect(g.stops.map((s) => s.offset)).toEqual([0, 0.8, 1]);
+  });
+
+  it("refuses a gradient with fewer than two colours", () => {
+    expect(() => box(linearGradient("#000"))).toThrow(/two colour stops/);
+  });
+});
+
+describe("radial", () => {
+  it("is centred and reaches the edges by default", () => {
+    const g = box(radialGradient("#fff", "#000")) as {
+      x0: number;
+      y0: number;
+      r0: number;
+      r1: number;
+    };
+    expect([g.x0, g.y0]).toEqual([100, 50]);
+    expect(g.r0).toBe(0);
+    expect(g.r1).toBe(100); // half the larger side
+  });
+
+  it("takes a centre and radius of its own", () => {
+    const g = box(
+      radialGradient({ center: [0.25, 0.25], radius: 0.8, stops: ["#fff", "#000"] }),
+    ) as { x0: number; y0: number; r1: number };
+    expect([g.x0, g.y0]).toEqual([50, 25]);
+    expect(g.r1).toBe(160);
+  });
+});
+
+describe("what reaches the page", () => {
+  const draw = async (bg: unknown) =>
+    renderPdf(
+      Document([
+        Page({ margin: 40 }, [
+          Column([Box({ bg, borderWidth: 0, width: 200, height: 100 } as never, [])]),
+        ]),
+      ]),
+      { compress: false },
+    );
+
+  it("paints a gradient as a clip plus a shading, never as a fill colour", async () => {
+    // PDF has no gradient FILL - `sh` floods the current clip - so the box becomes the clip.
+    const pdf = await draw(linearGradient("#000000", "#ffffff"));
+    expect(pdf).toMatch(/W n\n\/Sh\d+ sh/);
+    expect(pdf).toContain("/Shading");
+  });
+
+  it("leaves a solid colour on the old path", async () => {
+    const pdf = await draw("#dddddd");
+    expect(pdf).toContain("re f");
+    expect(pdf).not.toContain(" sh\n");
+  });
+
+  it("flips the gradient anchors with the box", async () => {
+    // The IR is top-left; the anchors are absolute page coordinates and must flip WITH the rect, or
+    // the gradient runs the wrong way round on the page.
+    const pdf = await draw(linearGradient({ angle: 180, stops: ["#000000", "#ffffff"] }));
+    const coords = /\/Coords \[([\d.\- ]+)\]/.exec(pdf);
+    expect(coords).not.toBeNull();
+    const [, y0, , y1] = coords![1].trim().split(/\s+/).map(Number);
+    // The box sits at y 701.89..801.89 in PDF space; "downwards" means from the HIGH y to the low.
+    expect(y0).toBeGreaterThan(y1);
+  });
+
+  it("still strokes a border around a gradient box", async () => {
+    const pdf = await renderPdf(
+      Document([
+        Page({ margin: 40 }, [
+          Column([
+            Box(
+              {
+                bg: linearGradient("#000000", "#ffffff"),
+                border: "#ff0000",
+                borderWidth: 2,
+                width: 200,
+                height: 100,
+              } as never,
+              [],
+            ),
+          ]),
+        ]),
+      ]),
+      { compress: false },
+    );
+    expect(pdf).toMatch(/ sh\n/);
+    expect(pdf).toContain("2 w");
+    expect(pdf).toMatch(/re S/);
+  });
+});


### PR DESCRIPTION
## Summary

Now you can have gradient backgrounds to your page/rows e.g.


## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added linear and radial gradients with configurable colors, stops, angles, centers, and radii.
  * Enabled gradients as backgrounds for boxes and rectangles.
  * Added convenient gradient constructors with automatic stop normalization and sensible defaults.
  * Added PDF rendering support, including clipping and border handling.

* **Bug Fixes**
  * Ensured gradient positioning remains correct when coordinate systems are vertically flipped.

* **Documentation**
  * Added guidance for using gradients and related layout options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->