### PR TITLE
feat: support woff fonts

### DIFF
--- a/src/lib/api/font-url.ts
+++ b/src/lib/api/font-url.ts
@@ -32,7 +32,7 @@ function describeSignature(bytes: Uint8Array): { ok: boolean; what: string } {
   if (v === 0x00010000 || tag === "true") return { ok: true, what: "TrueType" };
   if (tag === "OTTO")
     return { ok: false, what: "an OpenType/CFF font, which jasy does not parse yet" };
-  if (tag === "wOFF") return { ok: false, what: "a WOFF font, which jasy does not parse yet" };
+  if (tag === "wOFF") return { ok: true, what: "WOFF" };
   if (tag === "wOF2") return { ok: false, what: "a WOFF2 font, which jasy does not parse yet" };
   if (tag === "ttcf")
     return { ok: false, what: "a TrueType Collection, which jasy does not parse yet" };
@@ -127,7 +127,7 @@ async function fetchFont(url: string): Promise<Uint8Array> {
   const { ok, what } = describeSignature(bytes);
   if (!ok) {
     throw new FontUrlError(
-      `the file at ${url} is ${what}. jasy embeds TrueType-flavoured fonts (.ttf)`,
+      `the file at ${url} is ${what}. jasy embeds TrueType-flavoured fonts (.ttf and .woff)`,
     );
   }
   return bytes;

--- a/src/lib/edit/document.ts
+++ b/src/lib/edit/document.ts
@@ -1,5 +1,9 @@
 import { Lexer } from "./lexer.ts";
-import { DEFAULT_MAX_STREAM_SIZE, inflateBounded, PdfStreamTooLargeError } from "./inflate.ts";
+import {
+  DEFAULT_MAX_STREAM_SIZE,
+  inflateBounded,
+  PdfStreamTooLargeError,
+} from "../utils/inflate.ts";
 import {
   get,
   isDict,

--- a/src/lib/edit/index.ts
+++ b/src/lib/edit/index.ts
@@ -22,5 +22,5 @@ export type { FieldValue, FillOptions, FillResult } from "./fill.ts";
 // PdfStreamTooLargeError tells "this file is attacking me" apart from both.
 export { PdfDocument, PdfEncryptedError } from "./document.ts";
 export type { LoadOptions, OpenOptions } from "./document.ts";
-export { DEFAULT_MAX_STREAM_SIZE, PdfStreamTooLargeError } from "./inflate.ts";
+export { DEFAULT_MAX_STREAM_SIZE, PdfStreamTooLargeError } from "../utils/inflate.ts";
 export type { PdfDict, PdfName, PdfObject, PdfRef, PdfStream, PdfString } from "./objects.ts";

--- a/src/lib/utils/inflate.ts
+++ b/src/lib/utils/inflate.ts
@@ -1,7 +1,10 @@
 import { Unzlib, unzlibSync } from "fflate";
 
 /**
- * Inflating a stream with a ceiling, so a zip bomb cannot exhaust memory.
+ * Inflating with a ceiling, so a hostile or mistaken input cannot exhaust memory.
+ *
+ * Used by BOTH sides: the reader inflating a PDF stream, and the font path unpacking a WOFF table.
+ * It lives in `utils/` for exactly that reason - the generate path must not import from `edit/`.
  *
  * fflate's `unzlibSync(data, { out })` is NOT usable for this: it truncates silently instead of failing.
  * Hence the streamed form - input in slices, so the total can be checked while it grows.

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -6,6 +6,7 @@ import { zlibSync } from "fflate";
 import { bytesFromLatin1, latin1FromBytes } from "./bytes.ts";
 import { AFMParser } from "./afm-parser.ts";
 import { mergeSpans, TTFParser } from "./ttf-parser.ts";
+import { isWoff, woffToSfnt } from "./woff.ts";
 import { subsetTTF } from "./ttf-subsetter.ts";
 import { getArrayBuffer } from "./utf8-to-windows1252-encoder.ts";
 import type { SecurityHandler } from "../crypto/security-handler.ts";
@@ -710,7 +711,10 @@ endstream`;
       this.customFonts.set(name, byStyle);
     }
     if (byStyle.has(style)) return;
-    byStyle.set(style, new TTFParser(data));
+    // A WOFF is the same sfnt behind a small wrapper, so it is unpacked HERE - the one place every
+    // font path meets (a file, raw bytes, a URL, a browser upload) - and TTFParser never learns a
+    // second container format.
+    byStyle.set(style, new TTFParser(isWoff(data) ? woffToSfnt(data) : data));
     this.verticalsCache.delete(name); // this family now answers from the .ttf, not from an AFM
     this.decorationCache.delete(name);
     // Emission (the PDF font objects + page resource) is DEFERRED to first use via ensureEmitted(),

--- a/src/lib/utils/woff.ts
+++ b/src/lib/utils/woff.ts
@@ -1,0 +1,116 @@
+import { inflateBounded } from "./inflate.ts";
+
+/**
+ * WOFF 1.0 -> plain sfnt, so the existing `TTFParser` never learns a second container format.
+ *
+ * A WOFF is not a different FONT, it is a different wrapper: the same sfnt tables, each optionally
+ * zlib-compressed, behind a small header. Unpacking it back into an sfnt is therefore the whole job -
+ * every metric, glyph and cmap path downstream stays exactly as it was.
+ *
+ * WOFF2 is deliberately NOT here: it compresses with Brotli, which `fflate` does not do, and it also
+ * TRANSFORMS the glyf/loca tables rather than merely deflating them. That is a different piece of work,
+ * not a bigger version of this one.
+ */
+
+const SIG_WOFF = 0x774f4646; // "wOFF"
+const HEADER = 44;
+const DIR_ENTRY = 20;
+
+/** One table may not inflate past this. A single sfnt table above 64 MB is not a real font. */
+const MAX_TABLE_BYTES = 64 * 1024 * 1024;
+
+export class WoffError extends Error {
+  constructor(message: string) {
+    super(`@jasy/pdf: ${message}`);
+  }
+}
+
+const be32 = (b: Uint8Array, at: number): number =>
+  ((b[at] << 24) | (b[at + 1] << 16) | (b[at + 2] << 8) | b[at + 3]) >>> 0;
+const be16 = (b: Uint8Array, at: number): number => (b[at] << 8) | b[at + 1];
+
+/** Whether these bytes are a WOFF 1.0 container. Cheap enough to call on every font. */
+export const isWoff = (bytes: Uint8Array): boolean =>
+  bytes.length >= HEADER && be32(bytes, 0) === SIG_WOFF;
+
+/**
+ * Unpack a WOFF into the sfnt it wraps. The result is byte-for-byte what a `.ttf` of the same font
+ * would be, apart from table padding, so nothing downstream can tell the difference.
+ */
+export function woffToSfnt(woff: Uint8Array): Uint8Array {
+  if (!isWoff(woff)) throw new WoffError("these bytes are not a WOFF container");
+
+  const flavor = be32(woff, 4);
+  const numTables = be16(woff, 12);
+  if (numTables === 0) throw new WoffError("this WOFF declares no tables");
+  if (woff.length < HEADER + numTables * DIR_ENTRY) {
+    throw new WoffError("this WOFF is truncated: its table directory does not fit in the file");
+  }
+
+  // Read the directory first, then the tables, so a malformed offset is caught before any allocation.
+  const entries = Array.from({ length: numTables }, (_, i) => {
+    const at = HEADER + i * DIR_ENTRY;
+    return {
+      tag: be32(woff, at),
+      offset: be32(woff, at + 4),
+      compLength: be32(woff, at + 8),
+      origLength: be32(woff, at + 12),
+      checksum: be32(woff, at + 16),
+    };
+  });
+
+  const tables = entries.map((e) => {
+    if (e.offset + e.compLength > woff.length) {
+      throw new WoffError(`this WOFF is truncated: a table runs past the end of the file`);
+    }
+    const raw = woff.subarray(e.offset, e.offset + e.compLength);
+    // Equal lengths mean the table was stored as-is; anything else is zlib, per the spec.
+    if (e.compLength === e.origLength) return raw;
+    let out: Uint8Array;
+    try {
+      out = inflateBounded(raw, MAX_TABLE_BYTES);
+    } catch (err) {
+      throw new WoffError(
+        `a table in this WOFF could not be unpacked: ${String((err as Error)?.message ?? err)}`,
+      );
+    }
+    if (out.length !== e.origLength) {
+      throw new WoffError(
+        `a table in this WOFF unpacked to ${out.length} bytes where it declared ${e.origLength}`,
+      );
+    }
+    return out;
+  });
+
+  // Reassemble: offset table, directory, then the tables each padded to a 4-byte boundary.
+  const padded = (n: number) => (n + 3) & ~3;
+  const dirSize = numTables * 16;
+  const total = 12 + dirSize + tables.reduce((n, t) => n + padded(t.length), 0);
+  const out = new Uint8Array(total);
+  const view = new DataView(out.buffer);
+
+  // The binary-search hints an sfnt offset table carries. Readers may ignore them; a correct file has
+  // them right, and getting them wrong is the classic way a "valid" font is rejected by a strict one.
+  const entrySelector = Math.floor(Math.log2(numTables));
+  const searchRange = 2 ** entrySelector * 16;
+  view.setUint32(0, flavor);
+  view.setUint16(4, numTables);
+  view.setUint16(6, searchRange);
+  view.setUint16(8, entrySelector);
+  view.setUint16(10, numTables * 16 - searchRange);
+
+  let dir = 12;
+  let body = 12 + dirSize;
+  entries.forEach((e, i) => {
+    const data = tables[i];
+    view.setUint32(dir, e.tag);
+    view.setUint32(dir + 4, e.checksum);
+    view.setUint32(dir + 8, body);
+    view.setUint32(dir + 12, data.length); // the DECLARED length excludes the padding
+    out.set(data, body);
+    dir += 16;
+    body += padded(data.length);
+  });
+
+  return out;
+}

--- a/src/lib/utils/woff.ts
+++ b/src/lib/utils/woff.ts
@@ -19,6 +19,13 @@ const DIR_ENTRY = 20;
 /** One table may not inflate past this. A single sfnt table above 64 MB is not a real font. */
 const MAX_TABLE_BYTES = 64 * 1024 * 1024;
 
+/**
+ * And all of them together may not either. The per-table ceiling alone is not a bound: `numTables` is a
+ * uint16, so 65535 directory entries may all point at the SAME small compressed blob, and each would be
+ * inflated and kept. Generous enough for a full CJK face, which is the largest real font there is.
+ */
+const MAX_TOTAL_BYTES = 64 * 1024 * 1024;
+
 export class WoffError extends Error {
   constructor(message: string) {
     super(`@jasy/pdf: ${message}`);
@@ -59,10 +66,23 @@ export function woffToSfnt(woff: Uint8Array): Uint8Array {
     };
   });
 
+  // Tracked across ALL tables, and checked BEFORE each inflate so a hostile directory costs neither the
+  // CPU of unpacking nor the memory of keeping the result.
+  let unpacked = 0;
+  const claim = (bytes: number) => {
+    unpacked += bytes;
+    if (unpacked > MAX_TOTAL_BYTES) {
+      throw new WoffError(
+        `this WOFF unpacks to more than ${MAX_TOTAL_BYTES} bytes in total; no real font is that large`,
+      );
+    }
+  };
+
   const tables = entries.map((e) => {
     if (e.offset + e.compLength > woff.length) {
       throw new WoffError(`this WOFF is truncated: a table runs past the end of the file`);
     }
+    claim(e.origLength); // what it DECLARES, before any work is done on it
     const raw = woff.subarray(e.offset, e.offset + e.compLength);
     // Equal lengths mean the table was stored as-is; anything else is zlib, per the spec.
     if (e.compLength === e.origLength) return raw;

--- a/tests/unit/api/font-url.test.ts
+++ b/tests/unit/api/font-url.test.ts
@@ -77,13 +77,18 @@ describe("it refuses by name, never by failing deep inside the parser", () => {
     // `missing required table "head"`, which tells the user nothing about what they actually linked.
     for (const [tag, expected] of [
       ["OTTO", /OpenType\/CFF/],
-      ["wOFF", /WOFF font/],
       ["wOF2", /WOFF2/],
       ["ttcf", /TrueType Collection/],
     ] as const) {
       stubFetch(() => ok(fontLike(tag)));
       await expect(loadFontFromUrl("https://x.example/f")).rejects.toThrow(expected);
     }
+  });
+
+  it("accepts a WOFF, which is only a wrapper around the same sfnt", async () => {
+    // Not a refusal case any more: the wrapper is unpacked when the font is registered.
+    stubFetch(() => ok(fontLike("wOFF")));
+    await expect(loadFontFromUrl("https://x.example/f.woff")).resolves.toBeInstanceOf(Uint8Array);
   });
 
   it("spots the classic mistake - a URL that returns an error PAGE", async () => {

--- a/tests/unit/utils/inflate.test.ts
+++ b/tests/unit/utils/inflate.test.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_MAX_STREAM_SIZE,
   inflateBounded,
   PdfStreamTooLargeError,
-} from "../../../src/lib/edit/inflate.ts";
+} from "../../../src/lib/utils/inflate.ts";
 import { PdfDocument } from "../../../src/lib/edit/document.ts";
 import { get, isStream } from "../../../src/lib/edit/objects.ts";
 

--- a/tests/unit/utils/woff.test.ts
+++ b/tests/unit/utils/woff.test.ts
@@ -171,6 +171,25 @@ describe("a broken container is named, not parsed into nonsense", () => {
     expect(() => woffToSfnt(woff)).toThrow(/declared 99/);
   });
 
+  it("refuses a directory whose tables add up to more than any real font", () => {
+    // The hole a per-table ceiling does not close. Each table here is 2 MB of zeros - fine on its own,
+    // and it compresses to about a kilobyte, so the FILE stays tiny while the directory promises 66 MB.
+    // That is the actual shape of the attack: cheap to send, ruinous to unpack.
+    const many: Table[] = Array.from({ length: 33 }, (_, i) => ({
+      tag: `t${String(i).padStart(3, "0")}`,
+      data: new Uint8Array(2 * 1024 * 1024),
+    }));
+    const woff = makeWoff(many);
+    expect(woff.length).toBeLessThan(200_000); // a small file...
+    expect(() => woffToSfnt(woff)).toThrow(/more than \d+ bytes in total/); // ...refused all the same
+  });
+
+  it("refuses a single entry that declares more than the whole-font ceiling", () => {
+    const woff = makeWoff(source);
+    new DataView(woff.buffer).setUint32(44 + 12, 200 * 1024 * 1024);
+    expect(() => woffToSfnt(woff)).toThrow(/in total/);
+  });
+
   it("refuses a container with no tables", () => {
     const woff = makeWoff(source);
     new DataView(woff.buffer).setUint16(12, 0);

--- a/tests/unit/utils/woff.test.ts
+++ b/tests/unit/utils/woff.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import { zlibSync } from "fflate";
+import { isWoff, woffToSfnt, WoffError } from "../../../src/lib/utils/woff.ts";
+
+// A WOFF is not a different FONT, it is a different WRAPPER: the same sfnt tables, each optionally
+// zlib-compressed. So the test that matters is a round trip - wrap a known sfnt, unwrap it, and check
+// the tables come back byte for byte.
+//
+// Both halves are built here rather than committed. The only real fonts in this repo live in the
+// gitignored `claude-data/`, so a fixture-based test would fail in a fresh clone.
+
+const be32 = (v: number) => [(v >>> 24) & 255, (v >>> 16) & 255, (v >>> 8) & 255, v & 255];
+const be16 = (v: number) => [(v >>> 8) & 255, v & 255];
+const tagOf = (t: string) =>
+  t.charCodeAt(0) * 2 ** 24 + t.charCodeAt(1) * 65536 + t.charCodeAt(2) * 256 + t.charCodeAt(3);
+const pad4 = (n: number) => (n + 3) & ~3;
+
+interface Table {
+  tag: string;
+  data: Uint8Array;
+}
+
+/** Build a WOFF around the given tables, compressing a table only when that actually shrinks it. */
+function makeWoff(tables: Table[], flavor = 0x00010000): Uint8Array {
+  const bodies = tables.map((t) => {
+    const packed = zlibSync(t.data);
+    return packed.length < t.data.length ? packed : t.data;
+  });
+  const dirSize = tables.length * 20;
+  let offset = 44 + dirSize;
+  const dir: number[] = [];
+  bodies.forEach((body, i) => {
+    dir.push(
+      ...be32(tagOf(tables[i].tag)),
+      ...be32(offset),
+      ...be32(body.length),
+      ...be32(tables[i].data.length),
+      ...be32(0), // checksum - not verified on the way back in
+    );
+    offset += pad4(body.length);
+  });
+
+  const out = new Uint8Array(offset);
+  out.set(
+    [
+      ...be32(0x774f4646), // "wOFF"
+      ...be32(flavor),
+      ...be32(offset),
+      ...be16(tables.length),
+      ...be16(0),
+      ...be32(0), // totalSfntSize - a hint, not used
+      ...be16(1),
+      ...be16(0),
+      ...be32(0),
+      ...be32(0),
+      ...be32(0),
+      ...be32(0),
+      ...be32(0),
+    ],
+    0,
+  );
+  out.set(dir, 44);
+  let at = 44 + dirSize;
+  bodies.forEach((body) => {
+    out.set(body, at);
+    at += pad4(body.length);
+  });
+  return out;
+}
+
+/** Pull the tables back out of an sfnt, so a round trip can be compared table by table. */
+function readSfnt(sfnt: Uint8Array): { flavor: number; tables: Table[] } {
+  const v = new DataView(sfnt.buffer, sfnt.byteOffset, sfnt.byteLength);
+  const num = v.getUint16(4);
+  const tables: Table[] = [];
+  for (let i = 0; i < num; i++) {
+    const at = 12 + i * 16;
+    const tag = String.fromCharCode(...sfnt.subarray(at, at + 4));
+    const off = v.getUint32(at + 8);
+    const len = v.getUint32(at + 12);
+    tables.push({ tag, data: sfnt.subarray(off, off + len) });
+  }
+  return { flavor: v.getUint32(0), tables };
+}
+
+// Tags in ascending order, as both formats require. One table is deliberately incompressible so the
+// "stored, not deflated" branch is exercised too.
+const incompressible = Uint8Array.from({ length: 63 }, (_, i) => (i * 97 + 13) % 256);
+const source: Table[] = [
+  // 161 bytes: deliberately NOT a multiple of four, so the padding below has real work to do. With
+  // only aligned lengths the padding test cannot fail, which is how the first version of it passed
+  // with the padding removed.
+  { tag: "cmap", data: new TextEncoder().encode("cmap".repeat(40) + "!") },
+  { tag: "glyf", data: incompressible },
+  { tag: "head", data: new TextEncoder().encode("head".repeat(30)) },
+];
+
+describe("recognising the container", () => {
+  it("spots a WOFF and leaves anything else alone", () => {
+    expect(isWoff(makeWoff(source))).toBe(true);
+    expect(isWoff(new Uint8Array([0, 1, 0, 0, 0, 0]))).toBe(false); // a plain sfnt
+    expect(isWoff(new Uint8Array([1, 2]))).toBe(false); // too short to ask
+  });
+});
+
+describe("the round trip", () => {
+  it("gives every table back byte for byte", () => {
+    const { tables } = readSfnt(woffToSfnt(makeWoff(source)));
+    expect(tables.map((t) => t.tag)).toEqual(["cmap", "glyf", "head"]);
+    tables.forEach((t, i) => expect(Array.from(t.data)).toEqual(Array.from(source[i].data)));
+  });
+
+  it("handles a table stored uncompressed as well as a deflated one", () => {
+    // `glyf` above is random bytes, so zlib makes it bigger and the writer stores it raw. Both branches
+    // therefore run in the test above - this asserts the raw one really did stay raw.
+    const woff = makeWoff(source);
+    const view = new DataView(woff.buffer);
+    const compLen = view.getUint32(44 + 20 + 8);
+    const origLen = view.getUint32(44 + 20 + 12);
+    expect(compLen).toBe(origLen);
+  });
+
+  it("keeps the sfnt flavour, so a TrueType stays a TrueType", () => {
+    expect(readSfnt(woffToSfnt(makeWoff(source))).flavor).toBe(0x00010000);
+  });
+
+  it("writes the binary-search hints an sfnt offset table carries", () => {
+    // Three tables: entrySelector = floor(log2(3)) = 1, searchRange = 2 * 16 = 32, rangeShift = 16.
+    const sfnt = woffToSfnt(makeWoff(source));
+    const v = new DataView(sfnt.buffer);
+    expect(v.getUint16(4)).toBe(3);
+    expect(v.getUint16(6)).toBe(32);
+    expect(v.getUint16(8)).toBe(1);
+    expect(v.getUint16(10)).toBe(16);
+  });
+
+  it("pads every table to a four-byte boundary, as an sfnt requires", () => {
+    const sfnt = woffToSfnt(makeWoff(source));
+    const v = new DataView(sfnt.buffer);
+    const offsets = [0, 1, 2].map((i) => v.getUint32(12 + i * 16 + 8));
+    const lengths = [0, 1, 2].map((i) => v.getUint32(12 + i * 16 + 12));
+    for (const off of offsets) expect(off % 4).toBe(0);
+    // The DECLARED length stays exact - only the gap to the next table is padded.
+    expect(lengths[0]).toBe(161);
+    expect(offsets[1] - offsets[0]).toBe(164);
+  });
+});
+
+describe("a broken container is named, not parsed into nonsense", () => {
+  it("refuses bytes that are not a WOFF at all", () => {
+    expect(() => woffToSfnt(new Uint8Array(44))).toThrow(WoffError);
+  });
+
+  it("refuses a directory that does not fit in the file", () => {
+    const woff = makeWoff(source);
+    new DataView(woff.buffer).setUint16(12, 4000); // claim 4000 tables
+    expect(() => woffToSfnt(woff)).toThrow(/table directory does not fit/);
+  });
+
+  it("refuses a table that runs past the end", () => {
+    const woff = makeWoff(source);
+    new DataView(woff.buffer).setUint32(44 + 4, 999_999); // first table's offset
+    expect(() => woffToSfnt(woff)).toThrow(/runs past the end/);
+  });
+
+  it("refuses a table that unpacks to the wrong size", () => {
+    // The declared original length is what the sfnt directory will advertise; if the data disagrees,
+    // every offset after it would be wrong and the font would fail far away from the cause.
+    const woff = makeWoff(source);
+    new DataView(woff.buffer).setUint32(44 + 12, 99); // first table's origLength
+    expect(() => woffToSfnt(woff)).toThrow(/declared 99/);
+  });
+
+  it("refuses a container with no tables", () => {
+    const woff = makeWoff(source);
+    new DataView(woff.buffer).setUint16(12, 0);
+    expect(() => woffToSfnt(woff)).toThrow(/declares no tables/);
+  });
+});


### PR DESCRIPTION
## Summary

What the title says! Now you can use WOFF fonts!

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for embedding WOFF font files alongside TTF files.
  * Added validation and conversion for WOFF 1.0 fonts.
* **Bug Fixes**
  * Improved error messages for unsupported font formats.
  * Added safeguards for malformed or oversized font data.
* **Tests**
  * Added coverage for valid WOFF files, compressed tables, format preservation, and malformed inputs.
  * Continued rejecting unsupported WOFF2 and TrueType Collection formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->