### PR TITLE
feat: implement sub-page-numbers

### DIFF
--- a/src/lib/api/page-builder.ts
+++ b/src/lib/api/page-builder.ts
@@ -18,6 +18,10 @@ export type { PageInfo };
  * `pageNumber` is 1-based and counts PHYSICAL pages (an overflowing `Page` contributes several);
  * `pageCount` is the document total; `pageSize` is the media box in points.
  *
+ * `subPageNumber` / `subPageTotalPages` are the same counts WITHIN one logical `Page` element - what you
+ * want when a document is several sections and the footer should say "Attachment, page 1 of 4" beside
+ * "sheet 4 of 7". With a single `Page` they are identical to the document counts.
+ *
  * The numbers themselves are always exact. Two sizing caveats, both from the same chicken-and-egg (the
  * content decides the count that the content displays): in the flowing BODY the box is reserved before the
  * total is known, so a much wider final string can paint slightly past it; and a conditional header may
@@ -40,4 +44,17 @@ export function PageNumber({ offset = 0, ...style }: PageNumberOptions = {}): Pa
 /** The document's total page count as text. Sugar for `PageBuilder`. */
 export function PageCount({ offset = 0, ...style }: PageNumberOptions = {}): PageBuilderElement {
   return PageBuilder(({ pageCount }) => Text(String(pageCount + offset), style));
+}
+
+/** The page number WITHIN its logical `Page` (a section), as text. Sugar for `PageBuilder`. */
+export function SubPageNumber({
+  offset = 0,
+  ...style
+}: PageNumberOptions = {}): PageBuilderElement {
+  return PageBuilder(({ subPageNumber }) => Text(String(subPageNumber + offset), style));
+}
+
+/** How many pages the surrounding logical `Page` produced, as text. Sugar for `PageBuilder`. */
+export function SubPageCount({ offset = 0, ...style }: PageNumberOptions = {}): PageBuilderElement {
+  return PageBuilder(({ subPageTotalPages }) => Text(String(subPageTotalPages + offset), style));
 }

--- a/src/lib/elements/layout/page-builder-element.ts
+++ b/src/lib/elements/layout/page-builder-element.ts
@@ -34,6 +34,8 @@ export class PageBuilderElement extends PDFElement {
       ctx.pageInfo ?? {
         pageNumber: 1,
         pageCount: 1,
+        subPageNumber: 1,
+        subPageTotalPages: 1,
         pageSize: resolvePageSize(ctx.pageConfig),
       }
     );

