### PR TITLE
feat: use fonts from url

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -287,6 +287,10 @@ doc.addFont("Inter", "Inter-Regular.ttf"); // a path (Node reads it)
 doc.addFont("Brand", { normal: "B.ttf", bold: "B-Bold.ttf" }); // a styled family
 
 doc.getFonts(); // ["Inter", "Brand"]
+
+// From a URL - async, because the fetch happens NOW, exactly as a path is read now:
+await doc.addFontFromUrl("Inter", "https://cdn.example/Inter-Regular.ttf");
+await doc.addFontFromUrl("Brand", { normal: ".../B.ttf", bold: ".../B-Bold.ttf" });
 doc.hasFont("Inter"); // true
 
 await renderToBytes(doc); // pure output - the fonts are already in the document

--- a/examples/scripts/fill-existing-form.ts
+++ b/examples/scripts/fill-existing-form.ts
@@ -9,7 +9,9 @@
  * A signature over the original therefore stays intact, and the original file is a literal byte prefix
  * of the result.
  *
- * Run:  pnpm exec tsx examples/scripts/fill-existing-form.ts
+ * Run (the same way examples/render.sh does it - `@jasy/pdf` resolves to this repo):
+ *   mkdir -p node_modules/@jasy && ln -sfn "$PWD" node_modules/@jasy/pdf
+ *   pnpm build && node examples/scripts/fill-existing-form.ts
  */
 import { readFileSync, writeFileSync } from "node:fs";
 import { PdfDocument, readAcroForm, fillForm, flattenForm, FillError } from "@jasy/pdf/edit";

--- a/examples/scripts/font-from-url.ts
+++ b/examples/scripts/font-from-url.ts
@@ -1,0 +1,91 @@
+/**
+ * Register a font from a URL and render with it - no file, no build step, no font in your repository.
+ *
+ * `addFontFromUrl` fetches AT REGISTRATION, exactly as `addFont` reads a path there and then. That is
+ * why it is async and why a dead link fails HERE, on the line that asked for the font, rather than
+ * somewhere inside a later render.
+ *
+ * What arrives in the PDF is a SUBSET: only the glyphs the document actually uses are embedded. The
+ * three Lato faces below are about 2 MB of source, and the finished file is around 65 KB.
+ *
+ * Run (the same way examples/render.sh does it - `@jasy/pdf` resolves to this repo):
+ *   mkdir -p node_modules/@jasy && ln -sfn "$PWD" node_modules/@jasy/pdf
+ *   pnpm build && node examples/scripts/font-from-url.ts
+ */
+import { writeFileSync, mkdirSync } from "node:fs";
+import {
+  Box,
+  Column,
+  DefaultTextStyle,
+  Document,
+  Page,
+  Row,
+  Text,
+  renderToBytes,
+  FontUrlError,
+} from "@jasy/pdf";
+
+const CDN = "https://raw.githubusercontent.com/google/fonts/main/ofl/lato";
+
+const doc = Document({ size: 11 }, [
+  Page({ size: "A4", margin: 52, gap: 10 }, [
+    Text("Fonts, straight from a URL", { size: 22, bold: true, font: "Lato", color: "#0a2348" }),
+    Text(
+      "Nothing was downloaded by hand and nothing lives in this project. The three faces below were " +
+        "fetched over the network and embedded, subsetted, into this file - which is why the umlauts " +
+        "and the punctuation come out right.",
+      { font: "Lato", color: "#475569" },
+    ),
+
+    Box({ bg: "#eef2fb", radius: 6, padding: 14, borderWidth: 0 }, [
+      DefaultTextStyle({ font: "Lato", size: 13 }, [
+        Column({ gap: 5 }, [
+          Text("Regular - Größenwahn, Straße, Fußgängerübergang"),
+          Text("Bold - Größenwahn, Straße, Fußgängerübergang", { bold: true }),
+          Text("Italic - Größenwahn, Straße, Fußgängerübergang", { italic: true }),
+        ]),
+      ]),
+    ]),
+
+    Text("The same line in the built-in Helvetica, for comparison:", { size: 9, color: "#64748b" }),
+    Text("Regular - Größenwahn, Straße, Fußgängerübergang", { size: 13 }),
+
+    Row({ gap: 10 }, [
+      Box({ bg: "#e8f4ea", radius: 6, padding: 12, borderWidth: 0, width: 240 }, [
+        Text("A style that was never fetched falls back to normal - it is not faked:", {
+          size: 8.5,
+          color: "#2f6b45",
+        }),
+        Text("boldItalic (not loaded)", { font: "Lato", bold: true, italic: true, size: 12 }),
+      ]),
+      Box({ bg: "#fdf1e0", radius: 6, padding: 12, borderWidth: 0, width: 240 }, [
+        Text("Only the glyphs actually used are embedded:", { size: 8.5, color: "#8a5a12" }),
+        Text("subsetted, roughly 97% smaller", { font: "Lato", size: 12 }),
+      ]),
+    ]),
+  ]),
+]);
+
+// A whole styled family in one call; the faces are fetched in parallel. Leave a style out and
+// `Text({ bold })` falls back to `normal` rather than faking a weight.
+try {
+  await doc.addFontFromUrl("Lato", {
+    normal: `${CDN}/Lato-Regular.ttf`,
+    bold: `${CDN}/Lato-Bold.ttf`,
+    italic: `${CDN}/Lato-Italic.ttf`,
+  });
+} catch (e) {
+  // Named, and it says what the file actually was - a 404 page, a WOFF2, an OpenType/CFF font.
+  if (e instanceof FontUrlError) {
+    console.error(e.message);
+    process.exit(1);
+  }
+  throw e;
+}
+
+console.log("registered:", doc.getFonts().join(", "));
+
+mkdirSync("examples/out", { recursive: true });
+const bytes = await renderToBytes(doc);
+writeFileSync("examples/out/font-from-url.pdf", bytes);
+console.log(`examples/out/font-from-url.pdf - ${bytes.length} bytes`);

