### PR TITLE
feat: flexbox (wrap, shrink, flex-basis)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,8 +230,9 @@ rendering. This is the standing visual check; prefer it over one-off `scripts/ru
 - `pnpm test` — Vitest (watch). `pnpm exec vitest run` for a one-shot CI-style run.
   `pnpm run test:coverage` for coverage. Unit tests live in **`tests/unit/`**, mirroring the `src/lib/`
   structure (`tests/unit/{common,elements,renderer,utils}/…`). `src/` is pure production code — the
-  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **929 tests, green**
-  in the core (plus the `@jasy/e-invoice` suite).
+  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **936 tests, green** —
+  what the root run covers: core 839, `@jasy/cli` 37, `@jasy/vue` 33, `@jasy/e-invoice` 27. `@jasy/nuxt`
+  is excluded from it (`vitest.config.ts`) and runs on its own.
 - `pnpm run build` — `tsc` → `dist/`.
 - `pnpm run lint` (oxlint) + `pnpm run fmt:check` (oxfmt `--check`); `pnpm run fmt` formats. **Run `pnpm run fmt`
   before committing** — CI fails on unformatted files.
@@ -257,8 +258,9 @@ rendering. This is the standing visual check; prefer it over one-off `scripts/ru
 - New element = new file in `elements/`, export from `elements/index.ts`, write a renderer in
   `renderer/` that returns `IRNode[]`, **register it in `PDFRenderer.render()`**, export from
   `renderer/index.ts`, add a test under `tests/unit/<group>/` (mirror the source path; import the
-  subject via `../../../src/lib/<group>/<module>.ts` — **with the `.ts` extension**, which `nodenext`
-  requires; without it the module resolves to `any` and a real type error in the test is invisible, see
+  subject via a relative path to `src/lib/<group>/<module>.ts` — count the `../` from the test's OWN
+  depth (`tests/unit/<group>/` needs three, `tests/unit/elements/layout/` four) and **keep the `.ts`
+  extension**, which `nodenext` requires; without it the module resolves to `any` and a real type error in the test is invisible, see
   ISSUE-6). A layout test needs a `FontMetrics`: use `testMetrics()` from `tests/unit/support/metrics.ts`
   rather than a hand-rolled literal, so the object really satisfies the interface instead of being cast
   past it. A new drawable primitive also needs an `IRNode` variant in `ir/display-list.ts` + a `case` in
@@ -523,11 +525,13 @@ agree: true })` → declarative values, not object mutation. Save is an **increm
   candidate membership. Pinned by `tests/unit/api/flex-real-content.test.ts`, which is deliberately NOT
   plain boxes — a `Table`, a wrapping paragraph and a nested `Column` re-measure differently when an
   item is made narrower, and that is where a flex engine actually breaks. Gallery `31-flexbox`.
-- ✅ **Byte-stable output** (verified 2026-08-01) — the same document rendered twice is byte-identical,
-  including a ZUGFeRD invoice, across separate processes. Nothing in the render path reads the clock or a
-  random source (the only `getRandomValues` is in the encryption path, which PDF/A forbids anyway); we
-  write no `/CreationDate`/`/ModDate`; and the trailer `/ID` PDF/A requires is `contentId()`, an MD5 over
-  the objects. This is what makes an archived or audited e-invoice re-derivable and hashable years later.
+- ✅ **Byte-stable output, UNENCRYPTED** (verified 2026-08-01) — the same document rendered twice is
+  byte-identical, PDF/A and a ZUGFeRD invoice included, across separate processes. Nothing on that path
+  reads the clock or a random source; we write no `/CreationDate`/`/ModDate`; and the trailer `/ID` PDF/A
+  requires is `contentId()`, an MD5 over the objects. **`renderToBytes(doc, { encrypt })` is excluded and
+  cannot be otherwise**: R6 draws random salts and a random file key, and every stream gets a fresh IV, so
+  two renders of the same document differ by design (measured). Encryption and PDF/A are mutually
+  exclusive anyway, so the archival case never meets it. This is what makes an archived or audited e-invoice re-derivable and hashable years later.
   `packages/e-invoice/tests/determinism.test.ts` pins it, with a counter-test that a changed invoice
   number DOES change the bytes so the check cannot pass vacuously. The honest limit: byte-stable per
   library VERSION — a bump may legitimately change output, as turning kerning on did.
@@ -608,7 +612,8 @@ below), `@jasy/cli`@alpha.6, `@jasy/vue`@alpha.7, `@jasy/nuxt`@alpha.6** (the al
 page-break control — the termination guard, `PageBreak`, `breakBefore`/`breakAfter`, `keepTogether` — plus
 kerning turned on by default). Repo public + locked, full CI + changelog +
 bots in place (see Repo facts). The engine is **feature-complete for the alpha** — inheritance, `onOverflow`,
-custom formats, the line-breaker fixes; **929 tests green**. The **landing**
+custom formats, the line-breaker fixes; **936 tests green** (the root run, i.e. everything but
+`@jasy/nuxt`). The **landing**
 (`~/projects/jasy-landing` → **jasy.dev**) is built: showroom (12 cards), validator, docs, a home-page
 roadmap section, and a full **SEO + AI-discoverability layer** (OG image, JSON-LD, `robots.txt`,
 `llms.txt`, `sitemap.xml`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,7 @@ rendering. This is the standing visual check; prefer it over one-off `scripts/ru
 - `pnpm test` — Vitest (watch). `pnpm exec vitest run` for a one-shot CI-style run.
   `pnpm run test:coverage` for coverage. Unit tests live in **`tests/unit/`**, mirroring the `src/lib/`
   structure (`tests/unit/{common,elements,renderer,utils}/…`). `src/` is pure production code — the
-  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **512 tests, green**
+  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **929 tests, green**
   in the core (plus the `@jasy/e-invoice` suite).
 - `pnpm run build` — `tsc` → `dist/`.
 - `pnpm run lint` (oxlint) + `pnpm run fmt:check` (oxfmt `--check`); `pnpm run fmt` formats. **Run `pnpm run fmt`
@@ -257,8 +257,12 @@ rendering. This is the standing visual check; prefer it over one-off `scripts/ru
 - New element = new file in `elements/`, export from `elements/index.ts`, write a renderer in
   `renderer/` that returns `IRNode[]`, **register it in `PDFRenderer.render()`**, export from
   `renderer/index.ts`, add a test under `tests/unit/<group>/` (mirror the source path; import the
-  subject via `../../../src/lib/<group>/<module>`). A new drawable primitive also needs an `IRNode`
-  variant in `ir/display-list.ts` + a `case` in `PdfBackend.serializeNode`.
+  subject via `../../../src/lib/<group>/<module>.ts` — **with the `.ts` extension**, which `nodenext`
+  requires; without it the module resolves to `any` and a real type error in the test is invisible, see
+  ISSUE-6). A layout test needs a `FontMetrics`: use `testMetrics()` from `tests/unit/support/metrics.ts`
+  rather than a hand-rolled literal, so the object really satisfies the interface instead of being cast
+  past it. A new drawable primitive also needs an `IRNode` variant in `ir/display-list.ts` + a `case` in
+  `PdfBackend.serializeNode`.
 - Units are PDF points (1/72"). Page formats in `constants/page-sizes.ts`.
 
 ## What's built, and the genuine gaps
@@ -504,6 +508,29 @@ agree: true })` → declarative values, not object mutation. Save is an **increm
   of 4". Nearly free because Pass A of the page driver already walks one logical page at a time - the
   length of each run IS that section's total. The provisional `PageInfo` used during pagination carries
   them too, or a `PageBuilder` would measure against a half-filled object.
+- ✅ **Full flexbox** (2026-08-01) — `wrap` + `alignContent`, `flexShrink`, `flexBasis` (points or `%`),
+  `order`, `reverse` on `Row`/`Column`. This closes the last react-pdf parity gap in layout (Yoga gives
+  them that set for free). `FlexLayoutHelper.layout()` now dispatches: the untouched single-line engine
+  is `layoutLine()`, and `layoutWrapped()` splits into lines, measures each, then places the BLOCK of
+  lines by `alignContent`. Two defaults deviate from CSS ON PURPOSE — `flexShrink` is **0** (CSS says 1)
+  so no existing layout moves, and `alignContent` is `start`. All of it is off by default, which is why
+  the 30 gallery cases before it stayed byte-identical.
+  **The trap that cost a real bug:** a line's `%` children resolve against **the line minus its gaps**
+  (our documented relative-sizing rule, so N columns at (100/N)% fit exactly). The wrap pass has to use
+  the SAME base — it first measured against the full line, making each child a few points too wide, and
+  three chips at 33% wrapped the third for no reason. A line cannot be measured child by child: whether
+  a child fits depends on how many gaps the line ends up with, so `lineExtent()` re-costs the whole
+  candidate membership. Pinned by `tests/unit/api/flex-real-content.test.ts`, which is deliberately NOT
+  plain boxes — a `Table`, a wrapping paragraph and a nested `Column` re-measure differently when an
+  item is made narrower, and that is where a flex engine actually breaks. Gallery `31-flexbox`.
+- ✅ **Byte-stable output** (verified 2026-08-01) — the same document rendered twice is byte-identical,
+  including a ZUGFeRD invoice, across separate processes. Nothing in the render path reads the clock or a
+  random source (the only `getRandomValues` is in the encryption path, which PDF/A forbids anyway); we
+  write no `/CreationDate`/`/ModDate`; and the trailer `/ID` PDF/A requires is `contentId()`, an MD5 over
+  the objects. This is what makes an archived or audited e-invoice re-derivable and hashable years later.
+  `packages/e-invoice/tests/determinism.test.ts` pins it, with a counter-test that a changed invoice
+  number DOES change the bytes so the check cannot pass vacuously. The honest limit: byte-stable per
+  library VERSION — a bump may legitimately change output, as turning kerning on did.
 
 Genuine remaining gaps / deferred:
 
@@ -561,12 +588,12 @@ Genuine remaining gaps / deferred:
    industry norm so indexers can read it), so in accessible mode the document TITLE is readable without
    the password. A switch for people who want everything hidden is not built.
 8. **The test tree is not type-checked** (`todo.md` ISSUE-6, MEDIUM). `tsconfig.json` compiles only `src/**`
-   and CI runs vitest, never tsc over `tests/**`; `tsc --noEmit -p tsconfig.test.json` reports ~420 errors.
+   and CI runs vitest, never tsc over `tests/**`; `tsc --noEmit -p tsconfig.test.json` reports 384 errors.
    Dominant cause: tests import without the `.ts` extension, which `nodenext` rejects — the module then
    resolves to `any`, so a REAL type error in a test cannot be seen. `tests/unit/edit/` is already fixed
    (extensions added; the guards in `edit/objects.ts` widened to `PdfObject | undefined`, since they are
-   nearly always applied to a lookup that may find nothing). The rest are not, and the CLAUDE.md test
-   convention below still documents the extensionless form.
+   nearly always applied to a lookup that may find nothing), as are the `support/metrics` imports. The
+   rest are not; the convention above now documents the extension, so new tests stop adding to the pile.
 
 ## Roadmap
 
@@ -581,7 +608,7 @@ below), `@jasy/cli`@alpha.6, `@jasy/vue`@alpha.7, `@jasy/nuxt`@alpha.6** (the al
 page-break control — the termination guard, `PageBreak`, `breakBefore`/`breakAfter`, `keepTogether` — plus
 kerning turned on by default). Repo public + locked, full CI + changelog +
 bots in place (see Repo facts). The engine is **feature-complete for the alpha** — inheritance, `onOverflow`,