--- a/src/lib/elements/pdf-element.ts
+++ b/src/lib/elements/pdf-element.ts
@@ -29,8 +29,18 @@ export interface PositioningFrame {
  * the document's final physical page total. `pageSize` is the media box in points, orientation applied.
  */
 export interface PageInfo {
+  /** 1-based, counting PHYSICAL pages across the whole document. */
   pageNumber: number;
+  /** Physical pages in the whole document. */
   pageCount: number;
+  /**
+   * 1-based within the LOGICAL page this sheet came from - the `Page(...)` element the author wrote.
+   * A document of one `Page` has `subPageNumber === pageNumber`; a document of several (an invoice
+   * plus its attachment, say) restarts the count at each one.
+   */
+  subPageNumber: number;
+  /** Physical pages this logical page produced. */
+  subPageTotalPages: number;
   pageSize: { width: number; height: number };
 }
 

--- a/src/lib/renderer/pdf-document-renderer.ts
+++ b/src/lib/renderer/pdf-document-renderer.ts
@@ -45,8 +45,13 @@ export class PDFDocumentRenderer {
     // pure (`{ fitted, remainder }`), so the full list of physical pages can be settled up front. Only
     // then is the total page count known, which is what page numbers in a header/footer need.
     const physicalPages: PhysicalPage[] = [];
+    // Where each sheet sits WITHIN the logical page it came from. Pass A already knows: one logical
+    // `Page` element produces one run of sheets, so the run's length is that section's total.
+    const section: { number: number; total: number }[] = [];
     for (const page of document.getProps().children) {
-      physicalPages.push(...PDFDocumentRenderer.paginateLogicalPage(page, ctx));
+      const sheets = PDFDocumentRenderer.paginateLogicalPage(page, ctx);
+      sheets.forEach((_, i) => section.push({ number: i + 1, total: sheets.length }));
+      physicalPages.push(...sheets);
     }
 
     // Pass B - draw them, in order, so the emitted page objects keep their previous numbering. Each page
@@ -57,6 +62,8 @@ export class PDFDocumentRenderer {
       const pageInfo = {
         pageNumber: index + 1,
         pageCount: physicalPages.length,
+        subPageNumber: section[index].number,
+        subPageTotalPages: section[index].total,
         pageSize: resolvePageSize(PDFDocumentRenderer.configOf(physical, ctx)),
       };
       pageNumbers.push(

--- a/tests/unit/api/sub-page-numbers.test.ts
+++ b/tests/unit/api/sub-page-numbers.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  Column,
+  Document,
+  Page,
+  PageBuilder,
+  SubPageCount,
+  SubPageNumber,
+  Text,
+  renderToBytes,
+} from "../../../src/lib/api/index.ts";
+import { PdfDocument } from "../../../src/lib/edit/document.ts";
+import { isStream } from "../../../src/lib/edit/objects.ts";
+
+// `pageNumber` counts PHYSICAL pages across the whole document; `subPageNumber` counts within the
+// logical `Page` element the author wrote. The case that makes it real: an invoice plus an attachment,
+// where the footer should say "Attachment, page 1 of 4" beside "sheet 4 of 7".
+
+/** The text drawn on each page, in order - read back with our own parser rather than guessing at bytes. */
+const pageTexts = (bytes: Uint8Array): string[] => {
+  const doc = PdfDocument.load(bytes);
+  const kids = doc.lookup(doc.lookup(doc.catalog, "Pages"), "Kids");
+  return (Array.isArray(kids) ? kids : []).map((ref) => {
+    const contents = doc.lookup(doc.resolve(ref), "Contents");
+    return (Array.isArray(contents) ? contents : [contents])
+      .map((c) => {
+        const stream = doc.resolve(c);
+        return isStream(stream) ? new TextDecoder("latin1").decode(doc.streamData(stream)) : "";
+      })
+      .join("\n");
+  });
+};
+
+/** A logical page that overflows into `sheets` physical ones, footing each with its own counts. */
+const section = (label: string, sheets: number) =>
+  Page(
+    {
+      size: "A4",
+      margin: 40,
+      footer: PageBuilder(({ pageNumber, pageCount, subPageNumber, subPageTotalPages }) =>
+        Text(`${label} ${subPageNumber}/${subPageTotalPages} - sheet ${pageNumber}/${pageCount}`, {
+          size: 9,
+        }),
+      ),
+    },
+    [
+      Column(
+        Array.from({ length: sheets * 44 }, (_, i) => Text(`${label} line ${i}`, { size: 11 })),
+      ),
+    ],
+  );
+
+describe("a document of several logical pages", () => {
+  it("restarts the sub count at each one while the sheet count runs on", async () => {
+    const bytes = await renderToBytes(Document([section("Invoice", 2), section("Attachment", 2)]), {
+      compress: false,
+      kerning: false,
+    });
+    const pages = pageTexts(bytes);
+    expect(pages.length).toBeGreaterThanOrEqual(4);
+
+    // The first section's sheets are numbered 1..n within it, and the second section starts at 1 again
+    // even though the sheet number keeps climbing.
+    const feet = pages
+      .map((p) => /(\w+) (\d+)\/(\d+) - sheet (\d+)\/(\d+)/.exec(p))
+      .filter(Boolean);
+    expect(feet.length).toBe(pages.length);
+
+    const first = feet.filter((m) => m![1] === "Invoice");
+    const second = feet.filter((m) => m![1] === "Attachment");
+    expect(first.map((m) => m![2])).toEqual(first.map((_, i) => String(i + 1)));
+    expect(second.map((m) => m![2])).toEqual(second.map((_, i) => String(i + 1)));
+
+    // ... and the sheet numbers never restart.
+    expect(feet.map((m) => Number(m![4]))).toEqual(feet.map((_, i) => i + 1));
+
+    // Each section's total is its OWN, not the document's.
+    expect(first.every((m) => Number(m![3]) === first.length)).toBe(true);
+    expect(second.every((m) => Number(m![3]) === second.length)).toBe(true);
+    expect(Number(first[0]![5])).toBe(pages.length); // the document total, on every page
+  });
+});
+
+describe("a document of ONE logical page", () => {
+  it("makes the two counts identical, so nothing surprises a single-section document", async () => {
+    const bytes = await renderToBytes(Document([section("Report", 3)]), {
+      compress: false,
+      kerning: false,
+    });
+    for (const page of pageTexts(bytes)) {
+      const m = /(\w+) (\d+)\/(\d+) - sheet (\d+)\/(\d+)/.exec(page);
+      expect(m).not.toBeNull();
+      expect(m![2]).toBe(m![4]); // subPageNumber === pageNumber
+      expect(m![3]).toBe(m![5]); // subPageTotalPages === pageCount
+    }
+  });
+});
+
+describe("the sugar", () => {
+  it("SubPageNumber and SubPageCount draw the same values", async () => {
+    const bytes = await renderToBytes(
+      Document([
+        Page(
+          {
+            size: "A4",
+            margin: 40,
+            footer: Column([SubPageNumber({ size: 9 }), SubPageCount({ size: 9 })]),
+          },
+          [Column(Array.from({ length: 88 }, (_, i) => Text(`line ${i}`, { size: 11 })))],
+        ),
+      ]),
+      { compress: false, kerning: false },
+    );
+    const pages = pageTexts(bytes);
+    expect(pages.length).toBe(2);
+    expect(pages[0]).toContain("(1)");
+    expect(pages[1]).toContain("(2)");
+    for (const p of pages) expect(p).toContain("(2)"); // the total, on both
+  });
+});


### PR DESCRIPTION
## Summary

Jasy can calculate page number - and you can show them in your footer. Now it's possible to show sub-page-numbers. Think: invoice and attachments are two different documents in one PDF. show page numbers of each section now.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking physical sheet positions within logical pages.
  * Added page-builder helpers to display a logical page’s current number and total page count.
  * Page numbering supports optional offsets and text styling.

* **Bug Fixes**
  * Improved page information handling during layout and rendering, including reliable defaults for unavailable page data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->