--- a/src/lib/api/font-url.ts
+++ b/src/lib/api/font-url.ts
@@ -1,0 +1,89 @@
+/**
+ * Loading a font over the network for `doc.addFontFromUrl(...)`.
+ *
+ * `addFont` resolves its source AT REGISTRATION - a path is read there and then - and this keeps the
+ * same contract, differing only in being async. So the failure lands where you asked for the font,
+ * not somewhere inside a later render.
+ *
+ * `fetch` is used directly: it is in every browser and in Node since 18, so this needs no platform
+ * port, unlike the filesystem read beside it.
+ */
+
+/** One font file by URL, or a styled family of them. Mirrors `FontSource`, with strings meaning URLs. */
+export type UrlFontSource =
+  | string
+  | { normal: string; bold?: string; italic?: string; boldItalic?: string };
+
+/** Thrown when a font could not be fetched or is not one we can parse. Always says which URL. */
+export class FontUrlError extends Error {
+  constructor(message: string) {
+    super(`@jasy/pdf: ${message}`);
+  }
+}
+
+/**
+ * What the first four bytes of an sfnt file say it is. Checked here because `TTFParser` does not look
+ * at them: it goes straight for the table directory, so an HTML error page or a WOFF would fail deep
+ * inside with `missing required table "head"` instead of saying what the file actually is.
+ */
+function describeSignature(bytes: Uint8Array): { ok: boolean; what: string } {
+  const tag = String.fromCharCode(...bytes.subarray(0, 4));
+  const v = (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3];
+  if (v === 0x00010000 || tag === "true") return { ok: true, what: "TrueType" };
+  if (tag === "OTTO")
+    return { ok: false, what: "an OpenType/CFF font, which jasy does not parse yet" };
+  if (tag === "wOFF") return { ok: false, what: "a WOFF font, which jasy does not parse yet" };
+  if (tag === "wOF2") return { ok: false, what: "a WOFF2 font, which jasy does not parse yet" };
+  if (tag === "ttcf")
+    return { ok: false, what: "a TrueType Collection, which jasy does not parse yet" };
+  if (tag.startsWith("<") || tag === "%PDF") return { ok: false, what: "not a font at all" };
+  return { ok: false, what: "not a font we recognise" };
+}
+
+/** Fetch one font file and hand back its bytes, refusing anything we could not embed. */
+async function fetchFont(url: string): Promise<Uint8Array> {
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch (e) {
+    throw new FontUrlError(
+      `could not fetch the font at ${url}: ${String((e as Error)?.message ?? e)}`,
+    );
+  }
+  if (!response.ok) {
+    throw new FontUrlError(`the font at ${url} could not be fetched: HTTP ${response.status}`);
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.length < 4) {
+    throw new FontUrlError(`the font at ${url} is empty`);
+  }
+  const { ok, what } = describeSignature(bytes);
+  if (!ok) {
+    throw new FontUrlError(
+      `the file at ${url} is ${what}. jasy embeds TrueType-flavoured fonts (.ttf)`,
+    );
+  }
+  return bytes;
+}
+
+/** Fetch a whole `UrlFontSource`, in parallel for a family. */
+export async function loadFontFromUrl(
+  source: UrlFontSource,
+): Promise<
+  | Uint8Array
+  | { normal: Uint8Array; bold?: Uint8Array; italic?: Uint8Array; boldItalic?: Uint8Array }
+> {
+  if (typeof source === "string") return fetchFont(source);
+
+  const styles = ["normal", "bold", "italic", "boldItalic"] as const;
+  const wanted = styles.filter((s) => source[s] !== undefined);
+  const loaded = await Promise.all(wanted.map((s) => fetchFont(source[s]!)));
+  const family = { normal: new Uint8Array() } as {
+    normal: Uint8Array;
+    bold?: Uint8Array;
+    italic?: Uint8Array;
+    boldItalic?: Uint8Array;
+  };
+  wanted.forEach((s, i) => (family[s] = loaded[i]));
+  return family;
+}