-custom formats, the line-breaker fixes; **582 tests green**. The **landing**
+custom formats, the line-breaker fixes; **929 tests green**. The **landing**
 (`~/projects/jasy-landing` → **jasy.dev**) is built: showroom (12 cards), validator, docs, a home-page
 roadmap section, and a full **SEO + AI-discoverability layer** (OG image, JSON-LD, `robots.txt`,
 `llms.txt`, `sitemap.xml`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,6 +484,27 @@ agree: true })` → declarative values, not object mutation. Save is an **increm
   it grows. It costs nothing because a stream too small to reach the ceiling at DEFLATE's maximum expansion
   (1032:1) skips the check - which is nearly every stream in a real PDF.
 
+- ✅ **Fonts from a URL, and WOFF1** (2026-08-01) — `await doc.addFontFromUrl("Inter", url)`, one file or
+  a styled family (fetched in parallel). It resolves AT REGISTRATION, exactly as `addFont` reads a path
+  there and then, so a dead link fails on the line that asked for the font rather than inside a later
+  render. Guarded like any other network read: a 15 s timeout, a 32 MB ceiling enforced WHILE the body
+  arrives (`Content-Length` is only a hint), and every failure wrapped as `FontUrlError`.
+  It also names what a file actually IS - `TTFParser` never looks at the sfnt signature, so a 404 HTML
+  page used to fail deep inside as `missing required table "head"`.
+  **WOFF1** is unpacked at the ONE point every font path meets, `PDFObjectManager.registerCustomFont`'s
+  `new TTFParser(...)` - so a file, raw bytes, a URL and a browser upload all get it, and nothing
+  downstream learns a second container format (`utils/woff.ts`). A WOFF is not a different font, it is
+  the same sfnt tables optionally zlib-compressed behind a 44-byte header. Verified by wrapping a real
+  Lato `.ttf` into a WOFF and rendering both: identical glyph output, identical subset size (41,540 B),
+  identical PDF. `utils/inflate.ts` moved out of `edit/` for this - the generate path must not import
+  from the edit path, and the zip-bomb ceiling now guards a WOFF table too.
+- ✅ **Section page numbers** (2026-08-01) — `subPageNumber` / `subPageTotalPages` on `PageInfo`, plus
+  `SubPageNumber()` / `SubPageCount()` sugar. The count WITHIN one logical `Page` element, beside the
+  document-wide one: an invoice plus its attachment can foot "Attachment, page 1 of 2" next to "sheet 3
+  of 4". Nearly free because Pass A of the page driver already walks one logical page at a time - the
+  length of each run IS that section's total. The provisional `PageInfo` used during pagination carries
+  them too, or a `PageBuilder` would measure against a half-filled object.
+
 Genuine remaining gaps / deferred:
 
 1. **Absolute positioning — Stages 1+2 built** (2026-06-21). CSS-style: `Box({ relative: true })` is a
@@ -511,8 +532,10 @@ Genuine remaining gaps / deferred:
    DONE too: `platform/browser-image.ts` decodes via OffscreenCanvas (transparency → `/SMask`), swapped for the
    jimp path by the `browser` field. Nice-to-haves left: compact-AFM (size), `addFontFromUrl()`. See todo.md.
 4. `manual-test` has hard-coded machine-specific paths.
-5. Font gaps: only TTF / TrueType-flavoured OTF parsed (OTF/CFF, WOFF2 not yet). (TrueType kerning is DONE -
-   `kern` table + GPOS, on by default since 2026-07-11; this line used to claim otherwise.)
+5. Font gaps: TTF / TrueType-flavoured OTF **and WOFF1** are parsed; OTF/CFF and **WOFF2** are not.
+   WOFF2 needs Brotli (which `fflate` does not do) and additionally TRANSFORMS `glyf`/`loca` rather than
+   merely deflating them - a different piece of work, not a bigger version of WOFF1. (TrueType kerning is
+   DONE - `kern` table + GPOS, on by default since 2026-07-11; this line used to claim otherwise.)
    Bold/italic resolve via registered family variants with a clean fallback to `normal` (no faux styles).
    Color-emoji deferred (none blocking): COLR v1 **rotate/skew** transforms (24-31 —
    Noto doesn't use them; not built without a test font), variable-font paint variants, **sweep** gradient,

--- a/packages/e-invoice/tests/determinism.test.ts
+++ b/packages/e-invoice/tests/determinism.test.ts
@@ -41,10 +41,19 @@ const invoice: Invoice = {
 
 const sha = (b: Uint8Array) => createHash("sha256").update(b).digest("hex");
 
+/** The first offset at which two renders differ, or -1. A hash says only THAT they differ. */
+const firstDifference = (a: Uint8Array, b: Uint8Array): number => {
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) if (a[i] !== b[i]) return i;
+  return a.length === b.length ? -1 : n;
+};
+
 describe("re-rendering the same invoice", () => {
   it("produces byte-identical PDF and XML", async () => {
     const a = await renderZugferd(invoice);
     const b = await renderZugferd(invoice);
+    expect(firstDifference(a.bytes, b.bytes)).toBe(-1);
+    expect(b.bytes.length).toBe(a.bytes.length);
     expect(sha(b.bytes)).toBe(sha(a.bytes));
     expect(b.xml).toBe(a.xml);
   });
@@ -62,7 +71,14 @@ describe("re-rendering the same invoice", () => {
     );
     expect(ids).not.toBeNull();
     expect(ids![1]).toBe(ids![2]); // a fresh document uses one hash for both strings
+    const firstId = (bytes: Uint8Array) =>
+      /\/ID \[<([0-9A-F]+)>/.exec(Buffer.from(bytes).toString("latin1"))![1];
+
     const b = await renderZugferd(invoice);
-    expect(/\/ID \[<([0-9A-F]+)>/.exec(Buffer.from(b.bytes).toString("latin1"))![1]).toBe(ids![1]);
+    expect(firstId(b.bytes)).toBe(ids![1]);
+
+    // ... and it tracks the CONTENT, or an unchanged ID would prove nothing about a changed document.
+    const other = await renderZugferd({ ...invoice, number: "RE-2026-002" });
+    expect(firstId(other.bytes)).not.toBe(ids![1]);
   });
 });

--- a/packages/e-invoice/tests/determinism.test.ts
+++ b/packages/e-invoice/tests/determinism.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { createHash } from "node:crypto";
+import { renderZugferd } from "../src/render";
+import { Invoice } from "../src/invoice";
+
+// An archived or audited invoice gets re-rendered years later - from the same data, by the same
+// version. If the two files differ, every downstream hash, signature and diff is worthless. Nothing
+// in the render path may therefore come from the clock, a random source or iteration order.
+
+const invoice: Invoice = {
+  number: "RE-2026-001",
+  issueDate: "2026-06-17",
+  currency: "EUR",
+  dueDate: "2026-07-01",
+  buyerReference: "04011000-12345-34",
+  seller: {
+    name: "Muster GmbH",
+    vatId: "DE123456789",
+    electronicAddress: "rechnung@muster.de",
+    address: { line1: "Hauptstr. 1", city: "Berlin", postCode: "10115", country: "DE" },
+  },
+  buyer: { name: "Kunde AG", address: { city: "München", postCode: "80331", country: "DE" } },
+  lines: [
+    {
+      name: "Webdesign",
+      quantity: 2,
+      unit: "C62",
+      netUnitPrice: 100,
+      vat: { category: "S", ratePercent: 19 },
+    },
+    {
+      name: "Hosting",
+      quantity: 1,
+      unit: "C62",
+      netUnitPrice: 50,
+      vat: { category: "S", ratePercent: 7 },
+    },
+  ],
+  payment: { iban: "DE02120300000000202051", bic: "BYLADEM1001" },
+};
+
+const sha = (b: Uint8Array) => createHash("sha256").update(b).digest("hex");
+
+describe("re-rendering the same invoice", () => {
+  it("produces byte-identical PDF and XML", async () => {
+    const a = await renderZugferd(invoice);
+    const b = await renderZugferd(invoice);
+    expect(sha(b.bytes)).toBe(sha(a.bytes));
+    expect(b.xml).toBe(a.xml);
+  });
+
+  it("changes the bytes when the invoice changes, so the hash is not merely constant", async () => {
+    const a = await renderZugferd(invoice);
+    const b = await renderZugferd({ ...invoice, number: "RE-2026-002" });
+    expect(sha(b.bytes)).not.toBe(sha(a.bytes));
+  });
+
+  it("gives the trailer /ID as a content hash, equal across renders", async () => {
+    const a = await renderZugferd(invoice);
+    const ids = /\/ID \[<([0-9A-F]+)> <([0-9A-F]+)>\]/.exec(
+      Buffer.from(a.bytes).toString("latin1"),
+    );
+    expect(ids).not.toBeNull();
+    expect(ids![1]).toBe(ids![2]); // a fresh document uses one hash for both strings
+    const b = await renderZugferd(invoice);
+    expect(/\/ID \[<([0-9A-F]+)>/.exec(Buffer.from(b.bytes).toString("latin1"))![1]).toBe(ids![1]);
+  });
+});

--- a/src/lib/api/content.ts
+++ b/src/lib/api/content.ts
@@ -111,5 +111,6 @@ export function Image(src: ImageSource, opts: ImageOptions = {}): ImageElement {
     alt: opts.alt,
   })
     .withAlignSelf(opts.alignSelf)
-    .withOrder(opts.order);
+    .withOrder(opts.order)
+    .withFlexShrink(opts.flexShrink);
 }

--- a/src/lib/api/content.ts
+++ b/src/lib/api/content.ts
@@ -109,5 +109,7 @@ export function Image(src: ImageSource, opts: ImageOptions = {}): ImageElement {
     fit,
     radius: opts.radius !== undefined ? toRadius(opts.radius) : undefined,
     alt: opts.alt,
-  }).withAlignSelf(opts.alignSelf);
+  })
+    .withAlignSelf(opts.alignSelf)
+    .withOrder(opts.order);
 }

--- a/src/lib/api/dimension.ts
+++ b/src/lib/api/dimension.ts
@@ -42,6 +42,12 @@ export interface BoundsInput {
    * has no natural cross size to align.
    */
   alignSelf?: CrossAlign;
+  /**
+   * Where this child sits among its siblings (CSS `order`), lowest first, source order deciding ties.
+   * It moves the child in the LAYOUT only - the element tree is untouched, so a tagged PDF still
+   * exposes the source reading order. Default 0.
+   */
+  order?: number;
   minWidth?: SizeInput;
   maxWidth?: SizeInput;
   minHeight?: SizeInput;

--- a/src/lib/api/dimension.ts
+++ b/src/lib/api/dimension.ts
@@ -48,6 +48,12 @@ export interface BoundsInput {
    * exposes the source reading order. Default 0.
    */
   order?: number;
+  /**
+   * How willingly this child gives up main-axis space when the line overflows (CSS `flex-shrink`),
+   * weighted by its own size. **Default 0, deliberately unlike CSS's 1** - shrinking changes what a
+   * document looks like, so it is opted into per child rather than applied to everything at once.
+   */
+  flexShrink?: number;
   minWidth?: SizeInput;
   maxWidth?: SizeInput;
   minHeight?: SizeInput;

--- a/src/lib/api/layout.ts
+++ b/src/lib/api/layout.ts
@@ -48,6 +48,8 @@ export interface StackOptions extends BoundsInput {
   /** Try to keep this stack on one page (CSS `break-inside: avoid`). If it does not fit here but would
    *  fit on a fresh page, it moves there whole; if it is taller than a whole page, it splits anyway. */
   keepTogether?: boolean;
+  /** Lay the children out backwards along the axis (CSS `row-reverse` / `column-reverse`). */
+  reverse?: boolean;
 }
 
 /** Splits `StackOptions` width/height into the fixed points + fraction the stack elements expect. */
@@ -81,6 +83,7 @@ export function Column(a: StackOptions | PDFElement[], b?: PDFElement[]): PDFEle
       gap: opts.gap,
       main: opts.justify, // undefined → engine default `start` (matches §5)
       cross: opts.align ?? DEFAULT_CROSS,
+      reverse: opts.reverse,
       breakBefore: opts.breakBefore,
       breakAfter: opts.breakAfter,
       ...stackSize(opts),
@@ -100,6 +103,7 @@ export function Row(a: StackOptions | PDFElement[], b?: PDFElement[]): PDFElemen
       gap: opts.gap,
       main: opts.justify,
       cross: opts.align ?? DEFAULT_CROSS,
+      reverse: opts.reverse,
       breakBefore: opts.breakBefore,
       breakAfter: opts.breakAfter,
       ...stackSize(opts),
@@ -110,12 +114,12 @@ export function Row(a: StackOptions | PDFElement[], b?: PDFElement[]): PDFElemen
 /** Wraps `element` in a `keepTogether` group when the `keepTogether` option is set; otherwise returns it
  *  unchanged (byte-identical). Shared by the `Box`/`Column`/`Row` prop shortcut. */
 function maybeKeepTogether(
-  opts: { keepTogether?: boolean; alignSelf?: CrossAlign },
+  opts: { keepTogether?: boolean; alignSelf?: CrossAlign; order?: number },
   element: PDFElement,
 ): PDFElement {
-  // alignSelf goes on the OUTERMOST element - that is the one the surrounding stack places.
+  // alignSelf and order go on the OUTERMOST element - that is the one the surrounding stack places.
   const wrapped = opts.keepTogether ? new KeepTogetherElement({ child: element }) : element;
-  return wrapped.withAlignSelf(opts.alignSelf);
+  return wrapped.withAlignSelf(opts.alignSelf).withOrder(opts.order);
 }
 
 /**

--- a/src/lib/api/layout.ts
+++ b/src/lib/api/layout.ts
@@ -341,6 +341,12 @@ export function PageBreak(): PageBreakElement {
 export interface ExpandedOptions {
   /** Share of the leftover space vs other flex children (default 1). */
   flex?: number;
+  /**
+   * Main-axis size reserved BEFORE the leftover is shared out (CSS `flex-basis`): points, or a
+   * percentage of what the line offers its items. The child ends up with `basis + its share of the
+   * rest`, so `flexBasis: 120` with `flex: 0` is simply a fixed 120pt slot. Default 0.
+   */
+  flexBasis?: SizeInput;
 }
 
 /**
@@ -353,5 +359,11 @@ export function Expanded(a: ExpandedOptions | PDFElement, b?: PDFElement): Expan
   const isOptsForm = b !== undefined;
   const opts = (isOptsForm ? a : {}) as ExpandedOptions;
   const child = (isOptsForm ? b : a) as PDFElement;
-  return new ExpandedElement({ flex: opts.flex ?? 1, child });
+  const basis = opts.flexBasis !== undefined ? toDimension(opts.flexBasis) : undefined;
+  return new ExpandedElement({
+    flex: opts.flex ?? 1,
+    basis: basis?.points,
+    basisFactor: basis?.factor,
+    child,
+  });
 }

--- a/src/lib/api/layout.ts
+++ b/src/lib/api/layout.ts
@@ -50,6 +50,11 @@ export interface StackOptions extends BoundsInput {
   keepTogether?: boolean;
   /** Lay the children out backwards along the axis (CSS `row-reverse` / `column-reverse`). */
   reverse?: boolean;
+  /** Let the children flow onto further lines when they do not fit (CSS `flex-wrap: wrap`). The `gap`
+   *  is used BETWEEN the lines as well as between the items. */
+  wrap?: boolean;
+  /** How the block of wrapped lines sits across the axis (CSS `align-content`). Default `start`. */
+  alignContent?: MainAlign;
 }
 
 /** Splits `StackOptions` width/height into the fixed points + fraction the stack elements expect. */
@@ -84,6 +89,8 @@ export function Column(a: StackOptions | PDFElement[], b?: PDFElement[]): PDFEle
       main: opts.justify, // undefined → engine default `start` (matches §5)
       cross: opts.align ?? DEFAULT_CROSS,
       reverse: opts.reverse,
+      wrap: opts.wrap,
+      alignContent: opts.alignContent,
       breakBefore: opts.breakBefore,
       breakAfter: opts.breakAfter,
       ...stackSize(opts),
@@ -104,6 +111,8 @@ export function Row(a: StackOptions | PDFElement[], b?: PDFElement[]): PDFElemen
       main: opts.justify,
       cross: opts.align ?? DEFAULT_CROSS,
       reverse: opts.reverse,
+      wrap: opts.wrap,
+      alignContent: opts.alignContent,
       breakBefore: opts.breakBefore,
       breakAfter: opts.breakAfter,
       ...stackSize(opts),

--- a/src/lib/api/layout.ts
+++ b/src/lib/api/layout.ts
@@ -114,12 +114,15 @@ export function Row(a: StackOptions | PDFElement[], b?: PDFElement[]): PDFElemen
 /** Wraps `element` in a `keepTogether` group when the `keepTogether` option is set; otherwise returns it
  *  unchanged (byte-identical). Shared by the `Box`/`Column`/`Row` prop shortcut. */
 function maybeKeepTogether(
-  opts: { keepTogether?: boolean; alignSelf?: CrossAlign; order?: number },
+  opts: { keepTogether?: boolean; alignSelf?: CrossAlign; order?: number; flexShrink?: number },
   element: PDFElement,
 ): PDFElement {
   // alignSelf and order go on the OUTERMOST element - that is the one the surrounding stack places.
   const wrapped = opts.keepTogether ? new KeepTogetherElement({ child: element }) : element;
-  return wrapped.withAlignSelf(opts.alignSelf).withOrder(opts.order);
+  return wrapped
+    .withAlignSelf(opts.alignSelf)
+    .withOrder(opts.order)
+    .withFlexShrink(opts.flexShrink);
 }
 
 /**

--- a/src/lib/elements/container-element.ts
+++ b/src/lib/elements/container-element.ts
@@ -31,6 +31,10 @@ interface ContainerElementParams extends SizedElement, WithChildren {
   cross?: CrossAlign;
   /** Lay the children out backwards along the main axis (CSS `row-reverse`). */
   reverse?: boolean;
+  /** Let the children flow onto further lines when they do not fit (CSS `flex-wrap`). */
+  wrap?: boolean;
+  /** How the block of wrapped lines sits across the axis (CSS `align-content`). */
+  alignContent?: MainAlign;
   /** Width/height as a fraction (0..1) of the offered box instead of `width`/`height` (relative sizing). */
   widthFactor?: number;
   heightFactor?: number;
@@ -57,6 +61,8 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
   private main: MainAlign;
   private cross: CrossAlign;
   private reverse: boolean;
+  private wrap: boolean;
+  private alignContent?: MainAlign;
   private breakBefore: boolean;
   private breakAfter: boolean;
   // The requested size, snapshot at construction so re-layouts (fragmentation measuring, which
@@ -73,6 +79,8 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
     main,
     cross,
     reverse,
+    wrap,
+    alignContent,
     breakBefore,
     breakAfter,
     ...sizing
@@ -84,6 +92,8 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
     this.main = main ?? "start";
     this.cross = cross ?? "stretch";
     this.reverse = reverse ?? false;
+    this.wrap = wrap ?? false;
+    this.alignContent = alignContent;
     this.requested = { ...sizing, width, height };
     this.breakBefore = breakBefore ?? false;
     this.breakAfter = breakAfter ?? false;
@@ -149,6 +159,8 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
       main: this.main,
       cross: this.cross,
       reverse: this.reverse,
+      wrap: this.wrap,
+      alignContent: this.alignContent,
       breakAfter,
     });
   }
@@ -221,7 +233,14 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
         crossAvail,
         this.y,
         this.x,
-        { gap: this.gap, main: this.main, cross: this.cross, reverse: this.reverse },
+        {
+          gap: this.gap,
+          main: this.main,
+          cross: this.cross,
+          reverse: this.reverse,
+          wrap: this.wrap,
+          alignContent: this.alignContent,
+        },
         ctx,
       );
     }

--- a/src/lib/elements/container-element.ts
+++ b/src/lib/elements/container-element.ts
@@ -29,6 +29,8 @@ interface ContainerElementParams extends SizedElement, WithChildren {
   main?: MainAlign;
   /** Horizontal alignment of each child (cross axis); defaults to `stretch`. */
   cross?: CrossAlign;
+  /** Lay the children out backwards along the main axis (CSS `row-reverse`). */
+  reverse?: boolean;
   /** Width/height as a fraction (0..1) of the offered box instead of `width`/`height` (relative sizing). */
   widthFactor?: number;
   heightFactor?: number;
@@ -54,6 +56,7 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
   private gap: number;
   private main: MainAlign;
   private cross: CrossAlign;
+  private reverse: boolean;
   private breakBefore: boolean;
   private breakAfter: boolean;
   // The requested size, snapshot at construction so re-layouts (fragmentation measuring, which
@@ -69,6 +72,7 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
     gap,
     main,
     cross,
+    reverse,
     breakBefore,
     breakAfter,
     ...sizing
@@ -79,6 +83,7 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
     this.gap = gap ?? 0;
     this.main = main ?? "start";
     this.cross = cross ?? "stretch";
+    this.reverse = reverse ?? false;
     this.requested = { ...sizing, width, height };
     this.breakBefore = breakBefore ?? false;
     this.breakAfter = breakAfter ?? false;
@@ -143,6 +148,7 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
       gap: this.gap,
       main: this.main,
       cross: this.cross,
+      reverse: this.reverse,
       breakAfter,
     });
   }
@@ -215,7 +221,7 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
         crossAvail,
         this.y,
         this.x,
-        { gap: this.gap, main: this.main, cross: this.cross },
+        { gap: this.gap, main: this.main, cross: this.cross, reverse: this.reverse },
         ctx,
       );
     }

--- a/src/lib/elements/layout/expanded-element.ts
+++ b/src/lib/elements/layout/expanded-element.ts
@@ -18,8 +18,8 @@ export class ExpandedElement extends FlexiblePDFElement implements Fragmentable 
   private width: number = 0;
   private height: number = 0;
 
-  constructor({ flex, child }: ExpandedElementParams) {
-    super({ flex });
+  constructor({ flex, basis, basisFactor, child }: ExpandedElementParams) {
+    super({ flex, basis, basisFactor });
 
     this.child = child;
   }

--- a/src/lib/elements/layout/expanded-element.ts
+++ b/src/lib/elements/layout/expanded-element.ts
@@ -74,7 +74,14 @@ export class ExpandedElement extends FlexiblePDFElement implements Fragmentable 
   }
 
   private cloneWithChild(child: PDFElement): ExpandedElement {
-    return new ExpandedElement({ flex: this.flex, child });
+    // The basis has to come along: a fragment that lost it would claim only its share of the leftover,
+    // so a `flexBasis` slot would silently change width on the page it continues onto.
+    return new ExpandedElement({
+      flex: this.flex,
+      basis: this.basis,
+      basisFactor: this.basisFactor,
+      child,
+    });
   }
 
   override getProps() {
@@ -83,6 +90,8 @@ export class ExpandedElement extends FlexiblePDFElement implements Fragmentable 
       y: this.y,
       width: this.width,
       height: this.height,
+      basis: this.basis,
+      basisFactor: this.basisFactor,
       child: this.child,
     };
   }

--- a/src/lib/elements/pdf-element.ts
+++ b/src/lib/elements/pdf-element.ts
@@ -170,6 +170,25 @@ export abstract class PDFElement {
    */
   order = 0;
 
+  /**
+   * How willingly this child gives up main-axis space when the line overflows (CSS `flex-shrink`),
+   * weighted by its own size as CSS does. **Default 0, deliberately unlike CSS's 1**: shrinking is a
+   * change of what a document LOOKS like, and every document written before this existed must keep
+   * laying out exactly as it did. Opt in per child.
+   */
+  flexShrink = 0;
+
+  /** Sets `flexShrink` and returns the element. */
+  withFlexShrink(shrink: number | undefined): this {
+    if (shrink !== undefined) {
+      if (!Number.isFinite(shrink) || shrink < 0) {
+        throw new Error(`Invalid flexShrink ${shrink}: it must be a number of at least 0.`);
+      }
+      this.flexShrink = shrink;
+    }
+    return this;
+  }
+
   /** Sets `order` and returns the element, so a factory can thread it through in one expression. */
   withOrder(order: number | undefined): this {
     if (order !== undefined) {

--- a/src/lib/elements/pdf-element.ts
+++ b/src/lib/elements/pdf-element.ts
@@ -162,6 +162,22 @@ export abstract class PDFElement {
     if (align !== undefined) this.alignSelf = align;
     return this;
   }
+
+  /**
+   * Where this child sits among its siblings (CSS `order`), lowest first, source order deciding ties.
+   * It moves the child in the LAYOUT only - the element tree, and therefore the reading order a tagged
+   * PDF exposes, is untouched. Default 0.
+   */
+  order = 0;
+
+  /** Sets `order` and returns the element, so a factory can thread it through in one expression. */
+  withOrder(order: number | undefined): this {
+    if (order !== undefined) {
+      if (!Number.isFinite(order)) throw new Error(`Invalid order ${order}: it must be a number.`);
+      this.order = order;
+    }
+    return this;
+  }
 }
 
 export abstract class SizedPDFElement extends PDFElement {

--- a/src/lib/elements/pdf-element.ts
+++ b/src/lib/elements/pdf-element.ts
@@ -202,15 +202,40 @@ export abstract class SizedPDFElement extends PDFElement {
 export abstract class FlexiblePDFElement extends PDFElement {
   protected flex: number;
   protected verticalChildAlignment: VerticalAlignment;
+  /** Points reserved before any leftover is shared out (CSS `flex-basis`); default 0. */
+  protected basis: number;
+  /** The same as a fraction of the line, for `flexBasis: "25%"`. */
+  protected basisFactor?: number;
 
   constructor(data: FlexibleElement) {
     super();
     this.flex = data.flex;
     this.verticalChildAlignment = data.verticalChildAlignment || VerticalAlignment.middle;
+    this.basis = data.basis ?? 0;
+    this.basisFactor = data.basisFactor;
   }
 
   getFlex(): number {
     return this.flex;
+  }
+
+  /**
+   * The main extent this child starts from, before the leftover is shared out. `lineMain` is what the
+   * line offers its items (its extent minus the gaps), so a percentage basis resolves against the same
+   * base a percentage WIDTH already does - and falls back to 0 on an unbounded axis, where a fraction
+   * has no meaning.
+   */
+  /** Whether a PERCENTAGE basis was given - it resolves to 0 on an unbounded axis, so asking for the
+   *  number alone cannot tell "no basis" from "a basis that does not apply here". */
+  hasBasisFactor(): boolean {
+    return this.basisFactor !== undefined;
+  }
+
+  getBasis(lineMain: number): number {
+    if (this.basisFactor !== undefined) {
+      return Number.isFinite(lineMain) ? lineMain * this.basisFactor : 0;
+    }
+    return this.basis;
   }
 }
 
@@ -237,6 +262,10 @@ export interface WithChild {
 
 export interface FlexibleElement {
   flex: number;
+  /** Points reserved before the leftover is shared out (CSS `flex-basis`). */
+  basis?: number;
+  /** The same as a fraction of the line, for `flexBasis: "25%"`. */
+  basisFactor?: number;
   verticalChildAlignment?: VerticalAlignment;
 }
 

--- a/src/lib/elements/row-element.ts
+++ b/src/lib/elements/row-element.ts
@@ -22,6 +22,8 @@ interface RowElementParams extends WithChildren {
   main?: MainAlign;
   /** Vertical alignment of each child (cross axis); defaults to `stretch`. */
   cross?: CrossAlign;
+  /** Lay the children out backwards along the main axis (CSS `row-reverse`). */
+  reverse?: boolean;
   /** Width/height as points (fixed) or a fraction (0..1) of the offered box (relative sizing). */
   width?: number;
   height?: number;
@@ -61,6 +63,7 @@ export class RowElement extends SizedPDFElement {
   private gap: number;
   private main: MainAlign;
   private cross: CrossAlign;
+  private reverse: boolean;
   private breakBefore: boolean;
   private breakAfter: boolean;
   // The requested size (fixed points or a fraction), kept separate from the laid-out this.width/height.
@@ -71,6 +74,7 @@ export class RowElement extends SizedPDFElement {
     gap,
     main,
     cross,
+    reverse,
     width,
     height,
     breakBefore,
@@ -82,6 +86,7 @@ export class RowElement extends SizedPDFElement {
     this.gap = gap ?? 0;
     this.main = main ?? "start";
     this.cross = cross ?? "stretch";
+    this.reverse = reverse ?? false;
     this.requested = { ...sizing, width, height };
     this.breakBefore = breakBefore ?? false;
     this.breakAfter = breakAfter ?? false;
@@ -151,7 +156,7 @@ export class RowElement extends SizedPDFElement {
         crossAvail,
         this.x,
         this.y,
-        { gap: this.gap, main: this.main, cross: this.cross },
+        { gap: this.gap, main: this.main, cross: this.cross, reverse: this.reverse },
         ctx,
       );
     }
@@ -172,6 +177,7 @@ export class RowElement extends SizedPDFElement {
       gap: this.gap,
       main: this.main,
       cross: this.cross,
+      reverse: this.reverse,
     };
   }
 }

--- a/src/lib/elements/row-element.ts
+++ b/src/lib/elements/row-element.ts
@@ -24,6 +24,10 @@ interface RowElementParams extends WithChildren {
   cross?: CrossAlign;
   /** Lay the children out backwards along the main axis (CSS `row-reverse`). */
   reverse?: boolean;
+  /** Let the children flow onto further lines when they do not fit (CSS `flex-wrap`). */
+  wrap?: boolean;
+  /** How the block of wrapped lines sits across the axis (CSS `align-content`). */
+  alignContent?: MainAlign;
   /** Width/height as points (fixed) or a fraction (0..1) of the offered box (relative sizing). */
   width?: number;
   height?: number;
@@ -64,6 +68,8 @@ export class RowElement extends SizedPDFElement {
   private main: MainAlign;
   private cross: CrossAlign;
   private reverse: boolean;
+  private wrap: boolean;
+  private alignContent?: MainAlign;
   private breakBefore: boolean;
   private breakAfter: boolean;
   // The requested size (fixed points or a fraction), kept separate from the laid-out this.width/height.
@@ -75,6 +81,8 @@ export class RowElement extends SizedPDFElement {
     main,
     cross,
     reverse,
+    wrap,
+    alignContent,
     width,
     height,
     breakBefore,
@@ -87,6 +95,8 @@ export class RowElement extends SizedPDFElement {
     this.main = main ?? "start";
     this.cross = cross ?? "stretch";
     this.reverse = reverse ?? false;
+    this.wrap = wrap ?? false;
+    this.alignContent = alignContent;
     this.requested = { ...sizing, width, height };
     this.breakBefore = breakBefore ?? false;
     this.breakAfter = breakAfter ?? false;
@@ -156,7 +166,14 @@ export class RowElement extends SizedPDFElement {
         crossAvail,
         this.x,
         this.y,
-        { gap: this.gap, main: this.main, cross: this.cross, reverse: this.reverse },
+        {
+          gap: this.gap,
+          main: this.main,
+          cross: this.cross,
+          reverse: this.reverse,
+          wrap: this.wrap,
+          alignContent: this.alignContent,
+        },
         ctx,
       );
     }
@@ -178,6 +195,8 @@ export class RowElement extends SizedPDFElement {
       main: this.main,
       cross: this.cross,
       reverse: this.reverse,
+      wrap: this.wrap,
+      alignContent: this.alignContent,
     };
   }
 }

--- a/src/lib/utils/flex-layout.ts
+++ b/src/lib/utils/flex-layout.ts
@@ -130,13 +130,17 @@ export class FlexLayoutHelper {
     };
 
     // Pass 1: measure the fixed children (main extent + cross size) and total the flex.
+    // A flex child's BASIS is reserved here too: it is main extent the leftover no longer contains,
+    // exactly like a fixed child's size. With the default basis of 0 this line adds nothing.
     let fixedMain = 0;
     let totalFlex = 0;
+    let totalBasis = 0;
     let crossUsed = 0;
     const fixedSize = new Map<PDFElement, Size>();
     for (const child of children) {
       if (child instanceof FlexiblePDFElement) {
         totalFlex += child.getFlex();
+        totalBasis += child.getBasis(percentBase);
       } else {
         const size = child.calculateLayout(
           axis.measureConstraints(crossAvail, mainCapFor(child)),
@@ -149,7 +153,7 @@ export class FlexLayoutHelper {
       }
     }
 
-    const leftover = mainAvail - fixedMain - totalGap;
+    const leftover = mainAvail - fixedMain - totalBasis - totalGap;
     // A flex child on an UNBOUNDED main axis has no leftover space to claim. It must collapse to zero,
     // never to `Infinity`: an infinite extent would become the offset of every following sibling and get
     // written into the content stream verbatim, silently corrupting the page from that point on.
@@ -174,7 +178,8 @@ export class FlexLayoutHelper {
     if (totalFlex > 0) {
       for (const child of children) {
         if (child instanceof FlexiblePDFElement) {
-          const mainExtent = (child.getFlex() / totalFlex) * remaining;
+          const mainExtent =
+            child.getBasis(percentBase) + (child.getFlex() / totalFlex) * remaining;
           const size = child.calculateLayout(
             axis.flexConstraints(mainExtent, crossAvail),
             axis.offsetAt(mainStart, crossOrigin),
@@ -202,7 +207,7 @@ export class FlexLayoutHelper {
       const stretch = align === "stretch";
       let mainExtent: number;
       if (child instanceof FlexiblePDFElement) {
-        mainExtent = (child.getFlex() / totalFlex) * remaining;
+        mainExtent = child.getBasis(percentBase) + (child.getFlex() / totalFlex) * remaining;
         // A flex child fills the MAIN axis, and its cross size is only known after layout - there is
         // nothing to align against. So alignSelf is a no-op here, and that has to hold for the CROSS
         // CONSTRAINT too: reading the per-child alignment would hand an `alignSelf: "start"` flex child

--- a/src/lib/utils/flex-layout.ts
+++ b/src/lib/utils/flex-layout.ts
@@ -164,36 +164,41 @@ export class FlexLayoutHelper {
 
     // Which children share a line. A child is measured at its natural main extent; a flex child
     // contributes its BASIS, which is 0 unless it asked for one - so it never forces a break by itself.
+    // A child's natural main extent. A PERCENTAGE child has no fixed answer: its size depends on how
+    // many gaps the line ends up with, which depends on who is on it. So it is asked again for every
+    // candidate membership below rather than measured once.
+    const naturalMain = (child: PDFElement, base: number): number => {
+      if (child instanceof FlexiblePDFElement) return child.getBasis(base);
+      const factor = child.relativeSizeFactor(axis.mainHorizontal);
+      if (factor !== undefined) return base * factor;
+      // Measured UNCAPPED, the same way the single-line engine measures a plain child. Handing the
+      // line width in as a cap would silently squash a child wider than the line - CSS lets such a
+      // child overflow, and so does our own non-wrapping path.
+      const needsBound = child.needsBoundedMain(axis.mainHorizontal);
+      return axis.mainOf(
+        child.calculateLayout(
+          axis.measureConstraints(crossAvail, needsBound ? mainAvail : Infinity),
+          axis.offsetAt(mainStart, crossOrigin),
+          ctx,
+        ),
+      );
+    };
+
+    /** What a line of these children would occupy, resolving every `%` against ITS gap count. */
+    const lineExtent = (members: PDFElement[]): number => {
+      const gaps = Math.max(0, members.length - 1) * gap;
+      const base = Math.max(0, mainAvail - gaps);
+      return members.reduce((n, c) => n + naturalMain(c, base), 0) + gaps;
+    };
+
     const lines: PDFElement[][] = [[]];
-    let used = 0;
     for (const child of ordered) {
-      // Measured UNCAPPED on the main axis, the same way the single-line engine measures a plain
-      // child. Handing the line width in as a cap would silently squash a child that is wider than the
-      // line - CSS lets such a child overflow, and so does our own non-wrapping path. Only a child that
-      // cannot lay itself out without a bound (a percentage, or a nested stack holding a flex child)
-      // gets one, exactly as `mainCapFor` decides inside the engine.
-      const needsBound =
-        child.relativeSizeFactor(axis.mainHorizontal) !== undefined ||
-        child.needsBoundedMain(axis.mainHorizontal);
-      const size =
-        child instanceof FlexiblePDFElement
-          ? child.getBasis(mainAvail)
-          : axis.mainOf(
-              child.calculateLayout(
-                axis.measureConstraints(crossAvail, needsBound ? mainAvail : Infinity),
-                axis.offsetAt(mainStart, crossOrigin),
-                ctx,
-              ),
-            );
       const current = lines[lines.length - 1];
-      const wouldBe = used + (current.length > 0 ? gap : 0) + size;
       // A child wider than a whole line still gets one of its own rather than an empty line before it.
-      if (current.length > 0 && wouldBe > mainAvail) {
+      if (current.length > 0 && lineExtent([...current, child]) > mainAvail) {
         lines.push([child]);
-        used = size;
       } else {
         current.push(child);
-        used = wouldBe;
       }
     }
 

--- a/src/lib/utils/flex-layout.ts
+++ b/src/lib/utils/flex-layout.ts
@@ -69,6 +69,10 @@ export interface FlexOptions {
   cross?: CrossAlign;
   /** Lay the children out along the main axis backwards (CSS `row-reverse` / `column-reverse`). */
   reverse?: boolean;
+  /** Let the children flow onto further lines when they do not fit (CSS `flex-wrap: wrap`). */
+  wrap?: boolean;
+  /** How the BLOCK of wrapped lines sits across the axis (CSS `align-content`). Default `start`. */
+  alignContent?: MainAlign;
 }
 
 /**
@@ -96,7 +100,158 @@ export class FlexLayoutHelper {
    * extent occupied. Vertical with `gap 0`, `main start`, `cross stretch` reproduces the
    * previous Column layout exactly.
    */
+  /**
+   * Lays out the children along `axis`, on one line or several.
+   *
+   * Without `wrap` this is the single-line engine and nothing about it changed - the call goes
+   * straight through, which is what keeps every existing document byte-identical. With `wrap` the
+   * children are split into lines first and the SAME engine runs once per line.
+   */
   static layout(
+    children: PDFElement[],
+    axis: FlexAxis,
+    mainAvail: number,
+    crossAvail: number,
+    mainStart: number,
+    crossOrigin: number,
+    options: FlexOptions,
+    ctx: LayoutContext,
+  ): { mainUsed: number; crossUsed: number } {
+    if (!options.wrap || children.length === 0 || !Number.isFinite(mainAvail)) {
+      // An unbounded main axis has no edge to wrap at, so wrapping there is meaningless, not an error.
+      return FlexLayoutHelper.layoutLine(
+        children,
+        axis,
+        mainAvail,
+        crossAvail,
+        mainStart,
+        crossOrigin,
+        options,
+        ctx,
+      );
+    }
+    return FlexLayoutHelper.layoutWrapped(
+      children,
+      axis,
+      mainAvail,
+      crossAvail,
+      mainStart,
+      crossOrigin,
+      options,
+      ctx,
+    );
+  }
+
+  /**
+   * The wrapping path: split into lines, lay each one out, then place the lines across the axis.
+   *
+   * Lines are laid out TWICE - once to learn how tall each is, once at its final cross position. That
+   * is the same measure-then-place shape the single-line engine already uses, and it is what
+   * `alignContent` needs: the block of lines can only be centred once its total is known.
+   */
+  private static layoutWrapped(
+    children: PDFElement[],
+    axis: FlexAxis,
+    mainAvail: number,
+    crossAvail: number,
+    mainStart: number,
+    crossOrigin: number,
+    options: FlexOptions,
+    ctx: LayoutContext,
+  ): { mainUsed: number; crossUsed: number } {
+    const gap = options.gap ?? 0;
+    const ordered = inLayoutOrder(children, options.reverse ?? false);
+
+    // Which children share a line. A child is measured at its natural main extent; a flex child
+    // contributes its BASIS, which is 0 unless it asked for one - so it never forces a break by itself.
+    const lines: PDFElement[][] = [[]];
+    let used = 0;
+    for (const child of ordered) {
+      // Measured UNCAPPED on the main axis, the same way the single-line engine measures a plain
+      // child. Handing the line width in as a cap would silently squash a child that is wider than the
+      // line - CSS lets such a child overflow, and so does our own non-wrapping path. Only a child that
+      // cannot lay itself out without a bound (a percentage, or a nested stack holding a flex child)
+      // gets one, exactly as `mainCapFor` decides inside the engine.
+      const needsBound =
+        child.relativeSizeFactor(axis.mainHorizontal) !== undefined ||
+        child.needsBoundedMain(axis.mainHorizontal);
+      const size =
+        child instanceof FlexiblePDFElement
+          ? child.getBasis(mainAvail)
+          : axis.mainOf(
+              child.calculateLayout(
+                axis.measureConstraints(crossAvail, needsBound ? mainAvail : Infinity),
+                axis.offsetAt(mainStart, crossOrigin),
+                ctx,
+              ),
+            );
+      const current = lines[lines.length - 1];
+      const wouldBe = used + (current.length > 0 ? gap : 0) + size;
+      // A child wider than a whole line still gets one of its own rather than an empty line before it.
+      if (current.length > 0 && wouldBe > mainAvail) {
+        lines.push([child]);
+        used = size;
+      } else {
+        current.push(child);
+        used = wouldBe;
+      }
+    }
+
+    // Each line keeps SOURCE order internally: the ordering was applied above, and applying it again
+    // per line would reverse twice.
+    const lineOptions = { ...options, wrap: false, reverse: false };
+    const measure = lines.map((line) =>
+      FlexLayoutHelper.layoutLine(
+        line,
+        axis,
+        mainAvail,
+        Infinity, // let each line report the cross extent it actually needs
+        mainStart,
+        crossOrigin,
+        lineOptions,
+        ctx,
+      ),
+    );
+
+    const heights = measure.map((m) => m.crossUsed);
+    const totalCross = heights.reduce((n, h) => n + h, 0) + Math.max(0, lines.length - 1) * gap;
+
+    // `alignContent` distributes the BLOCK of lines across the axis, using the same vocabulary the main
+    // axis uses. Only meaningful in a bounded cross axis with room left over.
+    const slack = Number.isFinite(crossAvail) ? crossAvail - totalCross : 0;
+    const align = options.alignContent ?? "start";
+    let cursor = crossOrigin;
+    let between = gap;
+    if (slack > 0) {
+      if (align === "center") cursor += slack / 2;
+      else if (align === "end") cursor += slack;
+      else if (align === "between" && lines.length > 1) between = gap + slack / (lines.length - 1);
+      else if (align === "around") {
+        const unit = slack / lines.length;
+        cursor += unit / 2;
+        between = gap + unit;
+      }
+    }
+
+    lines.forEach((line, i) => {
+      FlexLayoutHelper.layoutLine(
+        line,
+        axis,
+        mainAvail,
+        heights[i], // the line's own extent, so `stretch` fills the line and not the container
+        mainStart,
+        cursor,
+        lineOptions,
+        ctx,
+      );
+      cursor += heights[i];
+      if (i < lines.length - 1) cursor += between;
+    });
+
+    return { mainUsed: mainAvail, crossUsed: Math.max(totalCross, cursor - crossOrigin) };
+  }
+
+  private static layoutLine(
     children: PDFElement[],
     axis: FlexAxis,
     mainAvail: number,

--- a/src/lib/utils/flex-layout.ts
+++ b/src/lib/utils/flex-layout.ts
@@ -121,7 +121,12 @@ export class FlexLayoutHelper {
     // The main cap to hand a child: `percentBase` for a percentage child (so its fraction resolves) and
     // for a child that cannot lay itself out without a bound (a nested stack holding an `Expanded`/
     // `Spacer`); unbounded for everyone else, who keep their natural size and never fill the line.
+    // Filled by the shrink pass below; read by `mainCapFor` in pass 2. Declared here so the closure
+    // can see it - it is empty for every document that does not ask for shrinking.
+    const shrunkCap = new Map<PDFElement, number>();
     const mainCapFor = (child: PDFElement): number => {
+      const target = shrunkCap.get(child);
+      if (target !== undefined) return target;
       if (percentBase === Infinity) return Infinity;
       const needsBound =
         child.relativeSizeFactor(axis.mainHorizontal) !== undefined ||
@@ -150,6 +155,40 @@ export class FlexLayoutHelper {
         fixedMain += axis.mainOf(size);
         crossUsed = Math.max(crossUsed, axis.crossOf(size));
         fixedSize.set(child, size);
+      }
+    }
+
+    // Shrinking: the line overflows and some children said they would give space back. CSS weights a
+    // shrinker's share by `shrink x its own size`, so a big item yields more than a small one - which is
+    // why this cannot reuse the grow maths above. Nobody shrinks by default, so a document that never
+    // asks for it never enters this block.
+    const shrinkers = children.filter(
+      (c) => c.flexShrink > 0 && !(c instanceof FlexiblePDFElement),
+    );
+    const overflow = fixedMain + totalBasis + totalGap - mainAvail;
+    if (shrinkers.length > 0 && Number.isFinite(mainAvail) && overflow > 0) {
+      const weight = (c: PDFElement) => c.flexShrink * axis.mainOf(fixedSize.get(c)!);
+      const totalWeight = shrinkers.reduce((n, c) => n + weight(c), 0);
+      if (totalWeight > 0) {
+        for (const child of shrinkers) {
+          const natural = axis.mainOf(fixedSize.get(child)!);
+          // Never below zero: when the GAPS alone outgrow the line, a proportional share asks for more
+          // than a child has. No test can tell this clamp apart from its absence - `constrainWidth`
+          // floors at 0 further down either way - but handing out a negative constraint is nonsense,
+          // and the next reader should not have to work out that it happens to be harmless.
+          const target = Math.max(0, natural - (weight(child) / totalWeight) * overflow);
+          shrunkCap.set(child, target);
+          // Re-measure NOW, not in pass 2: a narrower child may wrap to more lines, and the line's
+          // cross extent is settled just below.
+          const size = child.calculateLayout(
+            axis.measureConstraints(crossAvail, target),
+            axis.offsetAt(mainStart, crossOrigin),
+            ctx,
+          );
+          fixedMain += axis.mainOf(size) - natural;
+          crossUsed = Math.max(crossUsed, axis.crossOf(size));
+          fixedSize.set(child, size);
+        }
       }
     }
 

--- a/src/lib/utils/flex-layout.ts
+++ b/src/lib/utils/flex-layout.ts
@@ -167,21 +167,29 @@ export class FlexLayoutHelper {
     // A child's natural main extent. A PERCENTAGE child has no fixed answer: its size depends on how
     // many gaps the line ends up with, which depends on who is on it. So it is asked again for every
     // candidate membership below rather than measured once.
+    // A plain child's extent does not depend on the line, so it is laid out ONCE and remembered.
+    // Without this each membership probe re-lays every child already on the line - O(n^2) subtree
+    // layouts, which is expensive the moment those children hold a Table or a wrapping paragraph.
+    const measured = new Map<PDFElement, number>();
     const naturalMain = (child: PDFElement, base: number): number => {
       if (child instanceof FlexiblePDFElement) return child.getBasis(base);
       const factor = child.relativeSizeFactor(axis.mainHorizontal);
       if (factor !== undefined) return base * factor;
+      const cached = measured.get(child);
+      if (cached !== undefined) return cached;
       // Measured UNCAPPED, the same way the single-line engine measures a plain child. Handing the
       // line width in as a cap would silently squash a child wider than the line - CSS lets such a
       // child overflow, and so does our own non-wrapping path.
       const needsBound = child.needsBoundedMain(axis.mainHorizontal);
-      return axis.mainOf(
+      const main = axis.mainOf(
         child.calculateLayout(
           axis.measureConstraints(crossAvail, needsBound ? mainAvail : Infinity),
           axis.offsetAt(mainStart, crossOrigin),
           ctx,
         ),
       );
+      measured.set(child, main);
+      return main;
     };
 
     /** What a line of these children would occupy, resolving every `%` against ITS gap count. */

--- a/src/lib/utils/flex-layout.ts
+++ b/src/lib/utils/flex-layout.ts
@@ -67,6 +67,23 @@ export interface FlexOptions {
   gap?: number;
   main?: MainAlign;
   cross?: CrossAlign;
+  /** Lay the children out along the main axis backwards (CSS `row-reverse` / `column-reverse`). */
+  reverse?: boolean;
+}
+
+/**
+ * The order children are LAID OUT in: by `order` (lowest first, ties keeping source order), then
+ * reversed if the container asks for it. The element tree itself is never touched, so the reading order
+ * a tagged PDF exposes stays the source order - which is what CSS says too.
+ *
+ * `sort` is stable in every engine we target, so equal `order` values keep their source positions and a
+ * container where nobody sets one comes back with the identical array.
+ */
+function inLayoutOrder(children: PDFElement[], reverse: boolean): PDFElement[] {
+  const ordered = children.some((c) => c.order !== 0)
+    ? [...children].sort((a, b) => a.order - b.order)
+    : children;
+  return reverse ? [...ordered].reverse() : ordered;
 }
 
 export class FlexLayoutHelper {
@@ -92,6 +109,7 @@ export class FlexLayoutHelper {
     const gap = options.gap ?? 0;
     const main = options.main ?? "start";
     const cross = options.cross ?? "stretch";
+    children = inLayoutOrder(children, options.reverse ?? false);
     const count = children.length;
     const totalGap = Math.max(0, count - 1) * gap;
 

--- a/src/lib/validators/element-validator.ts
+++ b/src/lib/validators/element-validator.ts
@@ -62,7 +62,10 @@ export class Validator {
     // `flex: 0` used to be meaningless - claiming no share is what leaving the element out does. With a
     // `flexBasis` it is not: the child is then exactly its basis, a fixed slot that still participates
     // in the line. So the rule now reads "claim SOMETHING": a share, a basis, or both.
-    if (flex < 0 || (flex === 0 && element.getBasis(Infinity) <= 0 && !element.hasBasisFactor())) {
+    // A percentage basis resolves to 0 on an unbounded axis, so it is measured against a finite
+    // reference instead - otherwise `flexBasis: "0%"` would claim nothing and still pass.
+    const claimsSpace = element.getBasis(Infinity) > 0 || element.getBasis(1) > 0;
+    if (flex < 0 || (flex === 0 && !claimsSpace)) {
       throw new Error(
         `@jasy/pdf: Spacer/Expanded needs a flex above 0, got ${flex}. Flex is a SHARE of the leftover ` +
           "space, so 0 would claim none - which is what leaving the element out does. For a fixed gap " +

--- a/src/lib/validators/element-validator.ts
+++ b/src/lib/validators/element-validator.ts
@@ -59,11 +59,15 @@ export class Validator {
     // Ensure flexible elements have valid flex values. The message names what the CALLER wrote, not the
     // element class: `Spacer` and `Expanded` are what exists in their document, `ExpandedElement` is not.
     const flex = element.getFlex();
-    if (flex <= 0) {
+    // `flex: 0` used to be meaningless - claiming no share is what leaving the element out does. With a
+    // `flexBasis` it is not: the child is then exactly its basis, a fixed slot that still participates
+    // in the line. So the rule now reads "claim SOMETHING": a share, a basis, or both.
+    if (flex < 0 || (flex === 0 && element.getBasis(Infinity) <= 0 && !element.hasBasisFactor())) {
       throw new Error(
         `@jasy/pdf: Spacer/Expanded needs a flex above 0, got ${flex}. Flex is a SHARE of the leftover ` +
           "space, so 0 would claim none - which is what leaving the element out does. For a fixed gap " +
-          "use the `gap` of the surrounding Column or Row, or a Box with a height.",
+          "use the `gap` of the surrounding Column or Row, or a Box with a height. (A `flexBasis` " +
+          "makes `flex: 0` meaningful: the child is then exactly its basis.)",
       );
     }
 

--- a/tests/unit/api/flex-basis.test.ts
+++ b/tests/unit/api/flex-basis.test.ts
@@ -8,8 +8,7 @@ import { testMetrics } from "../support/metrics.ts";
 // `flexBasis` is the main-axis size a flex child STARTS from, before the leftover is shared out. It is
 // reserved exactly like a fixed child's size, so the leftover the others split shrinks by it.
 
-const ctx = {} as LayoutContext;
-const metricsCtx = { metrics: testMetrics() } as LayoutContext;
+const ctx = { metrics: testMetrics() } as LayoutContext;
 const filler = (opts: Record<string, unknown> = {}) =>
   Expanded(opts as never, Box({ borderWidth: 0 }, []));
 
@@ -80,8 +79,8 @@ describe("flexBasis across a page break", () => {
       };
       calculateLayout(c: BoxConstraints, o: { x: number; y: number }, ctx: LayoutContext): unknown;
     };
-    e.calculateLayout(BoxConstraints.loose(400, Infinity), { x: 0, y: 0 }, metricsCtx);
-    return e.fragment(50, 400, metricsCtx);
+    e.calculateLayout(BoxConstraints.loose(400, Infinity), { x: 0, y: 0 }, ctx);
+    return e.fragment(50, 400, ctx);
   };
 
   it("carries a point basis onto the continuation", () => {

--- a/tests/unit/api/flex-basis.test.ts
+++ b/tests/unit/api/flex-basis.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { Box, Expanded, Row } from "../../../src/lib/api/layout.ts";
+import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
+import { LayoutContext } from "../../../src/lib/elements/pdf-element.ts";
+
+// `flexBasis` is the main-axis size a flex child STARTS from, before the leftover is shared out. It is
+// reserved exactly like a fixed child's size, so the leftover the others split shrinks by it.
+
+const ctx = {} as LayoutContext;
+const filler = (opts: Record<string, unknown> = {}) =>
+  Expanded(opts as never, Box({ borderWidth: 0 }, []));
+
+/** The laid-out width of each child of a 400pt Row. */
+const widths = (children: unknown[], w = 400, gap = 0) => {
+  const row = Row({ gap, width: w }, children as never);
+  row.calculateLayout(BoxConstraints.loose(w, 200), { x: 0, y: 0 }, ctx);
+  return (row as unknown as { children: { getProps(): { width?: number } }[] }).children.map(
+    (c) => c.getProps().width,
+  );
+};
+
+describe("flexBasis", () => {
+  it("is reserved before the rest is shared", () => {
+    // 400 total, one child reserves 300, leaving 100. All three have flex 1, so each also takes a
+    // third of that 100 - the basis child included.
+    const [a, b, c] = widths([filler({ flexBasis: 300 }), filler(), filler()]);
+    expect(a).toBeCloseTo(333.33, 1);
+    expect(b).toBeCloseTo(33.33, 1);
+    expect(c).toBeCloseTo(33.33, 1);
+  });
+
+  it("with flex 0 it is simply a fixed slot", () => {
+    // Nothing to grow with, so the child is exactly its basis and the rest goes to the other.
+    expect(widths([filler({ flex: 0, flexBasis: 120 }), filler()])).toEqual([120, 280]);
+  });
+
+  it("takes a percentage of what the line offers", () => {
+    expect(widths([filler({ flex: 0, flexBasis: "25%" }), filler()])).toEqual([100, 300]);
+  });
+
+  it("resolves the percentage against the line MINUS the gaps", () => {
+    // 400 - 20 of gap = 380 offered to the items; 25% of that is 95.
+    expect(widths([filler({ flex: 0, flexBasis: "25%" }), filler()], 400, 20)).toEqual([95, 285]);
+  });
+
+  it("changes nothing when it is not set", () => {
+    for (const w of widths([filler(), filler(), filler()])) expect(w).toBeCloseTo(400 / 3, 6);
+  });
+
+  it("shares the leftover by flex, on top of each basis", () => {
+    // Bases 100 + 100 = 200 reserved; the remaining 200 splits 3:1.
+    expect(
+      widths([filler({ flex: 3, flexBasis: 100 }), filler({ flex: 1, flexBasis: 100 })]),
+    ).toEqual([250, 150]);
+  });
+});

--- a/tests/unit/api/flex-basis.test.ts
+++ b/tests/unit/api/flex-basis.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { Box, Expanded, Row } from "../../../src/lib/api/layout.ts";
+import { Box, Column, Expanded, Row } from "../../../src/lib/api/layout.ts";
+import { Text } from "../../../src/lib/api/text.ts";
 import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
 import { LayoutContext } from "../../../src/lib/elements/pdf-element.ts";
+import { testMetrics } from "../support/metrics.ts";
 
 // `flexBasis` is the main-axis size a flex child STARTS from, before the leftover is shared out. It is
 // reserved exactly like a fixed child's size, so the leftover the others split shrinks by it.
 
 const ctx = {} as LayoutContext;
+const metricsCtx = { metrics: testMetrics() } as LayoutContext;
 const filler = (opts: Record<string, unknown> = {}) =>
   Expanded(opts as never, Box({ borderWidth: 0 }, []));
 
@@ -52,5 +55,64 @@ describe("flexBasis", () => {
     expect(
       widths([filler({ flex: 3, flexBasis: 100 }), filler({ flex: 1, flexBasis: 100 })]),
     ).toEqual([250, 150]);
+  });
+});
+
+describe("flexBasis across a page break", () => {
+  // An Expanded that paginates re-wraps each half in a fresh Expanded. If that clone forgets the
+  // basis, the continuation claims only its share of the leftover and the slot changes width on the
+  // second page - a silent layout shift nobody would look for.
+  const paginating = (opts: Record<string, unknown>) =>
+    Expanded(
+      opts as never,
+      Column(Array.from({ length: 12 }, (_, i) => Text(`line ${i}`, { size: 10 }))) as never,
+    );
+
+  const split = (el: ReturnType<typeof Expanded>) => {
+    const e = el as unknown as {
+      fragment(
+        h: number,
+        w: number,
+        c: LayoutContext,
+      ): {
+        fitted: { getProps(): { basis: number; basisFactor?: number } } | null;
+        remainder: { getProps(): { basis: number; basisFactor?: number } } | null;
+      };
+      calculateLayout(c: BoxConstraints, o: { x: number; y: number }, ctx: LayoutContext): unknown;
+    };
+    e.calculateLayout(BoxConstraints.loose(400, Infinity), { x: 0, y: 0 }, metricsCtx);
+    return e.fragment(50, 400, metricsCtx);
+  };
+
+  it("carries a point basis onto the continuation", () => {
+    const { fitted, remainder } = split(paginating({ flex: 1, flexBasis: 120 }));
+    expect(fitted).not.toBeNull();
+    expect(remainder).not.toBeNull();
+    expect(fitted!.getProps().basis).toBe(120);
+    expect(remainder!.getProps().basis).toBe(120);
+  });
+
+  it("carries a percentage basis onto the continuation", () => {
+    const { fitted, remainder } = split(paginating({ flex: 1, flexBasis: "25%" }));
+    expect(fitted!.getProps().basisFactor).toBe(0.25);
+    expect(remainder!.getProps().basisFactor).toBe(0.25);
+  });
+
+  it("carries it for a flex-0 slot too, which is nothing BUT its basis", () => {
+    const { fitted, remainder } = split(paginating({ flex: 0, flexBasis: 90 }));
+    expect(fitted!.getProps().basis).toBe(90);
+    expect(remainder!.getProps().basis).toBe(90);
+  });
+});
+
+describe("a flex-0 child must still claim something", () => {
+  it("rejects a percentage basis of zero, which claims no space at all", () => {
+    expect(() => widths([filler({ flex: 0, flexBasis: "0%" }), filler()])).toThrow(
+      /needs a flex above 0/,
+    );
+  });
+
+  it("accepts a positive percentage basis", () => {
+    expect(() => widths([filler({ flex: 0, flexBasis: "25%" }), filler()])).not.toThrow();
   });
 });

--- a/tests/unit/api/flex-order.test.ts
+++ b/tests/unit/api/flex-order.test.ts
@@ -40,7 +40,7 @@ describe("order", () => {
     expect(xs(Row({ gap: 10 }, [tile(), tile(), tile()]))).toEqual([0, 50, 100]);
   });
 
-  it("refuses a value that is not a number", () => {
+  it("refuses a non-finite value", () => {
     expect(() => tile({ order: Infinity })).toThrow(/Invalid order/);
   });
 });

--- a/tests/unit/api/flex-order.test.ts
+++ b/tests/unit/api/flex-order.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { Box, Column, Row } from "../../../src/lib/api/layout.ts";
+import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
+import { LayoutContext } from "../../../src/lib/elements/pdf-element.ts";
+
+// `order` and `reverse` both decide WHERE a child is laid out, never what the tree contains - so a
+// tagged PDF keeps exposing the source reading order, which is what CSS says too.
+
+const ctx = {} as LayoutContext;
+const tile = (opts: Record<string, unknown> = {}) =>
+  Box({ borderWidth: 0, width: 40, height: 20, ...opts }, []);
+
+/** The laid-out x of each child of a Row, in TREE order - so a change of position is visible. */
+const xs = (row: ReturnType<typeof Row>, w = 400) => {
+  row.calculateLayout(BoxConstraints.loose(w, 200), { x: 0, y: 0 }, ctx);
+  return (row as unknown as { children: { getProps(): { x: number } }[] }).children.map(
+    (c) => c.getProps().x,
+  );
+};
+const ys = (col: ReturnType<typeof Column>, h = 400) => {
+  col.calculateLayout(BoxConstraints.loose(200, h), { x: 0, y: 0 }, ctx);
+  return (col as unknown as { children: { getProps(): { y: number } }[] }).children.map(
+    (c) => c.getProps().y,
+  );
+};
+
+describe("order", () => {
+  it("moves a child without moving it in the tree", () => {
+    // The third child asks to go first; the tree order (and therefore the reading order) is unchanged.
+    const row = Row({ gap: 10 }, [tile(), tile(), tile({ order: -1 })]);
+    expect(xs(row)).toEqual([50, 100, 0]);
+  });
+
+  it("keeps source order for ties, so a partial ordering is predictable", () => {
+    const row = Row({ gap: 10 }, [tile({ order: 1 }), tile({ order: 1 }), tile({ order: 0 })]);
+    expect(xs(row)).toEqual([50, 100, 0]);
+  });
+
+  it("changes nothing when nobody sets it", () => {
+    expect(xs(Row({ gap: 10 }, [tile(), tile(), tile()]))).toEqual([0, 50, 100]);
+  });
+
+  it("refuses a value that is not a number", () => {
+    expect(() => tile({ order: Infinity })).toThrow(/Invalid order/);
+  });
+});
+
+describe("reverse", () => {
+  it("lays a Row out backwards", () => {
+    const row = Row({ gap: 10, reverse: true }, [tile(), tile(), tile()]);
+    expect(xs(row)).toEqual([100, 50, 0]);
+  });
+
+  it("lays a Column out bottom to top", () => {
+    const col = Column({ gap: 10, reverse: true }, [tile(), tile(), tile()]);
+    expect(ys(col)).toEqual([60, 30, 0]);
+  });
+
+  it("composes with order - order first, then the reversal", () => {
+    // order puts the third child first; reversing then sends it to the far end.
+    const row = Row({ gap: 10, reverse: true }, [tile(), tile(), tile({ order: -1 })]);
+    expect(xs(row)).toEqual([50, 0, 100]);
+  });
+});

--- a/tests/unit/api/flex-real-content.test.ts
+++ b/tests/unit/api/flex-real-content.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { Box, Column, Row } from "../../../src/lib/api/layout.ts";
+import { Text } from "../../../src/lib/api/text.ts";
+import { Table } from "../../../src/lib/api/table.ts";
+import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
+import { LayoutContext } from "../../../src/lib/elements/pdf-element.ts";
+import { testMetrics } from "../support/metrics.ts";
+
+// The flex work so far was tested with plain boxes. Real documents put a Table, a wrapping paragraph
+// and nested stacks inside a flex item - and those RE-MEASURE differently when the item is made
+// narrower. This suite is about that: does it still hold when the content is not a rectangle.
+
+const ctx = { metrics: testMetrics() } as LayoutContext;
+
+// The height is left UNBOUNDED on purpose: a Box with no height of its own FILLS a bounded region,
+// which would make every height below read 600 and hide what these tests are about.
+const laid = (el: ReturnType<typeof Row>, w: number, h = Infinity) => {
+  el.calculateLayout(BoxConstraints.loose(w, h), { x: 0, y: 0 }, ctx);
+  return (el as unknown as { children: { getProps(): Record<string, number> }[] }).children.map(
+    (c) => c.getProps(),
+  );
+};
+
+describe("percentage children in a wrapping row", () => {
+  it("fits three 33% children on one line instead of wrapping the third", () => {
+    // The trap: the line-assignment pass must resolve a `%` child against the SAME base the layout
+    // uses - the line minus its gaps. Measuring against the full line makes each child a few points
+    // too wide, and the third one wraps for no reason.
+    const chip = () => Box({ borderWidth: 0, width: "33%", height: 20 }, []);
+    const row = Row({ gap: 6, wrap: true, width: 300 }, [chip(), chip(), chip()]);
+    expect(laid(row, 300).map((p) => p.y)).toEqual([0, 0, 0]);
+  });
+
+  it("wraps a fourth one, since four thirds do not fit", () => {
+    const chip = () => Box({ borderWidth: 0, width: "33%", height: 20 }, []);
+    const row = Row({ gap: 6, wrap: true, width: 300 }, [chip(), chip(), chip(), chip()]);
+    // 20pt of chip plus the 6pt gap, which is used between the LINES as well as between the items.
+    expect(laid(row, 300).map((p) => p.y)).toEqual([0, 0, 0, 26]);
+  });
+});
+
+describe("a flex item holding real content", () => {
+  const card = (text: string, opts: Record<string, unknown> = {}) =>
+    Box({ borderWidth: 1, padding: 4, ...opts } as never, [
+      Column({ gap: 2 }, [Text("Heading", { size: 10 }), Text(text, { size: 10 })]),
+    ]);
+
+  it("wraps cards whose height comes from their own text", () => {
+    const row = Row({ gap: 6, wrap: true, width: 300 }, [
+      card("aa bb", { width: 140 }),
+      card("cc dd", { width: 140 }),
+      card("ee ff", { width: 140 }),
+    ]);
+    const ys = laid(row, 300).map((p) => p.y);
+    expect(ys[0]).toBe(0);
+    expect(ys[1]).toBe(0);
+    expect(ys[2]).toBeGreaterThan(0); // the third moved to line two
+  });
+
+  it("lets a shrunk card grow taller as its text re-wraps", () => {
+    // The reason the shrink pass re-measures BEFORE the line's cross extent is settled: a narrower
+    // card needs more lines, and a line sized against the natural width would clip it.
+    const wide = Row({ width: 400 }, [card("aa bb cc dd ee ff", { width: 400 })]);
+    const tall = laid(wide, 400)[0].height;
+
+    const squeezed = Row({ width: 120 }, [
+      card("aa bb cc dd ee ff", { width: 400, flexShrink: 1 }),
+    ]);
+    const squeezedHeight = laid(squeezed, 120)[0].height;
+
+    expect(laid(squeezed, 120)[0].width).toBe(120); // it did shrink...
+    expect(squeezedHeight).toBeGreaterThan(tall); // ...and got taller, not clipped
+  });
+
+  it("carries a Table through a wrapping row", () => {
+    const cell = (t: string) => Text(t, { size: 10 });
+    const panel = (w: number) =>
+      Box({ borderWidth: 1, width: w }, [
+        Table({ columns: ["1fr", "1fr"] }, [
+          [cell("aa"), cell("bb")],
+          [cell("cc"), cell("dd")],
+        ]),
+      ]);
+    const row = Row({ gap: 6, wrap: true, width: 300 }, [panel(140), panel(140), panel(140)]);
+    const out = laid(row, 300);
+    expect(out.map((p) => p.y)).toEqual([out[0].y, out[0].y, out[2].y]);
+    expect(out[2].y).toBeGreaterThan(out[0].y);
+    for (const p of out) expect(p.height).toBeGreaterThan(0); // every panel really laid out
+  });
+
+  it("keeps a nested Column inside a shrinking item intact", () => {
+    const inner = Box({ borderWidth: 0, width: 200, flexShrink: 1 }, [
+      Column({ gap: 2 }, [Text("aa bb", { size: 10 }), Text("cc dd ee", { size: 10 })]),
+    ]);
+    const row = Row({ width: 100 }, [inner]);
+    const out = laid(row, 100)[0];
+    expect(out.width).toBe(100);
+    expect(out.height).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/api/flex-real-content.test.ts
+++ b/tests/unit/api/flex-real-content.test.ts
@@ -83,8 +83,8 @@ describe("a flex item holding real content", () => {
       ]);
     const row = Row({ gap: 6, wrap: true, width: 300 }, [panel(140), panel(140), panel(140)]);
     const out = laid(row, 300);
-    expect(out.map((p) => p.y)).toEqual([out[0].y, out[0].y, out[2].y]);
-    expect(out[2].y).toBeGreaterThan(out[0].y);
+    expect(out[1].y).toBe(out[0].y); // the first two share a line...
+    expect(out[2].y).toBeGreaterThan(out[0].y); // ...the third starts the next one
     for (const p of out) expect(p.height).toBeGreaterThan(0); // every panel really laid out
   });
 

--- a/tests/unit/api/flex-shrink.test.ts
+++ b/tests/unit/api/flex-shrink.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { Box, Row } from "../../../src/lib/api/layout.ts";
+import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
+import { LayoutContext } from "../../../src/lib/elements/pdf-element.ts";
+
+// `flexShrink` gives main-axis space back when the line overflows, weighted by the child's OWN size -
+// so a wide item yields more than a narrow one. Default 0, deliberately unlike CSS's 1: shrinking
+// changes what a document looks like, and every document written before this must lay out unchanged.
+
+const ctx = {} as LayoutContext;
+const tile = (width: number, opts: Record<string, unknown> = {}) =>
+  Box({ borderWidth: 0, width, height: 20, ...opts }, []);
+
+const widths = (children: unknown[], line = 400) => {
+  const row = Row({ width: line }, children as never);
+  row.calculateLayout(BoxConstraints.loose(line, 200), { x: 0, y: 0 }, ctx);
+  return (row as unknown as { children: { getProps(): { width?: number } }[] }).children.map(
+    (c) => c.getProps().width,
+  );
+};
+
+describe("nothing shrinks unless it says so", () => {
+  it("leaves an overflowing line alone by default", () => {
+    // 3 x 200 in a 400pt line: it overflows, and that is exactly what it did before this existed.
+    expect(widths([tile(200), tile(200), tile(200)])).toEqual([200, 200, 200]);
+  });
+});
+
+describe("giving space back", () => {
+  it("shrinks the one child that volunteered, by the whole overflow", () => {
+    // 200 + 300 = 500 in a 400pt line: 100 too much, and only the second offered.
+    expect(widths([tile(200), tile(300, { flexShrink: 1 })])).toEqual([200, 200]);
+  });
+
+  it("weights the share by each child's own size, as CSS does", () => {
+    // 300 + 100 = 400 over a 200pt line: 200 too much. Weights are 300 and 100, so the wide one
+    // gives up 150 and the narrow one 50 - not half each.
+    expect(widths([tile(300, { flexShrink: 1 }), tile(100, { flexShrink: 1 })], 200)).toEqual([
+      150, 50,
+    ]);
+  });
+
+  it("respects a higher willingness", () => {
+    // Weights 2x200 and 1x200: the eager one gives up two thirds of the 300 overflow.
+    expect(widths([tile(200, { flexShrink: 2 }), tile(200, { flexShrink: 1 })], 100)).toEqual([
+      0, 100,
+    ]);
+  });
+
+  it("bottoms out at zero rather than going negative", () => {
+    // Reachable only when the GAPS alone outgrow the line: the overflow is then larger than everything
+    // the children add up to. Two 50pt tiles with a 300pt gap in a 100pt line.
+    const row = Row({ width: 100, gap: 300 }, [
+      tile(50, { flexShrink: 1 }),
+      tile(50, { flexShrink: 1 }),
+    ] as never);
+    row.calculateLayout(BoxConstraints.loose(100, 200), { x: 0, y: 0 }, ctx);
+    const w = (row as unknown as { children: { getProps(): { width?: number } }[] }).children.map(
+      (c) => c.getProps().width,
+    );
+    expect(w).toEqual([0, 0]);
+  });
+
+  it("does nothing when the line is NOT overflowing", () => {
+    expect(widths([tile(100, { flexShrink: 1 }), tile(100)])).toEqual([100, 100]);
+  });
+
+  it("refuses a negative willingness", () => {
+    expect(() => tile(100, { flexShrink: -1 })).toThrow(/Invalid flexShrink/);
+  });
+});

--- a/tests/unit/api/flex-shrink.test.ts
+++ b/tests/unit/api/flex-shrink.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Box, Row } from "../../../src/lib/api/layout.ts";
+import { Image } from "../../../src/lib/api/content.ts";
+import { CustomBytesImage } from "../../../src/lib/elements/image-element.ts";
 import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
 import { LayoutContext } from "../../../src/lib/elements/pdf-element.ts";
 
@@ -67,5 +69,24 @@ describe("giving space back", () => {
 
   it("refuses a negative willingness", () => {
     expect(() => tile(100, { flexShrink: -1 })).toThrow(/Invalid flexShrink/);
+  });
+});
+
+describe("an Image is a flex child like any other", () => {
+  // `ImageOptions` extends `BoundsInput`, so the prop is offered and documented on an Image. It was
+  // accepted and then dropped on the floor - the picture simply overflowed.
+  const pic = (width: number, opts: Record<string, unknown> = {}) =>
+    Image(new CustomBytesImage(new Uint8Array([1])), { width, height: 20, ...opts });
+
+  it("honours flexShrink on an Image", () => {
+    // 300 + 200 in a 400pt line: 100 too much, shared out by each picture's own width.
+    const [a, b] = widths([pic(300, { flexShrink: 1 }), pic(200, { flexShrink: 1 })]);
+    expect(a! + b!).toBeCloseTo(400, 5); // the line is exactly filled...
+    expect(a!).toBeCloseTo(240, 5); // ...and the wide one gave up 60 of the 100, the narrow one 40
+    expect(b!).toBeCloseTo(160, 5);
+  });
+
+  it("still leaves an Image alone without it", () => {
+    expect(widths([pic(300), pic(300)])).toEqual([300, 300]);
   });
 });

--- a/tests/unit/api/flex-wrap.test.ts
+++ b/tests/unit/api/flex-wrap.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { Box, Row } from "../../../src/lib/api/layout.ts";
+import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
+import { LayoutContext } from "../../../src/lib/elements/pdf-element.ts";
+
+// `wrap` splits the children onto further lines when they do not fit. The single-line engine is
+// unchanged and simply runs once per line - which is what keeps every non-wrapping document identical.
+
+const ctx = {} as LayoutContext;
+const tile = (w: number, h = 20) => Box({ borderWidth: 0, width: w, height: h }, []);
+
+/** Where each child ended up: [x, y] per child, in tree order. */
+const places = (row: ReturnType<typeof Row>, w = 300, h = 400) => {
+  row.calculateLayout(BoxConstraints.loose(w, h), { x: 0, y: 0 }, ctx);
+  return (row as unknown as { children: { getProps(): { x: number; y: number } }[] }).children.map(
+    (c) => [c.getProps().x, c.getProps().y] as [number, number],
+  );
+};
+
+describe("without wrap nothing changes", () => {
+  it("keeps overflowing on one line, as it always did", () => {
+    const row = Row({ width: 300 }, [tile(200), tile(200)]);
+    expect(places(row)).toEqual([
+      [0, 0],
+      [200, 0],
+    ]);
+  });
+});
+
+describe("wrapping", () => {
+  it("moves a child that does not fit onto the next line", () => {
+    const row = Row({ width: 300, wrap: true }, [tile(200), tile(200)]);
+    expect(places(row)).toEqual([
+      [0, 0],
+      [0, 20],
+    ]);
+  });
+
+  it("counts the gap when deciding, and uses it between the lines too", () => {
+    // 140 + 10 + 140 = 290 fits in 300; adding a third would not, so it starts a line 10 below.
+    const row = Row({ width: 300, gap: 10, wrap: true }, [tile(140), tile(140), tile(140)]);
+    expect(places(row)).toEqual([
+      [0, 0],
+      [150, 0],
+      [0, 30],
+    ]);
+  });
+
+  it("lets a child wider than the line OVERFLOW rather than squashing it", () => {
+    // CSS does not shrink an item to make it fit - that is what `flexShrink` is for, and it is off by
+    // default. The child keeps its width, takes a line of its own, and runs past the edge.
+    const row = Row({ width: 100, wrap: true }, [tile(50), tile(400), tile(50)]);
+    row.calculateLayout(BoxConstraints.loose(100, 400), { x: 0, y: 0 }, ctx);
+    const kids = (row as unknown as { children: { getProps(): { width?: number; y: number } }[] })
+      .children;
+    expect(kids[1].getProps().width).toBe(400); // not squashed to 100
+    expect(kids.map((c) => c.getProps().y)).toEqual([0, 20, 40]);
+  });
+
+  it("does not open an empty line when the FIRST child is already too wide", () => {
+    // Without the guard an empty line is pushed ahead of it. That is invisible without a gap - an
+    // empty line is 0 tall - but with one it costs a whole gap of blank space at the top.
+    const row = Row({ width: 100, gap: 10, wrap: true }, [tile(400), tile(50)]);
+    expect(places(row).map((p) => p[1])).toEqual([0, 30]);
+  });
+
+  it("lets the gap itself decide the break", () => {
+    // 150 + 150 is exactly 300 and would fit - but the 10pt gap between them does not, so the second
+    // child moves down. Ignoring the gap here keeps them on one line and overflows by 10.
+    const row = Row({ width: 300, gap: 10, wrap: true }, [tile(150), tile(150)]);
+    expect(places(row)).toEqual([
+      [0, 0],
+      [0, 30],
+    ]);
+  });
+
+  it("stacks three lines in order", () => {
+    const row = Row({ width: 100, wrap: true }, [tile(60), tile(60), tile(60)]);
+    expect(places(row).map((p) => p[1])).toEqual([0, 20, 40]);
+  });
+});
+
+describe("alignContent places the BLOCK of lines", () => {
+  const three = () => [tile(60), tile(60), tile(60)];
+
+  it("starts at the top by default", () => {
+    expect(places(Row({ width: 100, wrap: true }, three()), 100, 200).map((p) => p[1])).toEqual([
+      0, 20, 40,
+    ]);
+  });
+
+  it("centres them", () => {
+    // Three 20pt lines = 60 in a 200pt box: 140 of slack, so 70 above.
+    expect(
+      places(Row({ width: 100, wrap: true, alignContent: "center" }, three()), 100, 200).map(
+        (p) => p[1],
+      ),
+    ).toEqual([70, 90, 110]);
+  });
+
+  it("pushes them to the end", () => {
+    expect(
+      places(Row({ width: 100, wrap: true, alignContent: "end" }, three()), 100, 200).map(
+        (p) => p[1],
+      ),
+    ).toEqual([140, 160, 180]);
+  });
+
+  it("spreads them with 'between'", () => {
+    expect(
+      places(Row({ width: 100, wrap: true, alignContent: "between" }, three()), 100, 200).map(
+        (p) => p[1],
+      ),
+    ).toEqual([0, 90, 180]);
+  });
+});
+
+describe("composing with the rest", () => {
+  it("applies `order` before the lines are cut, not within them", () => {
+    // The last child asks to go first, so it lands on line one and the others follow.
+    const row = Row({ width: 100, wrap: true }, [tile(60), tile(60), tile(60, 20)]);
+    (row as never as { children: { order: number }[] }).children[2].order = -1;
+    expect(places(row).map((p) => p[1])).toEqual([20, 40, 0]);
+  });
+
+  it("stretches a child to its own LINE, not to the whole container", () => {
+    // `cross: stretch` is the default. Each line must be offered its OWN extent - hand every line the
+    // container's height instead and the auto-sized child grows to 400 rather than matching the 30pt
+    // tile it shares a line with.
+    const auto = () => Box({ borderWidth: 0, width: 60 }, []);
+    const row = Row({ width: 130, wrap: true }, [tile(60, 30), auto(), tile(60, 50), auto()]);
+    row.calculateLayout(BoxConstraints.loose(130, 400), { x: 0, y: 0 }, ctx);
+    const kids = (row as unknown as { children: { getProps(): { height?: number; y: number } }[] })
+      .children;
+    expect(kids[1].getProps().height).toBe(30); // line one is 30 tall
+    expect(kids[3].getProps().height).toBe(50); // line two is 50 tall
+    expect(kids[2].getProps().y).toBe(30); // and line two starts below line one
+  });
+
+  it("wrapping an unbounded axis is a no-op, not an error", () => {
+    // There is no edge to wrap at; the children simply keep going, as they would without `wrap`.
+    const row = Row({ wrap: true }, [tile(200), tile(200)]);
+    row.calculateLayout(new BoxConstraints(), { x: 0, y: 0 }, ctx);
+    const ys = (row as unknown as { children: { getProps(): { y: number } }[] }).children.map(
+      (c) => c.getProps().y,
+    );
+    expect(ys).toEqual([0, 0]);
+  });
+});

--- a/tests/unit/elements/positioned-element.test.ts
+++ b/tests/unit/elements/positioned-element.test.ts
@@ -10,7 +10,7 @@ import { Orientation } from "../../../src/lib/renderer/pdf-config";
 import { PageSize } from "../../../src/lib/constants/page-sizes";
 import type { FontMetrics } from "../../../src/lib/utils/font-metrics";
 import type { PDFObjectManager } from "../../../src/lib/utils/pdf-object-manager";
-import { unitVerticals } from "../support/metrics";
+import { unitVerticals } from "../support/metrics.ts";
 
 const metrics: FontMetrics = {
   getStringWidth: (text) => text.length * 10,

--- a/tests/unit/elements/row-element.test.ts
+++ b/tests/unit/elements/row-element.test.ts
@@ -6,7 +6,7 @@ import { TextElement } from "../../../src/lib/elements/text-element";
 import { BoxConstraints } from "../../../src/lib/layout/box-constraints";
 import { LayoutContext } from "../../../src/lib/elements/pdf-element";
 import { FontMetrics } from "../../../src/lib/utils/font-metrics";
-import { unitVerticals } from "../support/metrics";
+import { unitVerticals } from "../support/metrics.ts";
 
 const box = (width: number, height: number) =>
   new RectangleElement({ x: 0, y: 0, children: [], width, height, borderWidth: 0 });

--- a/tests/unit/layout/box-fragment.test.ts
+++ b/tests/unit/layout/box-fragment.test.ts
@@ -7,7 +7,7 @@ import { LayoutContext, PDFElement } from "../../../src/lib/elements/pdf-element
 import { BoxConstraints, Offset, Size } from "../../../src/lib/layout/box-constraints";
 import { packChildren } from "../../../src/lib/layout/fragmentation";
 import type { FontMetrics } from "../../../src/lib/utils/font-metrics";
-import { unitVerticals } from "../support/metrics";
+import { unitVerticals } from "../support/metrics.ts";
 
 // Each glyph 10 wide, spaces 0: "aa bb cc dd ee ff" wraps to 3 lines of 10pt at width 50.
 const metrics: FontMetrics = {

--- a/tests/unit/renderer/text-renderer.test.ts
+++ b/tests/unit/renderer/text-renderer.test.ts
@@ -5,7 +5,7 @@ import { describe, it, vi, expect } from "vitest";
 import { TextElement } from "../../../src/lib/elements";
 import { HorizontalAlignment } from "../../../src/lib/elements/pdf-element";
 import { Color } from "../../../src/lib/common/color";
-import { unitVerticals } from "../support/metrics";
+import { unitVerticals } from "../support/metrics.ts";
 
 describe("TextRenderer - calculateTextHeight", () => {
   it("should calculate the correct text height for a simple string", () => {

--- a/tests/unit/support/metrics.ts
+++ b/tests/unit/support/metrics.ts
@@ -1,4 +1,5 @@
-import type { FontVerticals } from "../../../src/lib/text/line-metrics";
+import type { FontVerticals } from "../../../src/lib/text/line-metrics.ts";
+import type { FontMetrics } from "../../../src/lib/utils/font-metrics.ts";
 
 /**
  * Vertical metrics for the deterministic test fonts: 3/4 em above the baseline, 1/4 em below, no
@@ -9,3 +10,24 @@ import type { FontVerticals } from "../../../src/lib/text/line-metrics";
 export const UNIT_VERTICALS: FontVerticals = { ascent: 0.75, descent: 0.25, lineGap: 0 };
 
 export const unitVerticals = (): FontVerticals => UNIT_VERTICALS;
+
+/**
+ * A complete `FontMetrics` for layout tests: every glyph is 10pt wide at size 10, a space is free,
+ * kerning is off. Only the parts a test actually cares about need overriding - the rest exist so the
+ * object satisfies the interface rather than a cast, which is what lets a real type error show up.
+ */
+export const testMetrics = (over: Partial<FontMetrics> = {}): FontMetrics => ({
+  getStringWidth: (text, _family, fontSize) =>
+    [...text].reduce((w, c) => w + (c === " " ? 0 : fontSize), 0),
+  getCharWidth: (char, fontSize) => (char === " " ? 0 : fontSize),
+  getFontVerticals: unitVerticals,
+  getFontDecoration: () => ({
+    underlinePosition: -0.1,
+    underlineThickness: 0.05,
+    capHeight: 0.7,
+    xHeight: 0.5,
+  }),
+  kerningEnabled: false,
+  getKernPairs: (text) => Array.from({ length: Math.max(0, [...text].length - 1) }, () => 0),
+  ...over,
+});

--- a/tests/unit/text/line-breaker.test.ts
+++ b/tests/unit/text/line-breaker.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { breakSegmentsIntoLines, wrapStringIntoLines } from "../../../src/lib/text/line-breaker";
 import { FontStyle } from "../../../src/lib/utils/pdf-object-manager";
 import type { FontMetrics } from "../../../src/lib/utils/font-metrics";
-import { unitVerticals } from "../support/metrics";
+import { unitVerticals } from "../support/metrics.ts";
 import { lineBoxForSegmentLine } from "../../../src/lib/text/line-metrics";
 
 // Deterministic metrics: every glyph is 10 wide, spaces are 0. Expected line breaks

--- a/tests/unit/text/line-height.test.ts
+++ b/tests/unit/text/line-height.test.ts
@@ -4,7 +4,7 @@ import { BoxConstraints } from "../../../src/lib/layout/box-constraints";
 import { LayoutContext } from "../../../src/lib/elements/pdf-element";
 import { FontMetrics } from "../../../src/lib/utils/font-metrics";
 import { Text } from "../../../src/lib/api";
-import { unitVerticals } from "../support/metrics";
+import { unitVerticals } from "../support/metrics.ts";
 
 // Every glyph (and the space) is 10pt wide -> "alfa" = 40pt; at width 50 each word lands on its line.
 const metrics = {

--- a/tests/unit/text/text-fragment.test.ts
+++ b/tests/unit/text/text-fragment.test.ts
@@ -4,7 +4,7 @@ import { TextSegment } from "../../../src/lib/elements/text-element";
 import { LayoutContext } from "../../../src/lib/elements/pdf-element";
 import { BoxConstraints } from "../../../src/lib/layout/box-constraints";
 import type { FontMetrics } from "../../../src/lib/utils/font-metrics";
-import { unitVerticals } from "../support/metrics";
+import { unitVerticals } from "../support/metrics.ts";
 
 // Deterministic metrics: each glyph is 10 wide, spaces are 0. With six 2-char words and
 // maxWidth 50 the greedy breaker yields three lines of two words each.

--- a/tests/unit/text/text-truncation.test.ts
+++ b/tests/unit/text/text-truncation.test.ts
@@ -6,7 +6,7 @@ import { LayoutContext } from "../../../src/lib/elements/pdf-element";
 import { FontStyle } from "../../../src/lib/utils/pdf-object-manager";
 import { FontMetrics } from "../../../src/lib/utils/font-metrics";
 import { Text } from "../../../src/lib/api";
-import { unitVerticals } from "../support/metrics";
+import { unitVerticals } from "../support/metrics.ts";
 
 // Every glyph (and the space) is 10pt wide, no kerning -> "alfa" = 40pt. Deterministic wrapping.
 const metrics = {


### PR DESCRIPTION
## Summary

Short, but big: jasy can now handle flexbox like css!

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added flexible row and column layout controls, including ordering, reverse direction, wrapping, alignment, shrinking, and fixed or percentage-based sizing.
  - Added alignment, ordering, and shrinking controls for images.
  - Added section-level page numbering options.

- **Documentation**
  - Documented URL-based font registration, font-format support, layout controls, and page numbering.

- **Reliability**
  - Improved consistency of generated invoice PDFs and XML across repeated renders.
  - Added coverage for complex wrapping, sizing, pagination, and layout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->