--- a/src/lib/api/font-url.ts
+++ b/src/lib/api/font-url.ts
@@ -40,20 +40,87 @@ function describeSignature(bytes: Uint8Array): { ok: boolean; what: string } {
   return { ok: false, what: "not a font we recognise" };
 }
 
+/** How long one font may take to arrive before we give up. A hung server must not hang a render. */
+const TIMEOUT_MS = 15_000;
+
+/**
+ * How large a font file may be. Generous on purpose - a full CJK face is tens of megabytes and is a
+ * legitimate thing to embed - but not unbounded: a URL pointing at the wrong file (a video, a disk
+ * image) would otherwise be read into memory in full before anyone notices it is not a font.
+ */
+const MAX_BYTES = 32 * 1024 * 1024;
+
+/** Read the body with a running ceiling, so an oversized response is dropped WHILE it arrives. */
+async function readBounded(response: Response, url: string): Promise<Uint8Array> {
+  // `Content-Length` is the cheap early exit; a server may omit or misstate it, so it is a hint only
+  // and the real ceiling is enforced below while reading.
+  const declared = Number(response.headers?.get?.("content-length") ?? NaN);
+  if (Number.isFinite(declared) && declared > MAX_BYTES) {
+    throw new FontUrlError(`the font at ${url} is ${declared} bytes; the limit is ${MAX_BYTES}`);
+  }
+
+  const body = response.body;
+  if (!body?.getReader) {
+    // No streaming body (an older runtime, or a stubbed response): fall back to reading it whole and
+    // checking afterwards. Weaker, but never worse than not checking at all.
+    const whole = new Uint8Array(await response.arrayBuffer());
+    if (whole.length > MAX_BYTES) {
+      throw new FontUrlError(`the font at ${url} is larger than the ${MAX_BYTES} byte limit`);
+    }
+    return whole;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.length;
+    if (total > MAX_BYTES) {
+      await reader.cancel();
+      throw new FontUrlError(`the font at ${url} is larger than the ${MAX_BYTES} byte limit`);
+    }
+    chunks.push(value);
+  }
+  if (chunks.length === 1) return chunks[0];
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const c of chunks) {
+    out.set(c, at);
+    at += c.length;
+  }
+  return out;
+}
+
 /** Fetch one font file and hand back its bytes, refusing anything we could not embed. */
 async function fetchFont(url: string): Promise<Uint8Array> {
   let response: Response;
   try {
-    response = await fetch(url);
+    response = await fetch(url, { signal: AbortSignal.timeout(TIMEOUT_MS) });
   } catch (e) {
-    throw new FontUrlError(
-      `could not fetch the font at ${url}: ${String((e as Error)?.message ?? e)}`,
-    );
+    const why =
+      (e as Error)?.name === "TimeoutError" || (e as Error)?.name === "AbortError"
+        ? `it did not respond within ${TIMEOUT_MS} ms`
+        : String((e as Error)?.message ?? e);
+    throw new FontUrlError(`could not fetch the font at ${url}: ${why}`);
   }
   if (!response.ok) {
     throw new FontUrlError(`the font at ${url} could not be fetched: HTTP ${response.status}`);
   }
-  const bytes = new Uint8Array(await response.arrayBuffer());
+
+  // Everything past here still talks to the network, so a failure mid-body must not escape as a raw
+  // TypeError - a caller catching FontUrlError would miss it.
+  let bytes: Uint8Array;
+  try {
+    bytes = await readBounded(response, url);
+  } catch (e) {
+    if (e instanceof FontUrlError) throw e;
+    throw new FontUrlError(
+      `the font at ${url} could not be read: ${String((e as Error)?.message ?? e)}`,
+    );
+  }
+
   if (bytes.length < 4) {
     throw new FontUrlError(`the font at ${url} is empty`);
   }

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -4,6 +4,7 @@
 export * from "./color.ts";
 export * from "./insets.ts";
 export * from "./gradient.ts";
+export * from "./font-url.ts";
 export * from "./dimension.ts";
 export * from "./text.ts";
 export * from "./layout.ts";

--- a/src/lib/api/structure.ts
+++ b/src/lib/api/structure.ts
@@ -15,6 +15,7 @@ import { createSecurityHandler, type EncryptOptions } from "../crypto/security-h
 export type { EncryptOptions, Permissions } from "../crypto/security-handler.ts";
 import { uaXmp } from "../utils/ua-xmp.ts";
 import { Column, StackOptions } from "./layout.ts";
+import { loadFontFromUrl, type UrlFontSource } from "./font-url.ts";
 import { Insets, toEdges } from "./insets.ts";
 import { TextDefaults, toTextStyleOverride } from "./text.ts";
 
@@ -144,6 +145,10 @@ export interface JasyDocument extends PDFDocumentElement {
    *  path (read now, on Node), raw bytes, or a styled family. Re-adding a name overwrites it.
    *  A registered font that no `Text` actually uses is dropped at render and costs nothing. */
   addFont(name: string, source: FontSource): this;
+  /** The same, from a URL. Async because the fetch happens NOW, exactly as `addFont` reads a path
+   *  now - so a broken link fails where you asked for the font, not inside a later render.
+   *  `await doc.addFontFromUrl("Inter", "https://…/Inter-Regular.ttf")`, or a styled family of URLs. */
+  addFontFromUrl(name: string, source: UrlFontSource): Promise<this>;
   /** The names of the registered fonts. */
   getFonts(): string[];
   /** Whether a font is registered under `name`. */
@@ -194,6 +199,10 @@ export function Document(a: DocumentOptions | PageElement[], b?: PageElement[]):
   docFonts.set(doc, registry);
   doc.addFont = (name, source) => {
     registry.set(name, resolveFontSource(source));
+    return doc;
+  };
+  doc.addFontFromUrl = async (name, source) => {
+    registry.set(name, await loadFontFromUrl(source));
     return doc;
   };
   doc.getFonts = () => [...registry.keys()];

--- a/tests/unit/api/font-url.test.ts
+++ b/tests/unit/api/font-url.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { Document, Page, Text } from "../../../src/lib/api/index.ts";
+import { FontUrlError, loadFontFromUrl } from "../../../src/lib/api/font-url.ts";
+
+// `addFontFromUrl` fetches AT REGISTRATION, exactly as `addFont` reads a path there and then, so a
+// broken link fails where you asked for the font rather than inside a later render. `fetch` is stubbed
+// here: what matters is the contract around it, and no test may reach the network.
+//
+// No real .ttf is used - the only ones in this repo live in the gitignored `claude-data/`, so a test
+// depending on them would fail in a fresh clone. The signature check reads the first four bytes, which
+// is all these fixtures need to provide.
+
+/** A buffer that starts like the given sfnt flavour; the rest is padding, never parsed here. */
+const fontLike = (tag: "ttf" | "OTTO" | "wOFF" | "wOF2" | "ttcf" | "html"): Uint8Array => {
+  const head =
+    tag === "ttf"
+      ? [0x00, 0x01, 0x00, 0x00]
+      : tag === "html"
+        ? [0x3c, 0x21, 0x44, 0x4f] // "<!DO"
+        : [...tag].map((c) => c.charCodeAt(0));
+  return new Uint8Array([...head, ...Array.from({ length: 64 }, () => 0)]);
+};
+
+const stubFetch = (fn: (url: string) => Promise<Response> | Response) => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((u: string) => Promise.resolve(fn(u))),
+  );
+};
+const ok = (bytes: Uint8Array) =>
+  ({ ok: true, status: 200, arrayBuffer: async () => bytes.buffer }) as unknown as Response;
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("a font that loads", () => {
+  it("hands back the bytes it fetched", async () => {
+    stubFetch(() => ok(fontLike("ttf")));
+    const bytes = (await loadFontFromUrl("https://x.example/Inter.ttf")) as Uint8Array;
+    expect(bytes.subarray(0, 4)).toEqual(new Uint8Array([0, 1, 0, 0]));
+  });
+
+  it("fetches a whole family, one request per style", async () => {
+    const seen: string[] = [];
+    stubFetch((u) => {
+      seen.push(u);
+      return ok(fontLike("ttf"));
+    });
+    const family = (await loadFontFromUrl({
+      normal: "https://x.example/n.ttf",
+      bold: "https://x.example/b.ttf",
+    })) as { normal: Uint8Array; bold?: Uint8Array; italic?: Uint8Array };
+    expect(seen).toEqual(["https://x.example/n.ttf", "https://x.example/b.ttf"]);
+    expect(family.normal.length).toBeGreaterThan(0);
+    expect(family.bold).toBeDefined();
+    expect(family.italic).toBeUndefined(); // a style not given is not invented
+  });
+});
+
+describe("it refuses by name, never by failing deep inside the parser", () => {
+  it("says which URL and which status", async () => {
+    stubFetch(() => ({ ok: false, status: 404 }) as Response);
+    await expect(loadFontFromUrl("https://x.example/nope.ttf")).rejects.toThrow(
+      /nope\.ttf could not be fetched: HTTP 404/,
+    );
+  });
+
+  it("reports a network failure with its cause", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("getaddrinfo ENOTFOUND"))),
+    );
+    await expect(loadFontFromUrl("https://x.example/f.ttf")).rejects.toThrow(/ENOTFOUND/);
+  });
+
+  it("names the format when the file is a font we cannot parse", async () => {
+    // The point of checking the signature at all: TTFParser never looks at it and would fail with
+    // `missing required table "head"`, which tells the user nothing about what they actually linked.
+    for (const [tag, expected] of [
+      ["OTTO", /OpenType\/CFF/],
+      ["wOFF", /WOFF font/],
+      ["wOF2", /WOFF2/],
+      ["ttcf", /TrueType Collection/],
+    ] as const) {
+      stubFetch(() => ok(fontLike(tag)));
+      await expect(loadFontFromUrl("https://x.example/f")).rejects.toThrow(expected);
+    }
+  });
+
+  it("spots the classic mistake - a URL that returns an error PAGE", async () => {
+    stubFetch(() => ok(fontLike("html")));
+    await expect(loadFontFromUrl("https://x.example/f.ttf")).rejects.toThrow(/not a font at all/);
+  });
+
+  it("refuses an empty response", async () => {
+    stubFetch(() => ok(new Uint8Array()));
+    await expect(loadFontFromUrl("https://x.example/f.ttf")).rejects.toThrow(/is empty/);
+  });
+
+  it("throws a named error type, so a caller can tell it apart", async () => {
+    stubFetch(() => ok(fontLike("wOF2")));
+    await expect(loadFontFromUrl("https://x.example/f.ttf")).rejects.toBeInstanceOf(FontUrlError);
+  });
+});
+
+describe("on the document", () => {
+  it("registers under the name, queryable like any other font", async () => {
+    stubFetch(() => ok(fontLike("ttf")));
+    const doc = Document([Page({ margin: 40 }, [Text("hi", { font: "Inter" })])]);
+    expect(doc.hasFont("Inter")).toBe(false);
+
+    const same = await doc.addFontFromUrl("Inter", "https://x.example/Inter.ttf");
+    expect(same).toBe(doc); // chainable, like addFont
+    expect(doc.hasFont("Inter")).toBe(true);
+    expect(doc.getFonts()).toContain("Inter");
+  });
+
+  it("does not register anything when the fetch fails", async () => {
+    // The registry must not end up holding a half-loaded family.
+    stubFetch(() => ({ ok: false, status: 500 }) as Response);
+    const doc = Document([Page({ margin: 40 }, [Text("hi")])]);
+    await expect(doc.addFontFromUrl("Inter", "https://x.example/Inter.ttf")).rejects.toThrow();
+    expect(doc.hasFont("Inter")).toBe(false);
+  });
+});

--- a/tests/unit/api/font-url.test.ts
+++ b/tests/unit/api/font-url.test.ts
@@ -96,6 +96,89 @@ describe("it refuses by name, never by failing deep inside the parser", () => {
     await expect(loadFontFromUrl("https://x.example/f.ttf")).rejects.toThrow(/is empty/);
   });
 
+  it("gives up on a server that never answers", async () => {
+    // A hung server must not hang a render. The abort surfaces as a named error saying WHY.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_u: string, init?: { signal?: AbortSignal }) => {
+        const err = new Error("aborted");
+        err.name = "TimeoutError";
+        void init;
+        return Promise.reject(err);
+      }),
+    );
+    await expect(loadFontFromUrl("https://x.example/slow.ttf")).rejects.toThrow(
+      /did not respond within/,
+    );
+  });
+
+  it("passes an abort signal, so the timeout is real and not decorative", async () => {
+    const seen: (AbortSignal | undefined)[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_u: string, init?: { signal?: AbortSignal }) => {
+        seen.push(init?.signal);
+        return Promise.resolve(ok(fontLike("ttf")));
+      }),
+    );
+    await loadFontFromUrl("https://x.example/f.ttf");
+    expect(seen[0]).toBeInstanceOf(AbortSignal);
+  });
+
+  it("refuses a response that declares itself oversized, before reading it", async () => {
+    stubFetch(
+      () =>
+        ({
+          ok: true,
+          status: 200,
+          headers: { get: (h: string) => (h === "content-length" ? "99999999" : null) },
+          arrayBuffer: async () => new ArrayBuffer(0),
+        }) as unknown as Response,
+    );
+    await expect(loadFontFromUrl("https://x.example/huge.ttf")).rejects.toThrow(/the limit is/);
+  });
+
+  it("stops an oversized body WHILE it arrives, when nothing was declared", async () => {
+    // The header is a hint a server may omit or misstate; the real ceiling is enforced on the stream.
+    const chunk = new Uint8Array(1024 * 1024);
+    let served = 0;
+    stubFetch(
+      () =>
+        ({
+          ok: true,
+          status: 200,
+          headers: { get: () => null },
+          body: {
+            getReader: () => ({
+              read: async () => ({ done: false, value: (served++, chunk) }),
+              cancel: async () => undefined,
+            }),
+          },
+        }) as unknown as Response,
+    );
+    await expect(loadFontFromUrl("https://x.example/endless.ttf")).rejects.toThrow(
+      /larger than the/,
+    );
+    expect(served).toBeLessThan(100); // it stopped early rather than reading forever
+  });
+
+  it("wraps a body that fails mid-read, so the error type still holds", async () => {
+    stubFetch(
+      () =>
+        ({
+          ok: true,
+          status: 200,
+          headers: { get: () => null },
+          arrayBuffer: async () => {
+            throw new TypeError("terminated");
+          },
+        }) as unknown as Response,
+    );
+    const err = await loadFontFromUrl("https://x.example/f.ttf").catch((e) => e);
+    expect(err).toBeInstanceOf(FontUrlError);
+    expect(String(err.message)).toMatch(/could not be read: terminated/);
+  });
+
   it("throws a named error type, so a caller can tell it apart", async () => {
     stubFetch(() => ok(fontLike("wOF2")));
     await expect(loadFontFromUrl("https://x.example/f.ttf")).rejects.toBeInstanceOf(FontUrlError);


### PR DESCRIPTION
## Summary

Now we can also use fonts from an URL

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asynchronous font loading from URLs, including regular, bold, italic, and bold-italic styles.
  * Added clear errors for unavailable, invalid, empty, or unsupported font files.
  * Added an example demonstrating URL-based font registration and styled text rendering.

* **Documentation**
  * Updated font management guidance and example run instructions.

* **Tests**
  * Added coverage for successful loads, failures, validation, and document registration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->