### PR TITLE
feat: `RTL` - hebrew + arabic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,8 +230,8 @@ rendering. This is the standing visual check; prefer it over one-off `scripts/ru
 - `pnpm test` — Vitest (watch). `pnpm exec vitest run` for a one-shot CI-style run.
   `pnpm run test:coverage` for coverage. Unit tests live in **`tests/unit/`**, mirroring the `src/lib/`
   structure (`tests/unit/{common,elements,renderer,utils}/…`). `src/` is pure production code — the
-  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **954 tests, green** —
-  what the root run covers: core 857, `@jasy/cli` 37, `@jasy/vue` 33, `@jasy/e-invoice` 27. `@jasy/nuxt`
+  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **996 tests, green** —
+  what the root run covers: core 899, `@jasy/cli` 37, `@jasy/vue` 33, `@jasy/e-invoice` 27. `@jasy/nuxt`
   is excluded from it (`vitest.config.ts`) and runs on its own.
 - `pnpm run build` — `tsc` → `dist/`.
 - `pnpm run lint` (oxlint) + `pnpm run fmt:check` (oxfmt `--check`); `pnpm run fmt` formats. **Run `pnpm run fmt`
@@ -564,8 +564,34 @@ agree: true })` → declarative values, not object mutation. Save is an **increm
   mirrored — and our own test was vacuously green because it asserted the broken order. Known gap, in
   `todo.md`: we SUBSTITUTE the mirrored character (as react-pdf does) where Chrome keeps the original and
   mirrors the glyph, so extracted text has swapped brackets.
-  **Arabic is ORDERED correctly but not SHAPED** — letters do not join yet (that is `GSUB`, its own
-  project; the x positions are the only thing that differs from Chrome). Deliberate, and in `todo.md`.
+  Arabic ordering landed here; the JOINING that makes it readable came right after — see the shaping
+  entry below.
+
+- ✅ **Arabic SHAPING (OpenType GSUB)** (2026-08-02) — letters join and lam-alef collapses into one
+  glyph, read from the font's own `GSUB`. No presentation-form (U+FExx) fallback: that route is a dead
+  end, since modern Arabic faces omit the block and rely on `GSUB` alone.
+  Three modules, each with one job. **`utils/gsub.ts`** reads script → langsys → feature → lookup and
+  runs the types that carry Arabic: **1** (one glyph becomes another — that IS the joining), **4**
+  (several collapse into one — lam-alef) and **7** (the extension wrapper big fonts hide the rest
+  behind). Any other type is REPORTED, never guessed at. **`text/arabic.ts`** holds the Unicode 17.0.0
+  joining types (187 ranges, binary-searched); transparent marks are folded in from the character
+  database because `ArabicShaping.txt` lists almost none of them. **`text/shape.ts`** is the only place
+  the two meet.
+  **The rule that cost the most: shaping sees the LOGICAL text, and its GLYPHS are reversed after.** A
+  letter's form comes from its neighbours, and bidi has already swapped them — shaping the drawn text
+  gave a word 42.5 pt where it should be 34.4, and measuring and drawing were wrong TOGETHER, so
+  nothing looked inconsistent. `VisualRun.logical` exists for exactly this.
+  Two more that are easy to miss: **kerning is off for a shaped run** (its pairs are keyed by unshaped
+  glyphs, and the `TJ` path would re-shape each chunk in isolation, turning every letter isolated), and
+  **`letterSpacing` counts DRAWN glyphs**, since a ligature is one glyph for two code points.
+  `TextRun.glyphs` is the new IR field — a shaped run cannot be expressed as a string. `ToUnicode` maps
+  each shaped glyph back to the letters that were WRITTEN (recorded at shaping time, the only moment
+  both are known), so copied text is real Arabic and not presentation forms.
+  **Verified against headless Chrome AND react-pdf 4.5.1**: identical word widths to 0.1 pt and
+  identical extracted text. Demo `claude-data/out/bidi/bidi.pdf`.
+  Not built, none blocking: lookup type **6** (chained context — Naskh picks between two heights of the
+  hah family; same advance, so nothing shifts), **GPOS mark positioning**, the discretionary `liga`, and
+  scripts beyond the Arabic family. All in `todo.md`.
 
 Genuine remaining gaps / deferred:
 
@@ -643,7 +669,7 @@ below), `@jasy/cli`@alpha.6, `@jasy/vue`@alpha.7, `@jasy/nuxt`@alpha.6** (the al
 page-break control — the termination guard, `PageBreak`, `breakBefore`/`breakAfter`, `keepTogether` — plus
 kerning turned on by default). Repo public + locked, full CI + changelog +
 bots in place (see Repo facts). The engine is **feature-complete for the alpha** — inheritance, `onOverflow`,
-custom formats, the line-breaker fixes; **954 tests green** (the root run, i.e. everything but
+custom formats, the line-breaker fixes; **996 tests green** (the root run, i.e. everything but
 `@jasy/nuxt`). The **landing**
 (`~/projects/jasy-landing` → **jasy.dev**) is built: showroom (12 cards), validator, docs, a home-page
 roadmap section, and a full **SEO + AI-discoverability layer** (OG image, JSON-LD, `robots.txt`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -589,9 +589,10 @@ agree: true })` → declarative values, not object mutation. Save is an **increm
   both are known), so copied text is real Arabic and not presentation forms.
   **Verified against headless Chrome AND react-pdf 4.5.1**: identical word widths to 0.1 pt and
   identical extracted text. Demo `claude-data/out/bidi/bidi.pdf`.
-  Not built, none blocking: lookup type **6** (chained context — Naskh picks between two heights of the
-  hah family; same advance, so nothing shifts), **GPOS mark positioning**, the discretionary `liga`, and
-  scripts beyond the Arabic family. All in `todo.md`.
+  Not built, none blocking: lookup type **6** (chained context) and **GPOS mark positioning** — measured
+  2026-08-02, **react-pdf does neither either**: on vocalised Arabic our ink box and its are identical to
+  the pixel and only Chrome differs, by 3 px on one mark. Also the discretionary `liga` (Latin, nothing
+  to do with RTL) and scripts beyond the Arabic family. All in `todo.md`.
 
 Genuine remaining gaps / deferred:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,8 +230,8 @@ rendering. This is the standing visual check; prefer it over one-off `scripts/ru
 - `pnpm test` — Vitest (watch). `pnpm exec vitest run` for a one-shot CI-style run.
   `pnpm run test:coverage` for coverage. Unit tests live in **`tests/unit/`**, mirroring the `src/lib/`
   structure (`tests/unit/{common,elements,renderer,utils}/…`). `src/` is pure production code — the
-  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **936 tests, green** —
-  what the root run covers: core 839, `@jasy/cli` 37, `@jasy/vue` 33, `@jasy/e-invoice` 27. `@jasy/nuxt`
+  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **954 tests, green** —
+  what the root run covers: core 857, `@jasy/cli` 37, `@jasy/vue` 33, `@jasy/e-invoice` 27. `@jasy/nuxt`
   is excluded from it (`vitest.config.ts`) and runs on its own.
 - `pnpm run build` — `tsc` → `dist/`.
 - `pnpm run lint` (oxlint) + `pnpm run fmt:check` (oxfmt `--check`); `pnpm run fmt` formats. **Run `pnpm run fmt`
@@ -536,6 +536,37 @@ agree: true })` → declarative values, not object mutation. Save is an **increm
   number DOES change the bytes so the check cannot pass vacuously. The honest limit: byte-stable per
   library VERSION — a bump may legitimately change output, as turning kerning on did.
 
+- ✅ **Bidirectional text - ORDERING** (2026-08-02) — Hebrew, and mixed Hebrew/Latin/digits, come out in
+  the order a reader expects. `Text({ direction: "rtl" })`, inheritable from `Document`/`DefaultTextStyle`
+  like every other text style. The whole seam is **`src/lib/text/bidi.ts`** (`visualRunsOf`): one LINE of
+  pieces in, the runs to DRAW out, left to right. UAX #9 itself comes from `bidi-js` — the same library
+  react-pdf uses — and **nothing outside that file knows it exists**, so replacing it with our own is a
+  one-file change (a named `todo.md` item; the dep is unmaintained since 2023 and ships no types, hence
+  `src/types/bidi-js.d.ts`).
+  Why it was not a rewrite: bidi runs AFTER line breaking, per finished line, and `pushLine` already
+  emitted a line as runs with their own absolute x — so reordering is a permutation plus recomputed x.
+  Decorations and links follow for free, since they hang off the same x/advance.
+  Three things that are easy to get wrong and are pinned by tests: the algorithm runs over the **whole
+  line across span boundaries** (each run remembers its span, so it keeps that font/colour/link) — doing
+  it per span would leave a Hebrew span in source order; a **surrogate pair** is two code units at one
+  level, so a naive reversal splits an emoji in Hebrew text into two broken halves; and the fast path is
+  a strict **pass-through** (same pieces, empty ones included) so every existing document stays
+  byte-identical — 30/30 gallery unchanged.
+  `HorizontalAlignment.start` is new and is now the DEFAULT: CSS `text-align: start`, resolved to left in
+  `ltr` and right in `rtl` at the ONE place alignment is consumed. That is what makes an rtl paragraph
+  begin on the right without anyone asking.
+  **Verified against headless Chrome AND react-pdf 4.5.1**, not against our own reasoning: on Hebrew we
+  and react-pdf are identical character for character, and both sit within 1 pt of Chrome — a Latin
+  sentence with Hebrew in it, an rtl base line, digits inside rtl text, and bracket **mirroring**. Demo
+  `claude-data/out/bidi/bidi.pdf` (`claude-data/gallery/bidi-demo.ts`).
+  The react-pdf run is what caught the one real bug: `getMirroredCharactersMap` wants the LEVEL ARRAY
+  while bidi-js's README passes the result object, so it returned an empty map and no bracket was ever
+  mirrored — and our own test was vacuously green because it asserted the broken order. Known gap, in
+  `todo.md`: we SUBSTITUTE the mirrored character (as react-pdf does) where Chrome keeps the original and
+  mirrors the glyph, so extracted text has swapped brackets.
+  **Arabic is ORDERED correctly but not SHAPED** — letters do not join yet (that is `GSUB`, its own
+  project; the x positions are the only thing that differs from Chrome). Deliberate, and in `todo.md`.
+
 Genuine remaining gaps / deferred:
 
 1. **Absolute positioning — Stages 1+2 built** (2026-06-21). CSS-style: `Box({ relative: true })` is a
@@ -612,7 +643,7 @@ below), `@jasy/cli`@alpha.6, `@jasy/vue`@alpha.7, `@jasy/nuxt`@alpha.6** (the al
 page-break control — the termination guard, `PageBreak`, `breakBefore`/`breakAfter`, `keepTogether` — plus
 kerning turned on by default). Repo public + locked, full CI + changelog +
 bots in place (see Repo facts). The engine is **feature-complete for the alpha** — inheritance, `onOverflow`,
-custom formats, the line-breaker fixes; **936 tests green** (the root run, i.e. everything but
+custom formats, the line-breaker fixes; **954 tests green** (the root run, i.e. everything but
 `@jasy/nuxt`). The **landing**
 (`~/projects/jasy-landing` → **jasy.dev**) is built: showroom (12 cards), validator, docs, a home-page
 roadmap section, and a full **SEO + AI-discoverability layer** (OG image, JSON-LD, `robots.txt`,
@@ -658,5 +689,5 @@ more e-invoice profiles, framework bindings). See `todo.md` "⭐ Active" + "🔮
   else = issues + fork PRs. **CodeRabbit** (`.coderabbit.yaml`) reviews PRs; **Renovate** (`renovate.json`, app
   bypass-listed in the ruleset) opens weekly dependency PRs. Community-health files (CONTRIBUTING / CODE_OF_CONDUCT /
   SECURITY / LICENSE / issue+PR templates / FUNDING) all in. Branch `main`. Runtime deps: `jimp` (images), `fflate`
-  (isomorphic deflate); the old `reflect-metadata`
-  DI is gone (decorator removed).
+  (isomorphic deflate), `bidi-js` (UAX #9, behind the `text/bidi.ts` seam and slated to be replaced by
+  our own - see `todo.md`); the old `reflect-metadata` DI is gone (decorator removed).

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "fmt:check": "oxfmt --check"
   },
   "dependencies": {
+    "bidi-js": "^1.0.3",
     "fflate": "^0.8.3",
     "jimp": "^1.6.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      bidi-js:
+        specifier: ^1.0.3
+        version: 1.0.3
       fflate:
         specifier: ^0.8.3
         version: 0.8.3
@@ -62,6 +65,16 @@ importers:
         specifier: ^2.7.0
         version: 2.7.0
 
+  packages/e-invoice:
+    dependencies:
+      '@jasy/pdf':
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
+
   packages/nuxt:
     dependencies:
       '@jasy/pdf':
@@ -76,7 +89,7 @@ importers:
     devDependencies:
       '@nuxt/devtools':
         specifier: ^3.2.4
-        version: 3.2.4(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+        version: 3.2.4(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       '@nuxt/module-builder':
         specifier: ^1.0.2
         version: 1.0.2(@nuxt/cli@3.36.0(@nuxt/schema@4.4.8)(cac@6.7.14)(magicast@0.5.3))(@vue/compiler-core@3.5.38)(esbuild@0.28.1)(typescript@6.0.3)(vue-tsc@3.3.5(typescript@6.0.3))(vue@3.5.38(typescript@6.0.3))
@@ -85,19 +98,19 @@ importers:
         version: 4.4.8
       '@nuxt/test-utils':
         specifier: ^4.0.3
-        version: 4.0.3(crossws@0.4.6(srvx@0.11.17))(esbuild@0.28.1)(magicast@0.5.3)(rollup@4.61.1)(typescript@6.0.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0)))(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
+        version: 4.0.3(crossws@0.4.6(srvx@0.11.17))(esbuild@0.28.1)(magicast@0.5.3)(rollup@4.61.1)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9(@types/node@26.1.2)(@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0)))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
       '@types/node':
         specifier: latest
-        version: 26.0.1
+        version: 26.1.2
       nuxt:
         specifier: ^4.4.8
-        version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.0.1)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.17)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0)
+        version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.17)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0)
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0)))(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@26.1.2)(@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0)))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vue-tsc:
         specifier: ^3.3.3
         version: 3.3.5(typescript@6.0.3)
@@ -142,16 +155,6 @@ importers:
       vue-pdf-embed:
         specifier: ^2.1.5
         version: 2.1.5(vue@3.5.38(typescript@5.9.3))
-
-  packages/e-invoice:
-    dependencies:
-      '@jasy/pdf':
-        specifier: workspace:*
-        version: link:../..
-    devDependencies:
-      '@types/node':
-        specifier: ^25.9.3
-        version: 25.9.3
 
 packages:
 
@@ -2271,8 +2274,8 @@ packages:
   '@types/node@25.9.3':
     resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
-  '@types/node@26.0.1':
-    resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
+  '@types/node@26.1.2':
+    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -2625,6 +2628,9 @@ packages:
     resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -4457,6 +4463,10 @@ packages:
   regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
     hasBin: true
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -6388,19 +6398,19 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@2.7.0(magicast@0.5.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@nuxt/devtools-kit@2.7.0(magicast@0.5.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@nuxt/kit': 3.21.8(magicast@0.5.3)
       execa: 8.0.1
-      vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/devtools-kit@3.2.4(magicast@0.5.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@nuxt/devtools-kit@3.2.4(magicast@0.5.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       execa: 8.0.1
-      vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - magicast
 
@@ -6415,9 +6425,9 @@ snapshots:
       pkg-types: 2.3.1
       semver: 7.8.3
 
-  '@nuxt/devtools@3.2.4(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))':
+  '@nuxt/devtools@3.2.4(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))':
     dependencies:
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@nuxt/devtools-wizard': 3.2.4
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       '@vue/devtools-core': 8.1.3(vue@3.5.38(typescript@6.0.3))
@@ -6445,9 +6455,9 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 2.0.0
       tinyglobby: 0.2.17
-      vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-plugin-inspect: 11.4.1(@nuxt/kit@4.4.8(magicast@0.5.3))(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      vite-plugin-vue-tracer: 1.4.0(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-plugin-inspect: 11.4.1(@nuxt/kit@4.4.8(magicast@0.5.3))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vite-plugin-vue-tracer: 1.4.0(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       which: 6.0.1
       ws: 8.21.0
     transitivePeerDependencies:
@@ -6530,7 +6540,7 @@ snapshots:
       - vue
       - vue-tsc
 
-  '@nuxt/nitro-server@4.4.8(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(db0@0.3.4)(esbuild@0.28.1)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.0.1)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.17)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0))(oxc-parser@0.133.0)(rollup@4.61.1)(srvx@0.11.17)(typescript@6.0.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@nuxt/nitro-server@4.4.8(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(db0@0.3.4)(esbuild@0.28.1)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.17)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0))(oxc-parser@0.133.0)(rollup@4.61.1)(srvx@0.11.17)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
@@ -6544,11 +6554,11 @@ snapshots:
       escape-string-regexp: 5.0.0
       exsolve: 1.1.0
       h3: 1.15.11
-      impound: 1.1.5(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      impound: 1.1.5(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(oxc-parser@0.133.0)(srvx@0.11.17)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.0.1)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.17)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0)
+      nitropack: 2.13.4(oxc-parser@0.133.0)(srvx@0.11.17)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.17)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0)
       nypm: 0.6.7
       ohash: 2.0.11
       pathe: 2.0.3
@@ -6625,10 +6635,10 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/test-utils@4.0.3(crossws@0.4.6(srvx@0.11.17))(esbuild@0.28.1)(magicast@0.5.3)(rollup@4.61.1)(typescript@6.0.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0)))(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))':
+  '@nuxt/test-utils@4.0.3(crossws@0.4.6(srvx@0.11.17))(esbuild@0.28.1)(magicast@0.5.3)(rollup@4.61.1)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9(@types/node@26.1.2)(@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0)))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))':
     dependencies:
       '@clack/prompts': 1.2.0
-      '@nuxt/devtools-kit': 2.7.0(magicast@0.5.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@nuxt/devtools-kit': 2.7.0(magicast@0.5.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@nuxt/kit': 3.21.8(magicast@0.5.3)
       c12: 3.3.4(magicast@0.5.3)
       consola: 3.4.2
@@ -6653,11 +6663,11 @@ snapshots:
       std-env: 4.1.0
       tinyexec: 1.2.4
       ufo: 1.6.4
-      unplugin: 3.2.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      vitest-environment-nuxt: 2.0.0(crossws@0.4.6(srvx@0.11.17))(esbuild@0.28.1)(magicast@0.5.3)(rollup@4.61.1)(typescript@6.0.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0)))(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
+      unplugin: 3.2.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest-environment-nuxt: 2.0.0(crossws@0.4.6(srvx@0.11.17))(esbuild@0.28.1)(magicast@0.5.3)(rollup@4.61.1)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9(@types/node@26.1.2)(@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0)))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
       vue: 3.5.38(typescript@6.0.3)
     optionalDependencies:
-      vitest: 4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0)))(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@26.1.2)(@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0)))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -6672,12 +6682,12 @@ snapshots:
       - vite
       - webpack
 
-  '@nuxt/vite-builder@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@types/node@26.0.1)(eslint@10.5.0(jiti@2.7.0))(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.0.1)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.17)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0))(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vue-tsc@3.3.5(typescript@6.0.3))(vue@3.5.38(typescript@6.0.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@types/node@26.1.2)(eslint@10.5.0(jiti@2.7.0))(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.17)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0))(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vue-tsc@3.3.5(typescript@6.0.3))(vue@3.5.38(typescript@6.0.3))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.61.1)
-      '@vitejs/plugin-vue': 6.0.7(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
-      '@vitejs/plugin-vue-jsx': 5.1.6(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+      '@vitejs/plugin-vue': 6.0.7(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+      '@vitejs/plugin-vue-jsx': 5.1.6(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       autoprefixer: 10.5.2(postcss@8.5.15)
       consola: 3.4.2
       cssnano: 8.0.2(postcss@8.5.15)
@@ -6690,7 +6700,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.0.1)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.17)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0)
+      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.17)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0)
       nypm: 0.6.7
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -6699,9 +6709,9 @@ snapshots:
       std-env: 4.1.0
       ufo: 1.6.4
       unenv: 2.0.0-rc.24
-      vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-node: 5.3.0(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-plugin-checker: 0.14.4(eslint@10.5.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.70.0)(typescript@6.0.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-node: 5.3.0(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-plugin-checker: 0.14.4(eslint@10.5.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.70.0)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))
       vue: 3.5.38(typescript@6.0.3)
       vue-bundle-renderer: 2.3.1
     optionalDependencies:
@@ -7327,7 +7337,7 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
-  '@types/node@26.0.1':
+  '@types/node@26.1.2':
     dependencies:
       undici-types: 8.3.0
 
@@ -7358,14 +7368,14 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@5.1.6(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))':
+  '@vitejs/plugin-vue-jsx@5.1.6(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
       '@rolldown/pluginutils': 1.0.1
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.7)
-      vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue: 3.5.38(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
@@ -7375,10 +7385,10 @@ snapshots:
       vite: 6.4.3(@types/node@25.9.3)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue: 3.5.38(typescript@5.9.3)
 
-  '@vitejs/plugin-vue@6.0.7(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue: 3.5.38(typescript@6.0.3)
 
   '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0))':
@@ -7423,13 +7433,13 @@ snapshots:
     optionalDependencies:
       vite: 5.4.21(@types/node@25.9.3)(terser@5.48.0)
 
-  '@vitest/mocker@4.1.9(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.9(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -7780,6 +7790,10 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.38: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bindings@1.5.0:
     dependencies:
@@ -8675,12 +8689,12 @@ snapshots:
     dependencies:
       '@types/node': 16.9.1
 
-  impound@1.1.5(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  impound@1.1.5(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       es-module-lexer: 2.1.0
       pathe: 2.0.3
-      unplugin: 3.2.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      unplugin: 3.2.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       unplugin-utils: 0.3.1
     transitivePeerDependencies:
       - '@farmfe/core'
@@ -8933,12 +8947,12 @@ snapshots:
       ufo: 1.6.4
       unplugin: 2.3.11
 
-  magic-regexp@0.11.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  magic-regexp@0.11.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       magic-string: 0.30.21
       regexp-tree: 0.1.27
       type-level-regexp: 0.1.17
-      unplugin: 3.2.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      unplugin: 3.2.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -9070,7 +9084,7 @@ snapshots:
 
   ncp@2.0.0: {}
 
-  nitropack@2.13.4(oxc-parser@0.133.0)(srvx@0.11.17)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  nitropack@2.13.4(oxc-parser@0.133.0)(srvx@0.11.17)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.61.1)
@@ -9135,7 +9149,7 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.5.0
       unenv: 2.0.0-rc.24
-      unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.133.0)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.133.0)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
       untyped: 2.0.0
@@ -9216,16 +9230,16 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.0.1)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.17)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0):
+  nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.17)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.3)
       '@nuxt/cli': 3.36.0(@nuxt/schema@4.4.8)(cac@6.7.14)(magicast@0.5.3)
-      '@nuxt/devtools': 3.2.4(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+      '@nuxt/devtools': 3.2.4(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.8(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(db0@0.3.4)(esbuild@0.28.1)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.0.1)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.17)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0))(oxc-parser@0.133.0)(rollup@4.61.1)(srvx@0.11.17)(typescript@6.0.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@nuxt/nitro-server': 4.4.8(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(db0@0.3.4)(esbuild@0.28.1)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.17)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0))(oxc-parser@0.133.0)(rollup@4.61.1)(srvx@0.11.17)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@nuxt/schema': 4.4.8
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.8(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@types/node@26.0.1)(eslint@10.5.0(jiti@2.7.0))(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.0.1)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.17)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0))(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vue-tsc@3.3.5(typescript@6.0.3))(vue@3.5.38(typescript@6.0.3))(yaml@2.9.0)
+      '@nuxt/vite-builder': 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@types/node@26.1.2)(eslint@10.5.0(jiti@2.7.0))(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.17)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0))(optionator@0.9.4)(oxlint@1.70.0)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vue-tsc@3.3.5(typescript@6.0.3))(vue@3.5.38(typescript@6.0.3))(yaml@2.9.0)
       '@unhead/vue': 2.1.15(vue@3.5.38(typescript@6.0.3))
       '@vue/shared': 3.5.38
       chokidar: 5.0.0
@@ -9239,7 +9253,7 @@ snapshots:
       exsolve: 1.1.0
       hookable: 6.1.1
       ignore: 7.0.5
-      impound: 1.1.5(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      impound: 1.1.5(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       jiti: 2.7.0
       klona: 2.0.6
       knitwork: 1.3.0
@@ -9253,7 +9267,7 @@ snapshots:
       oxc-minify: 0.133.0
       oxc-parser: 0.133.0
       oxc-transform: 0.133.0
-      oxc-walker: 1.0.0(esbuild@0.28.1)(oxc-parser@0.133.0)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      oxc-walker: 1.0.0(esbuild@0.28.1)(oxc-parser@0.133.0)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       picomatch: 4.0.4
@@ -9268,15 +9282,15 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.5.0
       unhead: 2.1.15
-      unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.133.0)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      unplugin: 3.2.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      unimport: 6.3.0(esbuild@0.28.1)(oxc-parser@0.133.0)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      unplugin: 3.2.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       unrouting: 0.1.7
       untyped: 2.0.0
       vue: 3.5.38(typescript@6.0.3)
-      vue-router: 5.1.0(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+      vue-router: 5.1.0(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.6
-      '@types/node': 26.0.1
+      '@types/node': 26.1.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9471,9 +9485,9 @@ snapshots:
       '@oxc-transform/binding-win32-ia32-msvc': 0.133.0
       '@oxc-transform/binding-win32-x64-msvc': 0.133.0
 
-  oxc-walker@1.0.0(esbuild@0.28.1)(oxc-parser@0.133.0)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  oxc-walker@1.0.0(esbuild@0.28.1)(oxc-parser@0.133.0)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      magic-regexp: 0.11.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      magic-regexp: 0.11.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
       oxc-parser: 0.133.0
     transitivePeerDependencies:
@@ -9997,6 +10011,8 @@ snapshots:
 
   regexp-tree@0.1.27: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-from@5.0.0: {}
 
   resolve@1.22.12:
@@ -10454,7 +10470,7 @@ snapshots:
 
   unicorn-magic@0.4.0: {}
 
-  unimport@6.3.0(esbuild@0.28.1)(oxc-parser@0.133.0)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  unimport@6.3.0(esbuild@0.28.1)(oxc-parser@0.133.0)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       acorn: 8.17.0
       escape-string-regexp: 5.0.0
@@ -10468,7 +10484,7 @@ snapshots:
       scule: 1.3.0
       strip-literal: 3.1.0
       tinyglobby: 0.2.17
-      unplugin: 3.2.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      unplugin: 3.2.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       unplugin-utils: 0.3.1
     optionalDependencies:
       oxc-parser: 0.133.0
@@ -10494,7 +10510,7 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unplugin@3.2.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  unplugin@3.2.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.4
@@ -10502,7 +10518,7 @@ snapshots:
     optionalDependencies:
       esbuild: 0.28.1
       rollup: 4.61.1
-      vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   unrouting@0.1.7:
     dependencies:
@@ -10565,15 +10581,15 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-dev-rpc@2.0.0(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-dev-rpc@2.0.0(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       birpc: 4.0.0
-      vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-hot-client: 2.2.0(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-hot-client: 2.2.0(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
-  vite-hot-client@2.2.0(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-hot-client@2.2.0(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   vite-node@2.1.9(@types/node@25.9.3)(terser@5.48.0):
     dependencies:
@@ -10593,13 +10609,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@5.3.0(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite-node@5.3.0(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       es-module-lexer: 2.1.0
       obug: 2.1.3
       pathe: 2.0.3
-      vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -10613,7 +10629,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.14.4(eslint@10.5.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.70.0)(typescript@6.0.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3)):
+  vite-plugin-checker@0.14.4(eslint@10.5.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.70.0)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chokidar: 5.0.0
@@ -10622,7 +10638,7 @@ snapshots:
       picomatch: 4.0.4
       proper-lockfile: 4.1.2
       tiny-invariant: 1.3.3
-      vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     optionalDependencies:
       eslint: 10.5.0(jiti@2.7.0)
       optionator: 0.9.4
@@ -10630,7 +10646,7 @@ snapshots:
       typescript: 6.0.3
       vue-tsc: 3.3.5(typescript@6.0.3)
 
-  vite-plugin-inspect@11.4.1(@nuxt/kit@4.4.8(magicast@0.5.3))(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-plugin-inspect@11.4.1(@nuxt/kit@4.4.8(magicast@0.5.3))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       ansis: 4.3.1
       error-stack-parser-es: 1.0.5
@@ -10640,19 +10656,19 @@ snapshots:
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       unplugin-utils: 0.3.1
-      vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-dev-rpc: 2.0.0(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-dev-rpc: 2.0.0(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
 
-  vite-plugin-vue-tracer@1.4.0(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
+  vite-plugin-vue-tracer@1.4.0(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.1.0
       magic-string: 0.30.21
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue: 3.5.38(typescript@6.0.3)
 
   vite@5.4.21(@types/node@25.9.3)(terser@5.48.0):
@@ -10681,7 +10697,7 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
@@ -10690,16 +10706,16 @@ snapshots:
       rollup: 4.61.1
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.0.1
+      '@types/node': 26.1.2
       fsevents: 2.3.3
       jiti: 2.7.0
       terser: 5.48.0
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest-environment-nuxt@2.0.0(crossws@0.4.6(srvx@0.11.17))(esbuild@0.28.1)(magicast@0.5.3)(rollup@4.61.1)(typescript@6.0.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0)))(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))):
+  vitest-environment-nuxt@2.0.0(crossws@0.4.6(srvx@0.11.17))(esbuild@0.28.1)(magicast@0.5.3)(rollup@4.61.1)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9(@types/node@26.1.2)(@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0)))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))):
     dependencies:
-      '@nuxt/test-utils': 4.0.3(crossws@0.4.6(srvx@0.11.17))(esbuild@0.28.1)(magicast@0.5.3)(rollup@4.61.1)(typescript@6.0.3)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0)))(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
+      '@nuxt/test-utils': 4.0.3(crossws@0.4.6(srvx@0.11.17))(esbuild@0.28.1)(magicast@0.5.3)(rollup@4.61.1)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9(@types/node@26.1.2)(@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0)))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@farmfe/core'
@@ -10759,10 +10775,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0)))(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.9(@types/node@26.1.2)(@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0)))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.9(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -10779,10 +10795,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 26.0.1
+      '@types/node': 26.1.2
       '@vitest/coverage-v8': 2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0))
     transitivePeerDependencies:
       - msw
@@ -10800,7 +10816,7 @@ snapshots:
       pdfjs-dist: 5.7.284
       vue: 3.5.38(typescript@5.9.3)
 
-  vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
+  vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 8.0.0
       '@vue-macros/common': 3.1.2(vue@3.5.38(typescript@6.0.3))
@@ -10816,13 +10832,13 @@ snapshots:
       picomatch: 4.0.4
       scule: 1.3.0
       tinyglobby: 0.2.17
-      unplugin: 3.2.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      unplugin: 3.2.0(esbuild@0.28.1)(rollup@4.61.1)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       vue: 3.5.38(typescript@6.0.3)
       yaml: 2.9.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.38
-      vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'

--- a/src/lib/api/text.ts
+++ b/src/lib/api/text.ts
@@ -2,6 +2,7 @@ import { TextElement, TextRole, TextSegment } from "../elements/text-element.ts"
 import { HorizontalAlignment } from "../elements/pdf-element.ts";
 import { FontStyle } from "../utils/pdf-object-manager.ts";
 import { TextOverflow } from "../text/line-breaker.ts";
+import type { Direction } from "../text/bidi.ts";
 import { ResolvedTextStyle } from "../text/text-style.ts";
 import { ColorInput, toColor } from "./color.ts";
 
@@ -26,6 +27,10 @@ export interface TextStyle {
   skipInk?: boolean;
   /** Extra space after every glyph, in points (CSS `letter-spacing`). Negative tightens. Default 0. */
   letterSpacing?: number;
+  /** Base writing direction (CSS `direction`): `"rtl"` starts the line on the right, for Hebrew or
+   *  Arabic. Mixed text is reordered per Unicode UAX #9 either way, so Hebrew inside an `ltr`
+   *  paragraph already comes out right - this decides where the LINE starts. */
+  direction?: Direction;
   /** External URL - makes this run an inline hyperlink (a /Link annotation over its glyphs). On a
    *  `span` it links just that run; on a whole `Text` (plain string) it links the whole text. */
   href?: string;
@@ -148,6 +153,7 @@ export function Text(content: string | TextSegment[], opts: TextOptions = {}): T
     strikethrough: opts.strikethrough,
     skipInk: opts.skipInk,
     letterSpacing: opts.letterSpacing,
+    direction: opts.direction,
     role: opts.role,
   });
 }
@@ -171,6 +177,10 @@ export interface TextDefaults {
   strikethrough?: boolean;
   skipInk?: boolean;
   letterSpacing?: number;
+  /** Base writing direction (CSS `direction`): `"rtl"` starts the line on the right, for Hebrew or
+   *  Arabic. Mixed text is reordered per Unicode UAX #9 either way, so Hebrew inside an `ltr`
+   *  paragraph already comes out right - this decides where the LINE starts. */
+  direction?: Direction;
 }
 
 /** Maps the `Text`-style option names onto a partial engine `ResolvedTextStyle` (only the set
@@ -189,5 +199,6 @@ export function toTextStyleOverride(opts: TextDefaults): Partial<ResolvedTextSty
   if (opts.strikethrough !== undefined) style.strikethrough = opts.strikethrough;
   if (opts.skipInk !== undefined) style.skipInk = opts.skipInk;
   if (opts.letterSpacing !== undefined) style.letterSpacing = opts.letterSpacing;
+  if (opts.direction !== undefined) style.direction = opts.direction;
   return style;
 }

--- a/src/lib/elements/pdf-element.ts
+++ b/src/lib/elements/pdf-element.ts
@@ -259,6 +259,9 @@ export abstract class FlexiblePDFElement extends PDFElement {
 }
 
 export enum HorizontalAlignment {
+  /** CSS `text-align: start` - the side the writing STARTS on: left in `ltr`, right in `rtl`. The
+   *  default, so a right-to-left paragraph begins on the right without anyone asking for it. */
+  start = "START",
   left = "LEFT",
   right = "RIGHT",
   center = "CENTER",

--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -8,6 +8,7 @@ import { FontStyle } from "../utils/pdf-object-manager.ts";
 import { DEFAULT_TEXT_STYLE, ResolvedTextStyle } from "../text/text-style.ts";
 import type { FontMetrics } from "../utils/font-metrics.ts";
 import { BoxConstraints, Offset, Size } from "../layout/box-constraints.ts";
+import type { Direction } from "../text/bidi.ts";
 import { Fragmentable, FragmentResult } from "../layout/fragmentation.ts";
 import {
   wrapStringIntoLines,
@@ -72,6 +73,8 @@ interface TextElementParams {
   skipInk?: boolean;
   /** Extra space after every glyph, in points (CSS `letter-spacing`). Default 0. */
   letterSpacing?: number;
+  /** Base writing direction (CSS `direction`); decides where a line starts. Default `"ltr"`. */
+  direction?: Direction;
   /** Accessibility role for the tagged structure tree (heading level or paragraph; default `"p"`). */
   role?: TextRole;
 }
@@ -89,6 +92,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
   private readonly rawStrikethrough?: boolean;
   private readonly rawSkipInk?: boolean;
   private readonly rawLetterSpacing?: number;
+  private readonly rawDirection?: Direction;
 
   // Resolved style (raw -> inherited -> built-in default). Seeded to the built-in default in the
   // constructor so the element is self-sufficient, then refined against the cascade at layout time.
@@ -102,6 +106,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
   private strikethrough!: boolean;
   private skipInk!: boolean;
   private letterSpacing!: number;
+  private direction!: Direction;
 
   private content: string | TextSegment[];
   private maxLines?: number;
@@ -126,6 +131,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     strikethrough,
     skipInk,
     letterSpacing,
+    direction,
     role,
   }: TextElementParams) {
     super({ x: 0, y: 0 });
@@ -141,6 +147,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     this.rawStrikethrough = strikethrough;
     this.rawSkipInk = skipInk;
     this.rawLetterSpacing = letterSpacing;
+    this.rawDirection = direction;
     this.content = content;
     this.maxLines = maxLines;
     this.orphans = orphans;
@@ -165,6 +172,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     this.strikethrough = this.rawStrikethrough ?? ts.strikethrough;
     this.skipInk = this.rawSkipInk ?? ts.skipInk;
     this.letterSpacing = this.rawLetterSpacing ?? ts.letterSpacing;
+    this.direction = this.rawDirection ?? ts.direction;
   }
 
   /**
@@ -234,6 +242,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       fontSize: this.fontSize,
       fontStyle: this.fontStyle,
       letterSpacing: this.letterSpacing,
+      direction: this.direction,
     };
     const lines = breakSegmentsIntoLines(
       content,
@@ -290,6 +299,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       strikethrough: this.strikethrough,
       skipInk: this.skipInk,
       letterSpacing: this.letterSpacing,
+      direction: this.direction,
       role: this.role,
     }).adoptStructId(this); // a wrapped remainder is the SAME logical paragraph (one P across pages)
   }
@@ -397,6 +407,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       strikethrough: this.strikethrough,
       skipInk: this.skipInk,
       letterSpacing: this.letterSpacing,
+      direction: this.direction,
       role: this.role,
     };
   }

--- a/src/lib/ir/display-list.ts
+++ b/src/lib/ir/display-list.ts
@@ -35,6 +35,9 @@ export interface TextRun {
   x: number;
   y: number;
   text: string; // raw text; the backend handles PDF string escaping + encoding
+  /** The glyphs to draw, when the run was SHAPED. The backend emits these instead of encoding `text`,
+   *  which stays logical for `ToUnicode` and the accessible tree. */
+  glyphs?: number[];
   fontFamily: string;
   fontStyle: FontStyle;
   fontSize: number;

--- a/src/lib/renderer/pdf-backend.ts
+++ b/src/lib/renderer/pdf-backend.ts
@@ -352,15 +352,23 @@ export class PdfBackend {
           isCustom
             ? `<${om.encodeCustomText(node.fontFamily, t, node.fontStyle)}>`
             : `(${PdfBackend.escapePdfString(t)})`;
+        // A shaped run brings its own glyphs, already in drawing order - they cannot be derived from
+        // the text here.
+        const shapedHex =
+          node.glyphs && isCustom
+            ? om.registerGlyphs(node.fontFamily, node.glyphs, node.fontStyle)
+            : undefined;
         // Kerning (if the document has it on): a `TJ` array with the font's per-pair adjustments
         // between glyph chunks, measured into the layout by the SAME numbers (runAdvance). A plain
         // `Tj` when the run has no kerning, byte-identical.
         const kerns = om.kerningEnabled
           ? om.getKernPairs(node.text, node.fontFamily, node.fontStyle)
           : [];
-        const showOp = kerns.some((k) => k !== 0)
-          ? `${PdfBackend.kernedArray(node.text, kerns, encode)} TJ`
-          : `${encode(node.text)} Tj`;
+        const showOp = shapedHex
+          ? `<${shapedHex}> Tj`
+          : kerns.some((k) => k !== 0)
+            ? `${PdfBackend.kernedArray(node.text, kerns, encode)} TJ`
+            : `${encode(node.text)} Tj`;
         // letterSpacing is the `Tc` operator: extra advance after EVERY glyph (an embedded
         // Identity-H font too - that is `Tw`, word spacing, which only touches single-byte code 32).
         const spacing = node.letterSpacing ? `${node.letterSpacing.toFixed(3)} Tc\n` : "";

--- a/src/lib/renderer/text-renderer.ts
+++ b/src/lib/renderer/text-renderer.ts
@@ -371,8 +371,8 @@ export class TextRenderer {
     const decorations: Line[] = [];
 
     // Horizontal offset of a line of the given width under the current alignment.
-    // `start` means the side the writing begins on, so it is the one alignment that depends on the
-    // direction. Resolved HERE, the single place alignment is consumed.
+    // `start` is the one alignment that depends on the direction, resolved at the single place
+    // alignment is consumed.
     const align =
       textAlignment === HorizontalAlignment.start
         ? direction === "rtl"
@@ -472,6 +472,23 @@ export class TextRenderer {
       return skipInkSegments(runWidth, inkSpans, stroke.thickness);
     };
 
+    /**
+     * One drawn piece of a line. SHAPING must see the run's LOGICAL text - a letter's form comes from
+     * its neighbours, and a reversed run has those swapped - so we shape that and then reverse the
+     * GLYPHS for an rtl run. A font that does not shape keeps the old path exactly: draw the visual
+     * text, no glyph list, byte-identical output.
+     */
+    const shapedPiece = (
+      part: { text: string; logical: string; rtl: boolean },
+      family: string,
+      style: FontStyle,
+    ): { text: string; glyphs?: number[] } => {
+      const shaped = objectManager.shapeText(part.logical, family, style);
+      if (!shaped) return { text: part.text };
+      const ordered = part.rtl ? [...shaped].reverse() : shaped;
+      return { text: part.logical, glyphs: ordered.map((g) => g.glyph) };
+    };
+
     // The advance the viewer will use: plain glyph widths (a `Tj` never kerns) plus one
     // `letterSpacing` per code point (the `Tc` operator), from the one shared `advance.ts` primitive.
     const font = { fontFamily, fontSize, fontStyle };
@@ -496,15 +513,16 @@ export class TextRenderer {
         const lineWidth = runAdvance(objectManager, line, font, letterSpacing);
         let x = initialX + alignmentOffset(lineWidth);
         const baseline = yPosition + box.baseline + box.height * index;
-        // Bidi: one line becomes the pieces that are DRAWN, left to right. Latin-only text in an
-        // `ltr` paragraph comes back as the single original string, so nothing changes for it.
+        // Latin-only text in an `ltr` paragraph comes back as one unchanged piece.
         for (const part of visualRuns(line, direction)) {
-          const partWidth = runAdvance(objectManager, part.text, font, letterSpacing);
+          const piece = shapedPiece(part, fontFamily, fontStyle);
+          const partWidth = runAdvance(objectManager, piece.text, font, letterSpacing);
           runs.push({
             type: "text",
             x,
             y: baseline,
-            text: part.text,
+            text: piece.text,
+            ...(piece.glyphs ? { glyphs: piece.glyphs } : {}),
             fontFamily,
             fontStyle,
             fontSize,
@@ -512,7 +530,7 @@ export class TextRenderer {
             ...(letterSpacing ? { letterSpacing } : {}),
           });
           decorate(
-            part.text,
+            piece.text,
             x,
             partWidth,
             baseline,
@@ -537,18 +555,20 @@ export class TextRenderer {
     // height matches the measured height.
     const pushLine = (line: SegmentLine, lineY: number): void => {
       let x = initialX + alignmentOffset(line.width);
-      // Bidi runs over the WHOLE line, across span boundaries - a Hebrew span beside a Latin one has to
-      // be ordered against its neighbours, not inside itself. Each returned run carries the segment it
-      // came from, so it keeps that span's font, colour, decoration and link.
+      // Across span boundaries, so a Hebrew span is ordered against its neighbours rather than inside
+      // itself. Each run keeps the segment it came from, and with it that span's style.
       const ordered = visualRunsOf(
         line.segments.map((segment) => ({ text: segment.content, source: segment })),
         direction,
       );
-      ordered.forEach(({ text: runText, source: segment }) => {
+      ordered.forEach((part) => {
+        const segment = part.source;
         const family = segment.fontFamily || fontFamily;
         const size = segment.fontSize || fontSize;
         const style = segment.fontStyle || fontStyle;
         const segLetterSpacing = segment.letterSpacing ?? letterSpacing;
+        const piece = shapedPiece(part, family, style);
+        const runText = piece.text;
         const advance = runAdvance(
           objectManager,
           runText,
@@ -561,6 +581,7 @@ export class TextRenderer {
           x,
           y: lineY,
           text: runText,
+          ...(piece.glyphs ? { glyphs: piece.glyphs } : {}),
           fontFamily: family,
           fontStyle: style,
           fontSize: size,

--- a/src/lib/renderer/text-renderer.ts
+++ b/src/lib/renderer/text-renderer.ts
@@ -164,6 +164,12 @@ export class TextRenderer {
         : undefined;
     const imageSource = om.getEmojiImageSource();
     if (!own && !fallback && !imageSource) return [run];
+    // A SHAPED run cannot be split here: the sub-runs are cut by code point, while `glyphs` is a
+    // drawn-order list in which a ligature is one glyph for several code points - so no sub-run could
+    // be given the right slice, and inheriting the whole list would draw every glyph again per piece.
+    // Passed through whole instead: an emoji inside Arabic then comes from the text font rather than
+    // the emoji source (`todo.md`).
+    if (run.glyphs) return [run];
 
     const nodes: IRNode[] = [];
     let cursorX = run.x; // absolute x of the next glyph

--- a/src/lib/renderer/text-renderer.ts
+++ b/src/lib/renderer/text-renderer.ts
@@ -21,6 +21,7 @@ import {
 } from "../text/line-breaker.ts";
 import { lineBoxForSegmentLine, lineBoxForString } from "../text/line-metrics.ts";
 import { runAdvance } from "../text/advance.ts";
+import { visualRuns, visualRunsOf, type Direction } from "../text/bidi.ts";
 import {
   DecorationStroke,
   skipInkSegments,
@@ -98,6 +99,7 @@ export class TextRenderer {
       strikethrough,
       skipInk,
       letterSpacing,
+      direction,
       role,
     } = textElement.getProps();
 
@@ -122,6 +124,7 @@ export class TextRenderer {
       strikethrough,
       skipInk,
       letterSpacing,
+      direction,
     );
 
     // Accessible tagging: this whole text block is one structure element (a paragraph P, or a heading
@@ -357,6 +360,7 @@ export class TextRenderer {
     strikethrough = false,
     skipInk = false,
     letterSpacing = 0,
+    direction: Direction = "ltr",
   ): { runs: TextRun[]; links: Link[]; decorations: Line[] } {
     const runs: TextRun[] = [];
     // /Link annotation rects for any `href` spans, collected as we place segments. Empty for the
@@ -367,9 +371,17 @@ export class TextRenderer {
     const decorations: Line[] = [];
 
     // Horizontal offset of a line of the given width under the current alignment.
+    // `start` means the side the writing begins on, so it is the one alignment that depends on the
+    // direction. Resolved HERE, the single place alignment is consumed.
+    const align =
+      textAlignment === HorizontalAlignment.start
+        ? direction === "rtl"
+          ? HorizontalAlignment.right
+          : HorizontalAlignment.left
+        : textAlignment;
     const alignmentOffset = (lineWidth: number): number => {
-      if (textAlignment === HorizontalAlignment.center) return (maxWidth - lineWidth) / 2;
-      if (textAlignment === HorizontalAlignment.right) return maxWidth - lineWidth;
+      if (align === HorizontalAlignment.center) return (maxWidth - lineWidth) / 2;
+      if (align === HorizontalAlignment.right) return maxWidth - lineWidth;
       return 0;
     };
 
@@ -482,32 +494,38 @@ export class TextRenderer {
       const box = lineBoxForString(objectManager, fontFamily, fontStyle, fontSize, lineHeight);
       lines.forEach((line, index) => {
         const lineWidth = runAdvance(objectManager, line, font, letterSpacing);
-        const x = initialX + alignmentOffset(lineWidth);
+        let x = initialX + alignmentOffset(lineWidth);
         const baseline = yPosition + box.baseline + box.height * index;
-        runs.push({
-          type: "text",
-          x,
-          y: baseline,
-          text: line,
-          fontFamily,
-          fontStyle,
-          fontSize,
-          color,
-          ...(letterSpacing ? { letterSpacing } : {}),
-        });
-        decorate(
-          line,
-          x,
-          lineWidth,
-          baseline,
-          fontFamily,
-          fontStyle,
-          fontSize,
-          color,
-          underline,
-          strikethrough,
-          letterSpacing,
-        );
+        // Bidi: one line becomes the pieces that are DRAWN, left to right. Latin-only text in an
+        // `ltr` paragraph comes back as the single original string, so nothing changes for it.
+        for (const part of visualRuns(line, direction)) {
+          const partWidth = runAdvance(objectManager, part.text, font, letterSpacing);
+          runs.push({
+            type: "text",
+            x,
+            y: baseline,
+            text: part.text,
+            fontFamily,
+            fontStyle,
+            fontSize,
+            color,
+            ...(letterSpacing ? { letterSpacing } : {}),
+          });
+          decorate(
+            part.text,
+            x,
+            partWidth,
+            baseline,
+            fontFamily,
+            fontStyle,
+            fontSize,
+            color,
+            underline,
+            strikethrough,
+            letterSpacing,
+          );
+          x += partWidth;
+        }
       });
       return { runs, links, decorations };
     }
@@ -519,14 +537,21 @@ export class TextRenderer {
     // height matches the measured height.
     const pushLine = (line: SegmentLine, lineY: number): void => {
       let x = initialX + alignmentOffset(line.width);
-      line.segments.forEach((segment) => {
+      // Bidi runs over the WHOLE line, across span boundaries - a Hebrew span beside a Latin one has to
+      // be ordered against its neighbours, not inside itself. Each returned run carries the segment it
+      // came from, so it keeps that span's font, colour, decoration and link.
+      const ordered = visualRunsOf(
+        line.segments.map((segment) => ({ text: segment.content, source: segment })),
+        direction,
+      );
+      ordered.forEach(({ text: runText, source: segment }) => {
         const family = segment.fontFamily || fontFamily;
         const size = segment.fontSize || fontSize;
         const style = segment.fontStyle || fontStyle;
         const segLetterSpacing = segment.letterSpacing ?? letterSpacing;
         const advance = runAdvance(
           objectManager,
-          segment.content,
+          runText,
           { fontFamily: family, fontSize: size, fontStyle: style },
           segLetterSpacing,
         );
@@ -535,7 +560,7 @@ export class TextRenderer {
           type: "text",
           x,
           y: lineY,
-          text: segment.content,
+          text: runText,
           fontFamily: family,
           fontStyle: style,
           fontSize: size,
@@ -543,7 +568,7 @@ export class TextRenderer {
           ...(segLetterSpacing ? { letterSpacing: segLetterSpacing } : {}),
         });
         decorate(
-          segment.content,
+          runText,
           x,
           advance,
           lineY,

--- a/src/lib/text/advance.ts
+++ b/src/lib/text/advance.ts
@@ -46,7 +46,12 @@ export function runAdvance(
   letterSpacing = 0,
 ): number {
   let advance = metrics.getStringWidth(text, font.fontFamily, font.fontSize, font.fontStyle);
-  if (letterSpacing !== 0) advance += codePointCount(text) * letterSpacing;
+  if (letterSpacing !== 0) {
+    // Per DRAWN glyph, which is what `Tc` applies to; only a ligature makes that differ.
+    const glyphs =
+      metrics.shapedGlyphCount?.(text, font.fontFamily, font.fontStyle) ?? codePointCount(text);
+    advance += glyphs * letterSpacing;
+  }
   if (metrics.kerningEnabled) {
     let units = 0;
     for (const k of metrics.getKernPairs(text, font.fontFamily, font.fontStyle)) units += k;

--- a/src/lib/text/arabic.ts
+++ b/src/lib/text/arabic.ts
@@ -1,0 +1,106 @@
+/**
+ * Arabic (and Syriac / N'Ko / Adlam) JOINING: which of the four positional forms each letter takes -
+ * the half of shaping Unicode owns. Runs on the LOGICAL string.
+ *
+ * Name the SIDES, not the neighbours: a letter is joined on its right when the preceding one can join
+ * forwards (type D or L), on its left when the following one can join backwards (D or R). Thinking in
+ * "previous/next" puts a final form where an initial belongs.
+ */
+
+/**
+ * Joining types, from Unicode 17.0.0 `ArabicShaping.txt`, packed as `start,length,type` in hex.
+ * Anything not listed is `U` (non-joining), which is the standard's own default.
+ *
+ * `T` (transparent - combining marks) is mostly NOT in that file: the standard says an unlisted mark
+ * (category Mn/Me/Cf) is transparent, so those ranges are folded in from the character database.
+ */
+const PACKED =
+  "300,6f,5 483,6,5 591,2c,5 5bf,0,5 5c1,1,5 5c4,1,5 5c7,0,5 610,a,5 61c,0,5 620,0,1 622,3,2" +
+  "  626,0,1 627,0,2 628,0,1 629,0,2 62a,4,1 62f,3,2 633,c,1 640,0,4 641,6,1 648,0,2 649,1,1 64b,14,5" +
+  "  66e,1,1 670,0,5 671,2,2 675,2,2 678,f,1 688,11,2 69a,25,1 6c0,0,2 6c1,1,1 6c3,8,2 6cc,0,1" +
+  "  6cd,0,2 6ce,0,1 6cf,0,2 6d0,1,1 6d2,1,2 6d5,0,2 6d6,6,5 6df,5,5 6e7,1,5 6ea,3,5 6ee,1,2 6fa,2,1" +
+  "  6ff,0,1 70f,0,5 710,0,2 711,0,5 712,2,1 715,4,2 71a,3,1 71e,0,2 71f,8,1 728,0,2 729,0,1 72a,0,2" +
+  "  72b,0,1 72c,0,2 72d,1,1 72f,0,2 730,1a,5 74d,0,2 74e,a,1 759,2,2 75c,e,1 76b,1,2 76d,3,1 771,0,2" +
+  "  772,0,1 773,1,2 775,2,1 778,1,2 77a,5,1 7a6,a,5 7ca,20,1 7eb,8,5 7fa,0,4 7fd,0,5 816,3,5 81b,8,5" +
+  "  825,2,5 829,4,5 840,0,2 841,4,1 846,1,2 848,0,1 849,0,2 84a,9,1 854,0,2 855,0,1 856,2,2 859,2,5" +
+  "  860,0,1 862,3,1 867,0,2 868,0,1 869,1,2 870,12,2 883,2,4 886,0,1 889,4,1 88e,0,2 88f,0,1 897,8,5" +
+  "  8a0,9,1 8aa,2,2 8ae,0,2 8af,1,1 8b1,1,2 8b3,5,1 8b9,0,2 8ba,e,1 8ca,17,5 8e3,1c,5 1807,0,1" +
+  "  180a,0,4 1820,58,1 1885,1,5 1887,21,1 18aa,0,1 200d,0,4 a840,31,1 a872,0,3 fe00,f,5 fe20,f,5" +
+  "  10ac0,4,1 10ac5,0,2 10ac7,0,2 10ac9,1,2 10acd,0,3 10ace,4,2 10ad3,3,1 10ad7,0,3 10ad8,4,1" +
+  "  10add,0,2 10ade,2,1 10ae1,0,2 10ae4,0,2 10aeb,3,1 10aef,0,2 10b80,0,1 10b81,0,2 10b82,0,1" +
+  "  10b83,2,2 10b86,2,1 10b89,0,2 10b8a,1,1 10b8c,0,2 10b8d,0,1 10b8e,1,2 10b90,0,1 10b91,0,2" +
+  "  10ba9,3,2 10bad,1,1 10d00,0,3 10d01,20,1 10d22,0,2 10d23,0,1 10ec2,0,2 10ec3,1,1 10ec6,1,1" +
+  "  10f30,2,1 10f33,0,2 10f34,10,1 10f51,2,1 10f54,0,2 10f70,3,1 10f74,1,2 10f76,b,1 10fb0,0,1" +
+  "  10fb2,1,1 10fb4,2,2 10fb8,0,1 10fb9,1,2 10fbb,1,1 10fbd,0,2 10fbe,1,1 10fc1,0,1 10fc2,1,2" +
+  "  10fc4,0,1 10fc9,0,2 10fca,0,1 10fcb,0,3 1e900,43,1 1e94b,0,5";
+
+export type JoiningType = "D" | "R" | "L" | "C" | "T" | "U";
+/** The four positional forms, named as the OpenType features that realise them. */
+export type JoiningForm = "isol" | "init" | "medi" | "fina";
+
+const TYPES: JoiningType[] = ["U", "D", "R", "L", "C", "T"];
+
+// [start, end, typeIndex] triples, sorted by start - binary searched, so the table costs one lookup.
+const RANGES: [number, number, number][] = PACKED.trim()
+  .split(/\s+/)
+  .map((entry): [number, number, number] => {
+    const [start, length, type] = entry.split(",");
+    const from = parseInt(start, 16);
+    return [from, from + parseInt(length, 16), Number(type)];
+  });
+
+/** The joining type of one code point. `U` for everything the table does not mention. */
+export function joiningType(codePoint: number): JoiningType {
+  let lo = 0;
+  let hi = RANGES.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const [from, to, type] = RANGES[mid];
+    if (codePoint < from) hi = mid - 1;
+    else if (codePoint > to) lo = mid + 1;
+    else return TYPES[type];
+  }
+  return "U";
+}
+
+/** Whether a run contains anything the joining pass would touch. Cheap, and false for Latin. */
+export function needsJoining(codePoints: readonly number[]): boolean {
+  return codePoints.some((cp) => {
+    const t = joiningType(cp);
+    return t === "D" || t === "R" || t === "L" || t === "C";
+  });
+}
+
+/**
+ * The positional form of every code point, or `null` where none applies (space, digit, mark).
+ * `C` (tatweel, ZWJ) counts when deciding a NEIGHBOUR's form but takes none itself.
+ */
+export function joiningForms(codePoints: readonly number[]): (JoiningForm | null)[] {
+  const types = codePoints.map(joiningType);
+
+  /** The nearest neighbour that is not transparent - a mark never breaks a join. */
+  const neighbour = (from: number, step: number): JoiningType => {
+    for (let i = from + step; i >= 0 && i < types.length; i += step) {
+      if (types[i] !== "T") return types[i];
+    }
+    return "U";
+  };
+
+  return types.map((type, i) => {
+    if (type !== "D" && type !== "R" && type !== "L") return null;
+    const before = neighbour(i, -1);
+    const after = neighbour(i, +1);
+    const joinedRight = before === "D" || before === "L" || before === "C";
+    const joinedLeft = after === "D" || after === "R" || after === "C";
+
+    if (type === "D") {
+      if (joinedRight && joinedLeft) return "medi";
+      if (joinedRight) return "fina";
+      if (joinedLeft) return "init";
+      return "isol";
+    }
+    // R joins only on its right; L (a handful of Syriac letters) only on its left.
+    if (type === "R") return joinedRight ? "fina" : "isol";
+    return joinedLeft ? "init" : "isol";
+  });
+}

--- a/src/lib/text/bidi.ts
+++ b/src/lib/text/bidi.ts
@@ -1,0 +1,120 @@
+import bidiFactory from "bidi-js";
+
+/**
+ * Bidirectional text: turning ONE logical line into the runs that get drawn, left to right.
+ *
+ * This module is the whole seam. `bidi-js` implements UAX #9 (the Unicode Bidirectional Algorithm)
+ * and nothing outside this file knows it exists, so replacing it with our own implementation later
+ * is a change to this file alone - see the `todo.md` item.
+ *
+ * ORDERING only. Arabic additionally needs SHAPING (letters change form by position and join into
+ * ligatures), which is a separate piece of work and not done here.
+ */
+
+const bidi = bidiFactory();
+
+export type Direction = "ltr" | "rtl";
+
+/** A piece of a line, already in the order it is drawn. */
+export interface VisualRun {
+  /** VISUAL order: hand it to the drawing code as it stands, left to right. */
+  text: string;
+  /** True when this run came out of right-to-left text - the caller may need it for alignment. */
+  rtl: boolean;
+}
+
+/** A run that remembers which input piece it came from, so a span keeps its font and colour. */
+export interface AttributedRun<T> extends VisualRun {
+  source: T;
+}
+
+// Every block whose script runs right to left, plus the explicit bidi control characters. Used only
+// as a fast path: no match and a left-to-right base means the algorithm cannot reorder anything.
+const RTL_OR_CONTROL =
+  /[\u0590-\u08FF\u200F\u202B\u202E\u2067\uFB1D-\uFDFF\uFE70-\uFEFF]|[\uD802\uD803\uD83A\uD83B][\uDC00-\uDFFF]/;
+
+/** Whether this text could be reordered at all. Cheap, and false for every Latin-only document. */
+export const needsBidi = (text: string): boolean => RTL_OR_CONTROL.test(text);
+
+const isHighSurrogate = (c: string): boolean => c >= "\uD800" && c <= "\uDBFF";
+const isLowSurrogate = (c: string): boolean => c >= "\uDC00" && c <= "\uDFFF";
+
+/**
+ * Reorder one LINE of pieces into the runs to draw, left to right. The pieces are laid end to end and
+ * the algorithm runs over the WHOLE line, which is what makes a Hebrew span next to a Latin one come
+ * out in the right order rather than each being reordered inside itself.
+ *
+ * A run ends where the direction changes OR where the source piece does, so every returned run has
+ * exactly one direction and exactly one origin.
+ *
+ * Breaking into lines happens BEFORE this, in logical order - what UAX #9 prescribes, since the
+ * algorithm runs per finished line.
+ */
+export function visualRunsOf<T>(
+  pieces: { text: string; source: T }[],
+  base: Direction = "ltr",
+): AttributedRun<T>[] {
+  const text = pieces.map((p) => p.text).join("");
+  // The fast path hands the pieces back VERBATIM - same count, same order, empty ones included - so a
+  // caller that draws run by run produces exactly the bytes it did before bidi existed.
+  if (text === "" || (base === "ltr" && !needsBidi(text))) {
+    return pieces.map((p) => ({ ...p, rtl: false }));
+  }
+
+  // Which piece each code unit came from, so a visual run can be traced back to its span.
+  const owner = new Int32Array(text.length);
+  let at = 0;
+  pieces.forEach((piece, index) => {
+    owner.fill(index, at, at + piece.text.length);
+    at += piece.text.length;
+  });
+
+  const levels = bidi.getEmbeddingLevels(text, base);
+  const order = bidi.getReorderedIndices(text, levels);
+  // `.levels`, NOT the result object: the function indexes its argument directly, while the library's
+  // README shows the object. Passed the object it silently returns an EMPTY map and no bracket is ever
+  // mirrored - which looks like working code right up to the moment someone reads the output.
+  const mirrored = bidi.getMirroredCharactersMap(text, levels.levels);
+
+  const runs: AttributedRun<T>[] = [];
+  let current: string[] = [];
+  let currentRtl = false;
+  let currentOwner = -1;
+
+  const flush = (): void => {
+    if (current.length > 0) {
+      runs.push({ text: current.join(""), rtl: currentRtl, source: pieces[currentOwner].source });
+      current = [];
+    }
+  };
+
+  for (let k = 0; k < order.length; k++) {
+    const i = order[k];
+    const rtl = (levels.levels[i] & 1) === 1;
+    if (rtl !== currentRtl || owner[i] !== currentOwner) flush();
+    currentRtl = rtl;
+    currentOwner = owner[i];
+
+    // A surrogate PAIR is two code units at the same level, so reversing a run splits it and the
+    // astral character (an emoji in Hebrew text, say) turns into two broken halves. They arrive
+    // adjacent and swapped, so putting them back is local.
+    const next = k + 1 < order.length ? order[k + 1] : -1;
+    if (isLowSurrogate(text[i]) && next === i - 1 && isHighSurrogate(text[next])) {
+      current.push(text[next], text[i]);
+      k++;
+      continue;
+    }
+    current.push(mirrored.get(i) ?? text[i]);
+  }
+  flush();
+  return runs;
+}
+
+/**
+ * The same for one plain string. An EMPTY string still yields one (empty) run: a caller drawing line
+ * by line would otherwise skip a blank line entirely, which is a different document.
+ */
+export const visualRuns = (text: string, base: Direction = "ltr"): VisualRun[] => {
+  if (text === "") return [{ text, rtl: false }];
+  return visualRunsOf([{ text, source: null }], base).map(({ text: t, rtl }) => ({ text: t, rtl }));
+};

--- a/src/lib/text/bidi.ts
+++ b/src/lib/text/bidi.ts
@@ -1,14 +1,11 @@
 import bidiFactory from "bidi-js";
 
 /**
- * Bidirectional text: turning ONE logical line into the runs that get drawn, left to right.
+ * Bidirectional text (UAX #9): one logical line in, the runs to draw left to right out. ORDERING
+ * only - joining letters into shapes is `text/shape.ts`.
  *
- * This module is the whole seam. `bidi-js` implements UAX #9 (the Unicode Bidirectional Algorithm)
- * and nothing outside this file knows it exists, so replacing it with our own implementation later
- * is a change to this file alone - see the `todo.md` item.
- *
- * ORDERING only. Arabic additionally needs SHAPING (letters change form by position and join into
- * ligatures), which is a separate piece of work and not done here.
+ * The whole seam to `bidi-js`: nothing outside this file knows it exists, so replacing it with our
+ * own is a change here alone (`todo.md`).
  */
 
 const bidi = bidiFactory();
@@ -19,6 +16,12 @@ export type Direction = "ltr" | "rtl";
 export interface VisualRun {
   /** VISUAL order: hand it to the drawing code as it stands, left to right. */
   text: string;
+  /**
+   * The same characters in LOGICAL order. SHAPING must use this: a letter's form comes from its
+   * neighbours, and reversing swaps them - shaping the visual text gives every letter the wrong form
+   * (measured: a word 8pt too wide). Shape this, then reverse the GLYPHS.
+   */
+  logical: string;
   /** True when this run came out of right-to-left text - the caller may need it for alignment. */
   rtl: boolean;
 }
@@ -40,25 +43,21 @@ const isHighSurrogate = (c: string): boolean => c >= "\uD800" && c <= "\uDBFF";
 const isLowSurrogate = (c: string): boolean => c >= "\uDC00" && c <= "\uDFFF";
 
 /**
- * Reorder one LINE of pieces into the runs to draw, left to right. The pieces are laid end to end and
- * the algorithm runs over the WHOLE line, which is what makes a Hebrew span next to a Latin one come
- * out in the right order rather than each being reordered inside itself.
+ * Reorder one LINE of pieces into the runs to draw. The algorithm runs over the pieces JOINED, not
+ * each on its own, or a Hebrew span beside a Latin one would stay in source order. A run ends where
+ * the direction or the source piece changes.
  *
- * A run ends where the direction changes OR where the source piece does, so every returned run has
- * exactly one direction and exactly one origin.
- *
- * Breaking into lines happens BEFORE this, in logical order - what UAX #9 prescribes, since the
- * algorithm runs per finished line.
+ * Line breaking happens before this, in logical order - what UAX #9 prescribes.
  */
 export function visualRunsOf<T>(
   pieces: { text: string; source: T }[],
   base: Direction = "ltr",
 ): AttributedRun<T>[] {
   const text = pieces.map((p) => p.text).join("");
-  // The fast path hands the pieces back VERBATIM - same count, same order, empty ones included - so a
-  // caller that draws run by run produces exactly the bytes it did before bidi existed.
+  // Verbatim - same count, same order, empty pieces included - so untouched documents stay
+  // byte-identical.
   if (text === "" || (base === "ltr" && !needsBidi(text))) {
-    return pieces.map((p) => ({ ...p, rtl: false }));
+    return pieces.map((p) => ({ ...p, logical: p.text, rtl: false }));
   }
 
   // Which piece each code unit came from, so a visual run can be traced back to its span.
@@ -71,9 +70,8 @@ export function visualRunsOf<T>(
 
   const levels = bidi.getEmbeddingLevels(text, base);
   const order = bidi.getReorderedIndices(text, levels);
-  // `.levels`, NOT the result object: the function indexes its argument directly, while the library's
-  // README shows the object. Passed the object it silently returns an EMPTY map and no bracket is ever
-  // mirrored - which looks like working code right up to the moment someone reads the output.
+  // `.levels`, NOT the result object the library's README passes: it indexes its argument directly,
+  // and given the object it silently returns an empty map - no bracket ever mirrored.
   const mirrored = bidi.getMirroredCharactersMap(text, levels.levels);
 
   const runs: AttributedRun<T>[] = [];
@@ -83,7 +81,13 @@ export function visualRunsOf<T>(
 
   const flush = (): void => {
     if (current.length > 0) {
-      runs.push({ text: current.join(""), rtl: currentRtl, source: pieces[currentOwner].source });
+      const text = current.join("");
+      runs.push({
+        text,
+        logical: currentRtl ? [...text].reverse().join("") : text,
+        rtl: currentRtl,
+        source: pieces[currentOwner].source,
+      });
       current = [];
     }
   };
@@ -95,9 +99,8 @@ export function visualRunsOf<T>(
     currentRtl = rtl;
     currentOwner = owner[i];
 
-    // A surrogate PAIR is two code units at the same level, so reversing a run splits it and the
-    // astral character (an emoji in Hebrew text, say) turns into two broken halves. They arrive
-    // adjacent and swapped, so putting them back is local.
+    // A surrogate pair is two code units at one level, so reversing splits an astral character (an
+    // emoji in Hebrew text) into two broken halves. They arrive adjacent and swapped.
     const next = k + 1 < order.length ? order[k + 1] : -1;
     if (isLowSurrogate(text[i]) && next === i - 1 && isHighSurrogate(text[next])) {
       current.push(text[next], text[i]);
@@ -110,11 +113,12 @@ export function visualRunsOf<T>(
   return runs;
 }
 
-/**
- * The same for one plain string. An EMPTY string still yields one (empty) run: a caller drawing line
- * by line would otherwise skip a blank line entirely, which is a different document.
- */
+/** The same for one plain string. An empty string still yields one run, or a blank line would vanish. */
 export const visualRuns = (text: string, base: Direction = "ltr"): VisualRun[] => {
-  if (text === "") return [{ text, rtl: false }];
-  return visualRunsOf([{ text, source: null }], base).map(({ text: t, rtl }) => ({ text: t, rtl }));
+  if (text === "") return [{ text, logical: text, rtl: false }];
+  return visualRunsOf([{ text, source: null }], base).map(({ text: t, logical, rtl }) => ({
+    text: t,
+    logical,
+    rtl,
+  }));
 };

--- a/src/lib/text/bidi.ts
+++ b/src/lib/text/bidi.ts
@@ -75,20 +75,24 @@ export function visualRunsOf<T>(
   const mirrored = bidi.getMirroredCharactersMap(text, levels.levels);
 
   const runs: AttributedRun<T>[] = [];
-  let current: string[] = [];
+  let current: string[] = []; // visual order, mirrored
+  let written: string[] = []; // the same run as the author wrote it
   let currentRtl = false;
   let currentOwner = -1;
 
   const flush = (): void => {
     if (current.length > 0) {
-      const text = current.join("");
       runs.push({
-        text,
-        logical: currentRtl ? [...text].reverse().join("") : text,
+        text: current.join(""),
+        // Tracked separately rather than un-reversing the visual text: that text has been MIRRORED,
+        // so a bracket would come back as its twin and shaping - and `ToUnicode` after it - would see
+        // a character the author never wrote.
+        logical: (currentRtl ? [...written].reverse() : written).join(""),
         rtl: currentRtl,
         source: pieces[currentOwner].source,
       });
       current = [];
+      written = [];
     }
   };
 
@@ -104,10 +108,12 @@ export function visualRunsOf<T>(
     const next = k + 1 < order.length ? order[k + 1] : -1;
     if (isLowSurrogate(text[i]) && next === i - 1 && isHighSurrogate(text[next])) {
       current.push(text[next], text[i]);
+      written.push(text[next], text[i]);
       k++;
       continue;
     }
     current.push(mirrored.get(i) ?? text[i]);
+    written.push(text[i]);
   }
   flush();
   return runs;

--- a/src/lib/text/shape.ts
+++ b/src/lib/text/shape.ts
@@ -1,0 +1,96 @@
+import { joiningForms, needsJoining, type JoiningForm } from "./arabic.ts";
+import type { GsubTable } from "../utils/gsub.ts";
+
+/**
+ * SHAPING: code points in, the glyphs actually drawn out. Where the two halves meet - `arabic.ts`
+ * says WHICH positional form a letter takes, `gsub.ts` says which GLYPH that form is in this font.
+ *
+ * Not a string, because a ligature is one glyph for several code points. `codePoints` carries the
+ * origin so `ToUnicode` can still say what the glyph means.
+ */
+
+/** One drawn glyph, with the code points it came from. */
+export interface ShapedGlyph {
+  glyph: number;
+  /** Advance in FONT UNITS - the caller scales by fontSize / unitsPerEm, as everywhere else. */
+  advance: number;
+  /** The code points this glyph stands for; more than one only for a ligature. */
+  codePoints: number[];
+}
+
+/** The little a font has to answer for shaping - deliberately not the whole `TTFParser`. */
+export interface ShapingFont {
+  gsub(): GsubTable | undefined;
+  getGlyphIndex(codePoint: number): number;
+  getAdvanceWidth(glyph: number): number;
+}
+
+/** The features that realise the four positional forms, in the order a shaper applies them. */
+const FORM_FEATURES: Record<JoiningForm, string> = {
+  isol: "isol",
+  init: "init",
+  medi: "medi",
+  fina: "fina",
+};
+
+/**
+ * Shape a run, or `undefined` when there is nothing to do - so untouched documents keep their path.
+ *
+ * `rlig` (required ligatures - lam-alef, wrong when drawn apart) but not `liga`, which is
+ * discretionary and would change how existing Latin text looks.
+ */
+export function shapeRun(
+  codePoints: readonly number[],
+  font: ShapingFont,
+): ShapedGlyph[] | undefined {
+  if (!needsJoining(codePoints)) return undefined;
+  const gsub = font.gsub();
+  if (!gsub || !gsub.hasScript("arab")) return undefined;
+
+  const forms = joiningForms(codePoints);
+  let glyphs: ShapedGlyph[] = codePoints.map((cp, i) => {
+    let glyph = font.getGlyphIndex(cp);
+    const form = forms[i];
+    if (form) {
+      // First lookup that covers the glyph wins. A missing `isol` is normal: the plain glyph already
+      // IS that form.
+      for (const lookup of gsub.lookups("arab", FORM_FEATURES[form])) {
+        const substituted = gsub.substituteSingle(lookup, glyph);
+        if (substituted !== null) {
+          glyph = substituted;
+          break;
+        }
+      }
+    }
+    return { glyph, advance: font.getAdvanceWidth(glyph), codePoints: [cp] };
+  });
+
+  glyphs = applyLigatures(glyphs, gsub, font);
+  return glyphs;
+}
+
+/** Collapse required ligatures, longest match first, carrying every component's code points along. */
+function applyLigatures(glyphs: ShapedGlyph[], gsub: GsubTable, font: ShapingFont): ShapedGlyph[] {
+  const lookups = gsub.lookups("arab", "rlig");
+  if (lookups.length === 0) return glyphs;
+
+  const ids = glyphs.map((g) => g.glyph);
+  const out: ShapedGlyph[] = [];
+  for (let i = 0; i < glyphs.length; ) {
+    let applied = false;
+    for (const lookup of lookups) {
+      const match = gsub.substituteLigature(lookup, ids, i);
+      if (!match) continue;
+      out.push({
+        glyph: match.glyph,
+        advance: font.getAdvanceWidth(match.glyph),
+        codePoints: glyphs.slice(i, i + match.consumed).flatMap((g) => g.codePoints),
+      });
+      i += match.consumed;
+      applied = true;
+      break;
+    }
+    if (!applied) out.push(glyphs[i++]);
+  }
+  return out;
+}

--- a/src/lib/text/text-style.ts
+++ b/src/lib/text/text-style.ts
@@ -1,6 +1,7 @@
 import { Color } from "../common/color.ts";
 import { FontStyle } from "../utils/pdf-object-manager.ts";
 import { HorizontalAlignment } from "../elements/pdf-element.ts";
+import type { Direction } from "./bidi.ts";
 
 /**
  * The inheritable text properties - the same set CSS and Flutter cascade. A `Text` resolves each of
@@ -26,6 +27,10 @@ export interface ResolvedTextStyle {
   skipInk: boolean;
   /** Extra space after every glyph, in points (CSS `letter-spacing`). Default 0. */
   letterSpacing: number;
+  /** Base writing direction (CSS `direction`). It decides where a line STARTS and how neutral
+   *  characters between two scripts resolve; the reordering itself follows Unicode UAX #9 either
+   *  way, so Hebrew inside an `ltr` paragraph still comes out right. */
+  direction: Direction;
 }
 
 /**
@@ -37,12 +42,13 @@ export const DEFAULT_TEXT_STYLE: ResolvedTextStyle = {
   fontFamily: "Helvetica",
   fontStyle: FontStyle.Normal,
   color: new Color(0, 0, 0),
-  textAlignment: HorizontalAlignment.left,
+  textAlignment: HorizontalAlignment.start,
   lineHeight: undefined,
   underline: false,
   strikethrough: false,
   skipInk: false,
   letterSpacing: 0,
+  direction: "ltr",
 };
 
 /** Layers a partial override onto a complete style; an unset (undefined) field keeps the base. */
@@ -62,5 +68,6 @@ export function mergeTextStyle(
     strikethrough: override.strikethrough ?? base.strikethrough,
     skipInk: override.skipInk ?? base.skipInk,
     letterSpacing: override.letterSpacing ?? base.letterSpacing,
+    direction: override.direction ?? base.direction,
   };
 }

--- a/src/lib/utils/font-metrics.ts
+++ b/src/lib/utils/font-metrics.ts
@@ -35,4 +35,8 @@ export interface FontMetrics {
   /** Per-adjacent-pair kerning of `text`, in em/1000 (negative tightens); length `codePoints - 1`,
    *  zero next to a space. Only meaningful when `kerningEnabled`. */
   getKernPairs(text: string, fontFamily: string, fontStyle: FontStyle): number[];
+
+  /** How many glyphs the run will DRAW, when a ligature made that differ from its code-point count.
+   *  Absent or `undefined` means "the same", which is every Latin run. */
+  shapedGlyphCount?(text: string, fontFamily?: string, fontStyle?: FontStyle): number | undefined;
 }

--- a/src/lib/utils/gsub.ts
+++ b/src/lib/utils/gsub.ts
@@ -18,6 +18,9 @@ interface Lookup {
 
 const EXTENSION = 7;
 
+/** A coverage table may not expand past this: a glyph id is a uint16, so no honest one can. */
+const MAX_COVERAGE_ENTRIES = 65536;
+
 export class GsubTable {
   private scriptList: number;
   private featureList: number;
@@ -51,7 +54,8 @@ export class GsubTable {
       defaultOff !== 0
         ? scriptOff + defaultOff
         : u16(this.data, scriptOff + 2) > 0
-          ? scriptOff + u16(this.data, scriptOff + 6)
+          ? // The first LangSysRecord is at +4 and is tag(4) + offset(2), so its offset is at +8.
+            scriptOff + u16(this.data, scriptOff + 8)
           : undefined;
     if (langSys === undefined) return [];
 
@@ -175,14 +179,24 @@ export class GsubTable {
     if (u16(this.data, off) === 1) {
       for (let i = 0; i < count; i++) map.set(u16(this.data, off + 4 + i * 2), i);
     } else {
+      // Format 2 is RANGES, and a malformed file can claim far more glyphs than any font holds. Such
+      // a table is refused whole rather than expanded - the feature then simply does not apply.
+      let total = 0;
       for (let i = 0; i < count; i++) {
         const record = off + 4 + i * 6;
         const start = u16(this.data, record);
         const end = u16(this.data, record + 2);
+        if (end < start) continue; // an inverted range covers nothing
+        total += end - start + 1;
+        if (total > MAX_COVERAGE_ENTRIES) return this.cacheCoverage(off, new Map());
         const startIndex = u16(this.data, record + 4);
         for (let g = start; g <= end; g++) map.set(g, startIndex + (g - start));
       }
     }
+    return this.cacheCoverage(off, map);
+  }
+
+  private cacheCoverage(off: number, map: Map<number, number>): Map<number, number> {
     this.coverageCache.set(off, map);
     return map;
   }

--- a/src/lib/utils/gsub.ts
+++ b/src/lib/utils/gsub.ts
@@ -1,0 +1,189 @@
+import { u16, u32, i16, latin1FromBytes } from "./bytes.ts";
+
+/**
+ * The OpenType `GSUB` table: glyph substitution - what makes Arabic letters join and `f`+`i` a `fi`.
+ *
+ * Narrow on purpose. Of the eight lookup types this reads type 1 (one glyph becomes another - the
+ * joining itself), type 4 (several collapse into one - lam-alef) and type 7 (the extension wrapper).
+ * Anything else is reported, not guessed at, so a font needing more fails visibly.
+ *
+ * Structure: a SCRIPT picks a language system, which lists FEATURES, which list LOOKUPS.
+ */
+
+/** A lookup we know how to run: its type and the absolute offsets of its subtables. */
+interface Lookup {
+  type: number;
+  subtables: number[];
+}
+
+const EXTENSION = 7;
+
+export class GsubTable {
+  private scriptList: number;
+  private featureList: number;
+  private lookupList: number;
+  private lookupCache = new Map<number, Lookup | null>();
+  private coverageCache = new Map<number, Map<number, number>>();
+
+  constructor(
+    private data: Uint8Array,
+    private base: number,
+  ) {
+    this.scriptList = base + u16(data, base + 4);
+    this.featureList = base + u16(data, base + 6);
+    this.lookupList = base + u16(data, base + 8);
+  }
+
+  /** Whether the font carries this script at all - `arab` is the question the shaper asks. */
+  hasScript(script: string): boolean {
+    return this.scriptOffset(script) !== undefined;
+  }
+
+  /** A feature's lookup indices, under the script's DEFAULT language system - Arabic shaping features
+   *  are script-wide, so a language-specific override would only add typographic niceties. */
+  lookups(script: string, feature: string): number[] {
+    const scriptOff = this.scriptOffset(script);
+    if (scriptOff === undefined) return [];
+    // The default LangSys is optional; fall back to the first named one - a font declaring only
+    // `ARA ` still shapes Arabic.
+    const defaultOff = u16(this.data, scriptOff);
+    const langSys =
+      defaultOff !== 0
+        ? scriptOff + defaultOff
+        : u16(this.data, scriptOff + 2) > 0
+          ? scriptOff + u16(this.data, scriptOff + 6)
+          : undefined;
+    if (langSys === undefined) return [];
+
+    const out: number[] = [];
+    const count = u16(this.data, langSys + 4);
+    for (let i = 0; i < count; i++) {
+      const featureIndex = u16(this.data, langSys + 6 + i * 2);
+      const record = this.featureList + 2 + featureIndex * 6;
+      if (latin1FromBytes(this.data.subarray(record, record + 4)) !== feature) continue;
+      const featureOff = this.featureList + u16(this.data, record + 4);
+      const lookupCount = u16(this.data, featureOff + 2);
+      for (let j = 0; j < lookupCount; j++) out.push(u16(this.data, featureOff + 4 + j * 2));
+    }
+    return out;
+  }
+
+  /** Type 1: substitute one glyph. `null` when no subtable covers it - the feature does not apply. */
+  substituteSingle(lookupIndex: number, glyph: number): number | null {
+    const lookup = this.lookup(lookupIndex);
+    if (!lookup || lookup.type !== 1) return null;
+    for (const sub of lookup.subtables) {
+      const coverage = this.coverage(sub + u16(this.data, sub + 2));
+      const index = coverage.get(glyph);
+      if (index === undefined) continue;
+      // Format 1 shifts every covered glyph by one delta; format 2 lists a replacement per glyph.
+      return u16(this.data, sub) === 1
+        ? (glyph + i16(this.data, sub + 4)) & 0xffff
+        : u16(this.data, sub + 6 + index * 2);
+    }
+    return null;
+  }
+
+  /**
+   * Type 4: collapse a run of glyphs into one, starting at `at`. Longest match wins, as the spec
+   * requires - a three-glyph ligature beats the two-glyph one that starts the same way.
+   */
+  substituteLigature(
+    lookupIndex: number,
+    glyphs: readonly number[],
+    at: number,
+  ): { glyph: number; consumed: number } | null {
+    const lookup = this.lookup(lookupIndex);
+    if (!lookup || lookup.type !== 4) return null;
+    let best: { glyph: number; consumed: number } | null = null;
+
+    for (const sub of lookup.subtables) {
+      const coverage = this.coverage(sub + u16(this.data, sub + 2));
+      const setIndex = coverage.get(glyphs[at]);
+      if (setIndex === undefined) continue;
+      const set = sub + u16(this.data, sub + 6 + setIndex * 2);
+      const ligatureCount = u16(this.data, set);
+      for (let i = 0; i < ligatureCount; i++) {
+        const lig = set + u16(this.data, set + 2 + i * 2);
+        const components = u16(this.data, lig + 2); // includes the glyph coverage already matched
+        if (at + components > glyphs.length) continue;
+        let matches = true;
+        for (let c = 1; c < components && matches; c++) {
+          matches = glyphs[at + c] === u16(this.data, lig + 2 + c * 2);
+        }
+        if (matches && (best === null || components > best.consumed)) {
+          best = { glyph: u16(this.data, lig), consumed: components };
+        }
+      }
+    }
+    return best;
+  }
+
+  /** The type of a lookup, for reporting what a font needs that we do not do. */
+  lookupType(lookupIndex: number): number | undefined {
+    return this.lookup(lookupIndex)?.type;
+  }
+
+  private scriptOffset(script: string): number | undefined {
+    const count = u16(this.data, this.scriptList);
+    for (let i = 0; i < count; i++) {
+      const record = this.scriptList + 2 + i * 6;
+      if (latin1FromBytes(this.data.subarray(record, record + 4)) === script) {
+        return this.scriptList + u16(this.data, record + 4);
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Resolve a lookup, unwrapping type 7 (extension) - which exists only because the 16-bit offsets
+   * elsewhere cannot reach far enough in a big font. Callers never learn it was wrapped.
+   */
+  private lookup(index: number): Lookup | null {
+    const cached = this.lookupCache.get(index);
+    if (cached !== undefined) return cached;
+
+    let result: Lookup | null = null;
+    if (index < u16(this.data, this.lookupList)) {
+      const off = this.lookupList + u16(this.data, this.lookupList + 2 + index * 2);
+      const type = u16(this.data, off);
+      const count = u16(this.data, off + 4);
+      const subtables: number[] = [];
+      let realType = type;
+      for (let i = 0; i < count; i++) {
+        const sub = off + u16(this.data, off + 6 + i * 2);
+        if (type === EXTENSION) {
+          realType = u16(this.data, sub + 2);
+          subtables.push(sub + u32(this.data, sub + 4));
+        } else {
+          subtables.push(sub);
+        }
+      }
+      result = { type: realType, subtables };
+    }
+    this.lookupCache.set(index, result);
+    return result;
+  }
+
+  /** Coverage table -> glyph id to its INDEX in the table, which is how subtables address glyphs. */
+  private coverage(off: number): Map<number, number> {
+    const cached = this.coverageCache.get(off);
+    if (cached) return cached;
+
+    const map = new Map<number, number>();
+    const count = u16(this.data, off + 2);
+    if (u16(this.data, off) === 1) {
+      for (let i = 0; i < count; i++) map.set(u16(this.data, off + 4 + i * 2), i);
+    } else {
+      for (let i = 0; i < count; i++) {
+        const record = off + 4 + i * 6;
+        const start = u16(this.data, record);
+        const end = u16(this.data, record + 2);
+        const startIndex = u16(this.data, record + 4);
+        for (let g = start; g <= end; g++) map.set(g, startIndex + (g - start));
+      }
+    }
+    this.coverageCache.set(off, map);
+    return map;
+  }
+}

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -8,6 +8,7 @@ import { AFMParser } from "./afm-parser.ts";
 import { mergeSpans, TTFParser } from "./ttf-parser.ts";
 import { isWoff, woffToSfnt } from "./woff.ts";
 import { subsetTTF } from "./ttf-subsetter.ts";
+import { shapeRun, type ShapedGlyph } from "../text/shape.ts";
 import { getArrayBuffer } from "./utf8-to-windows1252-encoder.ts";
 import type { SecurityHandler } from "../crypto/security-handler.ts";
 import type { Gradient, GradientStop } from "../ir/display-list.ts";
@@ -212,6 +213,12 @@ export class PDFObjectManager implements FontMetrics {
       used: Set<number>;
     }
   >();
+
+  // Shaped runs, keyed by font + text; `null` means "asked, and there was nothing to shape".
+  private shapeCache = new Map<string, ShapedGlyph[] | null>();
+  // Per font, glyph -> the code points it stands for. A shaped glyph is often absent from the cmap (a
+  // ligature) or maps back to a presentation form, so `ToUnicode` cannot come from the cmap alone.
+  private shapedOrigins = new Map<string, Map<number, number[]>>();
 
   // Embedded file attachments (their /Filespec object numbers + display names). Referenced from
   // the catalog's /Names/EmbeddedFiles + /AF. Drives ZUGFeRD's embedded factur-x.xml.
@@ -754,13 +761,16 @@ endstream`;
   // Fills the reserved font objects with a SUBSET of each font (only the glyphs the document used),
   // tagged "ABCDEF+" as PDF/A requires for subsets. Call once, after the render pass, before output.
   finalizeCustomFonts(): void {
-    for (const e of this.customFontEmit.values()) {
+    for (const [key, e] of this.customFontEmit) {
       const ttf = e.ttf;
       const base = `${this.subsetTag(e.pdfName, e.used)}+${e.pdfName}`;
       this.replaceObject(e.fontFile, this.buildFontFile2(ttf, e.used));
       this.replaceObject(e.descriptor, this.buildFontDescriptor(base, ttf, e.fontFile));
       this.replaceObject(e.cidFont, this.buildCIDFont(base, ttf, e.descriptor, e.used));
-      this.replaceObject(e.toUnicode, this.buildToUnicode(ttf, e.used));
+      this.replaceObject(
+        e.toUnicode,
+        this.buildToUnicode(ttf, e.used, this.shapedOrigins.get(key)),
+      );
       this.replaceObject(e.type0, this.buildType0(base, e.cidFont, e.toUnicode));
     }
   }
@@ -856,6 +866,59 @@ endstream`;
     return this.fonts.getFont(name, resolved);
   }
 
+  /** How many glyphs a run draws - its code-point count unless a ligature merged some. `letterSpacing`
+   *  is per glyph (`Tc`), so this is what it multiplies. */
+  shapedGlyphCount(text: string, fontFamily?: string, fontStyle?: FontStyle): number | undefined {
+    return this.shapeText(text, fontFamily, fontStyle)?.length;
+  }
+
+  /**
+   * The shaped glyphs of a run, or undefined when nothing needed shaping. The ONE place shaping is
+   * decided, so measuring and drawing cannot disagree. Memoised: a paragraph is measured several
+   * times (layout, pagination, drawing).
+   */
+  shapeText(text: string, fontFamily?: string, fontStyle: FontStyle = FontStyle.Normal) {
+    const resolved = this.resolveCustomStyle(fontFamily, fontStyle);
+    if (!resolved) return undefined;
+    const key = `${this.customKey(fontFamily!, resolved)}\u0000${text}`;
+    const cached = this.shapeCache.get(key);
+    if (cached !== undefined) return cached ?? undefined;
+    const ttf = this.customFonts.get(fontFamily!)!.get(resolved)!;
+    const shaped =
+      shapeRun(
+        [...text].map((c) => c.codePointAt(0)!),
+        ttf,
+      ) ?? null;
+    this.shapeCache.set(key, shaped);
+    if (shaped) {
+      // Recorded at shaping time - the only moment the glyph and its code points are known together.
+      const fontKey = this.customKey(fontFamily!, resolved);
+      let origins = this.shapedOrigins.get(fontKey);
+      if (!origins) this.shapedOrigins.set(fontKey, (origins = new Map()));
+      for (const g of shaped) origins.set(g.glyph, g.codePoints);
+    }
+    return shaped ?? undefined;
+  }
+
+  /** Hex Identity-H for glyphs the producer already resolved (a shaped run), which cannot be given as
+   *  text. Recording each keeps it in the subset. */
+  registerGlyphs(
+    name: string,
+    glyphs: readonly number[],
+    style: FontStyle = FontStyle.Normal,
+  ): string {
+    const resolved = this.resolveCustomStyle(name, style);
+    if (!resolved) return "";
+    this.ensureEmitted(name, resolved);
+    const emit = this.customFontEmit.get(this.customKey(name, resolved))!;
+    let out = "";
+    for (const g of glyphs) {
+      emit.used.add(g);
+      out += g.toString(16).padStart(4, "0").toUpperCase();
+    }
+    return out;
+  }
+
   // Encodes text as a hex Identity-H string for an embedded font's Tj operator: each codepoint
   // becomes its 2-byte glyph id (CID == GID under /CIDToGIDMap /Identity).
   encodeCustomText(name: string, text: string, style: FontStyle = FontStyle.Normal): string {
@@ -865,11 +928,24 @@ endstream`;
     // Once per text run, not per character: the flat key is fine here.
     const emit = this.customFontEmit.get(this.customKey(name, resolved))!;
     const { ttf, used } = emit;
+    const hex4 = (gid: number) => gid.toString(16).padStart(4, "0").toUpperCase();
+
+    // The SAME shaped run the measuring path used, so the glyphs drawn are the glyphs measured.
+    const shaped = this.shapeText(text, name, style);
+    if (shaped) {
+      let out = "";
+      for (const g of shaped) {
+        used.add(g.glyph);
+        out += hex4(g.glyph);
+      }
+      return out;
+    }
+
     let hex = "";
     for (const ch of text) {
       const gid = ttf.getGlyphIndex(ch.codePointAt(0)!);
       used.add(gid); // record the glyph so the subset keeps it
-      hex += gid.toString(16).padStart(4, "0").toUpperCase();
+      hex += hex4(gid);
     }
     return hex;
   }
@@ -915,17 +991,29 @@ endstream`;
 
   // Maps glyph id -> Unicode so the text stays copy-/searchable (rendering doesn't need it). Only
   // the used glyphs are listed, to match the subset.
-  private buildToUnicode(ttf: TTFParser, used: Set<number>): string {
+  private buildToUnicode(
+    ttf: TTFParser,
+    used: Set<number>,
+    shapedOrigins: Map<number, number[]> = new Map(),
+  ): string {
     const hex4 = (n: number) => n.toString(16).padStart(4, "0").toUpperCase();
+    // A code point above the BMP needs its surrogate PAIR here - a `bfchar` destination is UTF-16BE.
+    const utf16 = (code: number) =>
+      code > 0xffff
+        ? hex4(0xd800 + ((code - 0x10000) >> 10)) + hex4(0xdc00 + ((code - 0x10000) & 0x3ff))
+        : hex4(code);
     const rev = ttf.reverseCmap();
+    // A SHAPED glyph wins: it is often absent from the cmap (a ligature) or maps back to a
+    // presentation form rather than the letter that was written (a joining form), so the reverse
+    // cmap alone would make copied text wrong.
     const entries = [...used]
       .sort((a, b) => a - b)
-      .filter((g) => rev.has(g))
-      .map((g) => [g, rev.get(g)!] as [number, number]);
+      .filter((g) => shapedOrigins.has(g) || rev.has(g))
+      .map((g) => [g, shapedOrigins.get(g) ?? [rev.get(g)!]] as [number, number[]]);
     const blocks: string[] = [];
     for (let i = 0; i < entries.length; i += 100) {
       const block = entries.slice(i, i + 100);
-      const lines = block.map(([gid, code]) => `<${hex4(gid)}> <${hex4(code)}>`);
+      const lines = block.map(([gid, codes]) => `<${hex4(gid)}> <${codes.map(utf16).join("")}>`);
       blocks.push(`${block.length} beginbfchar\n${lines.join("\n")}\nendbfchar`);
     }
     const body =
@@ -1016,6 +1104,10 @@ endstream`;
   getKernPairs(text: string, fontFamily: string, fontStyle: FontStyle): number[] {
     const chars = [...text];
     if (chars.length < 2) return [];
+    // A shaped run does not kern here: these pairs are keyed by the UNSHAPED glyphs, and the `TJ`
+    // path would re-shape each chunk on its own, turning every letter isolated. Arabic kerning is in
+    // GPOS, applied during shaping - not built (`todo.md`).
+    if (this.shapeText(text, fontFamily, fontStyle)) return [];
     const out: number[] = [];
     // An embedded font kerns by GLYPH id (kern table / GPOS); a standard-14 one by character (AFM).
     const ttf = this.getCustomFont(fontFamily, fontStyle);
@@ -1084,6 +1176,14 @@ endstream`;
     fontSize: number,
     fontStyle: FontStyle,
   ): number {
+    // Shaping first: a joined run is narrower than the same letters apart, so measuring the unshaped
+    // form while drawing the shaped one would break every line. Both sides ask `shapeText`.
+    const shaped = this.shapeText(text, fontFamily, fontStyle);
+    if (shaped) {
+      const ttf = this.getCustomFont(fontFamily, fontStyle)!;
+      return shaped.reduce((w, g) => w + ttf.unitsToPoints(g.advance, fontSize), 0);
+    }
+
     let width = 0;
 
     // Iterate code points, not UTF-16 units: an astral char (emoji, CJK-ext) is a surrogate pair,

--- a/src/lib/utils/ttf-parser.ts
+++ b/src/lib/utils/ttf-parser.ts
@@ -4,6 +4,7 @@
 
 import { i16, latin1FromBytes, u8, u16, u32 } from "./bytes.ts";
 import type { FontDecoration } from "../text/text-decoration.ts";
+import { GsubTable } from "./gsub.ts";
 
 interface TableRecord {
   offset: number;
@@ -165,6 +166,8 @@ export class TTFParser {
   // GPOS Type 2 (pair positioning) subtables, in absolute byte offsets. Queried per pair (format 2
   // is class-based, so it cannot be enumerated into `kernPairs` up front). Preferred over `kern`.
   private gposPairPos: number[] = [];
+  // GSUB (glyph substitution - Arabic joining, ligatures), built on first use.
+  private gsubTable?: GsubTable | null;
 
   constructor(private data: Uint8Array) {
     this.readTableDirectory();
@@ -233,6 +236,20 @@ export class TTFParser {
     return Math.round((v * 1000) / this.unitsPerEm);
   }
 
+  /** The font's `GSUB`, or undefined when it has none. Parsed once, on demand. */
+  gsub(): GsubTable | undefined {
+    if (this.gsubTable === undefined) {
+      const record = this.tables["GSUB"];
+      // Degrade to "no shaping" rather than break font loading - same rule as kern.
+      try {
+        this.gsubTable = record ? new GsubTable(this.data, record.offset) : null;
+      } catch {
+        this.gsubTable = null;
+      }
+    }
+    return this.gsubTable ?? undefined;
+  }
+
   // Codepoint → glyph id (0 = .notdef when the font has no glyph for it).
   getGlyphIndex(codePoint: number): number {
     const g = this.cmap.get(codePoint);
@@ -252,6 +269,11 @@ export class TTFParser {
   }
 
   // Char width at fontSize, scaled from font units (em = unitsPerEm) to points.
+  /** Font units -> points at `fontSize`; the one scaling rule for shaped and plain advances alike. */
+  unitsToPoints(units: number, fontSize: number): number {
+    return (units / this.unitsPerEm) * fontSize;
+  }
+
   getCharWidth(char: string, fontSize: number): number {
     const units = this.getAdvanceWidth(this.getGlyphIndex(char.codePointAt(0)!));
     return (units / this.unitsPerEm) * fontSize;

--- a/src/types/bidi-js.d.ts
+++ b/src/types/bidi-js.d.ts
@@ -1,0 +1,23 @@
+/**
+ * Local typings for `bidi-js`, which ships none. Only the surface we use is declared - deliberately,
+ * so the seam in `text/bidi.ts` stays the single place that knows this library exists at all.
+ */
+declare module "bidi-js" {
+  export interface EmbeddingLevels {
+    /** UAX #9 embedding level per UTF-16 code unit; odd means right-to-left. */
+    levels: Uint8Array;
+    paragraphs: { start: number; end: number; level: number }[];
+  }
+
+  export interface Bidi {
+    getEmbeddingLevels(text: string, baseDirection?: "ltr" | "rtl" | "auto"): EmbeddingLevels;
+    /** Logical indices in the order they are DRAWN, left to right (rule L2). */
+    getReorderedIndices(text: string, levels: EmbeddingLevels): number[];
+    /** Index -> replacement for characters that mirror in a right-to-left run, e.g. `(` -> `)`.
+     *  Takes the LEVEL ARRAY, unlike its neighbours - typed that way on purpose so the mistake the
+     *  library's own README invites cannot compile. */
+    getMirroredCharactersMap(text: string, levels: Uint8Array): Map<number, string>;
+  }
+
+  export default function bidiFactory(): Bidi;
+}

--- a/tests/unit/renderer/text-bidi.test.ts
+++ b/tests/unit/renderer/text-bidi.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from "vitest";
+import { TextRenderer } from "../../../src/lib/renderer/text-renderer.ts";
+import { FontStyle, PDFObjectManager } from "../../../src/lib/utils/pdf-object-manager.ts";
+import { TextElement } from "../../../src/lib/elements/text-element.ts";
+import { HorizontalAlignment } from "../../../src/lib/elements/pdf-element.ts";
+import { unitVerticals } from "../support/metrics.ts";
+import { DEFAULT_TEXT_STYLE, type ResolvedTextStyle } from "../../../src/lib/text/text-style.ts";
+import type { TextRun } from "../../../src/lib/ir/display-list.ts";
+import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
+
+// What the bidi seam is worth only shows in the DISPLAY LIST: which run is drawn where. Every glyph
+// is 10 wide here, so an x position is readable as "how many glyphs came before me".
+
+const HE = "שלום";
+const HE_VISUAL = [...HE].reverse().join("");
+
+const om = () =>
+  ({
+    getStringWidth: vi.fn((t: string) => [...t].length * 10),
+    getCharWidth: vi.fn(() => 10),
+    getFontVerticals: unitVerticals,
+    getFontDecoration: () => ({
+      underlinePosition: -0.1,
+      underlineThickness: 0.05,
+      capHeight: 0.7,
+      xHeight: 0.5,
+    }),
+    kerningEnabled: false,
+    getKernPairs: (t: string) => Array.from({ length: Math.max(0, [...t].length - 1) }, () => 0),
+    struct: { enabled: false },
+    isCustomFont: () => false,
+    getColorFont: () => undefined,
+    getEmojiSource: () => undefined,
+    getEmojiFont: () => undefined,
+    getEmojiImageSource: () => undefined,
+  }) as unknown as PDFObjectManager;
+
+/** The text runs a `TextElement` produces, in the order the page draws them. */
+const drawn = async (
+  el: TextElement,
+  width = 400,
+  textStyle?: ResolvedTextStyle,
+): Promise<TextRun[]> => {
+  el.calculateLayout(BoxConstraints.tight(width, 400), { x: 0, y: 0 }, {
+    metrics: om(),
+    textStyle,
+  } as never);
+  const nodes = await TextRenderer.render(el, om());
+  return nodes.filter((n): n is TextRun => n.type === "text");
+};
+
+describe("a Hebrew word in a Latin sentence", () => {
+  it("draws three runs, with the Hebrew reversed and in the middle", async () => {
+    const runs = await drawn(
+      new TextElement({ content: `Hi ${HE} there`, fontSize: 10, fontFamily: "Helvetica" }),
+    );
+    expect(runs.map((r) => r.text)).toEqual(["Hi ", HE_VISUAL, " there"]);
+    // Each run starts exactly where the previous one ended - 3, then 4, then 6 glyphs of 10.
+    expect(runs.map((r) => r.x)).toEqual([0, 30, 70]);
+  });
+});
+
+describe("a right-to-left paragraph", () => {
+  it("starts on the RIGHT without anyone asking for an alignment", async () => {
+    // CSS `text-align` starts at `start`, which is the right edge in `rtl`. 3 glyphs of 10 in a 400pt
+    // box therefore begin at 370.
+    const runs = await drawn(
+      new TextElement({ content: "abc", fontSize: 10, fontFamily: "Helvetica", direction: "rtl" }),
+    );
+    expect(runs.map((r) => r.x)).toEqual([370]);
+  });
+
+  it("still obeys an explicit alignment", async () => {
+    const runs = await drawn(
+      new TextElement({
+        content: "abc",
+        fontSize: 10,
+        fontFamily: "Helvetica",
+        direction: "rtl",
+        textAlignment: HorizontalAlignment.left,
+      }),
+    );
+    expect(runs.map((r) => r.x)).toEqual([0]);
+  });
+
+  it("leaves a left-to-right paragraph where it always was", async () => {
+    const runs = await drawn(
+      new TextElement({ content: "abc", fontSize: 10, fontFamily: "Helvetica" }),
+    );
+    expect(runs.map((r) => r.x)).toEqual([0]);
+  });
+});
+
+describe("spans keep their own style through the reordering", () => {
+  it("carries each run's colour and size from the span it came from", async () => {
+    const runs = await drawn(
+      new TextElement({
+        fontSize: 10,
+        fontFamily: "Helvetica",
+        direction: "rtl",
+        content: [
+          { content: "abc", fontSize: 20 },
+          { content: HE, fontStyle: FontStyle.Bold },
+        ],
+      }),
+    );
+    // The line starts on the RIGHT, so the first span written ends up rightmost and is drawn LAST.
+    // Each run still carries its own span's settings - the point of attributing runs back to spans.
+    expect(runs.map((r) => r.text)).toEqual([HE_VISUAL, "abc"]);
+    expect(runs[0].fontStyle).toBe(FontStyle.Bold);
+    expect(runs[1].fontSize).toBe(20);
+  });
+});
+
+describe("direction inherits like every other text style", () => {
+  it("is picked up from the cascade, not just from the element", async () => {
+    const el = new TextElement({ content: "abc", fontSize: 10, fontFamily: "Helvetica" });
+    // What `Document({ direction: "rtl" })` and `DefaultTextStyle` do: seed the cascade, which
+    // reaches the element through the LayoutContext.
+    const inherited = { ...DEFAULT_TEXT_STYLE, direction: "rtl" as const };
+    expect((await drawn(el, 400, inherited)).map((r) => r.x)).toEqual([370]);
+  });
+
+  it("lets the element override the inherited direction", async () => {
+    const el = new TextElement({
+      content: "abc",
+      fontSize: 10,
+      fontFamily: "Helvetica",
+      direction: "ltr",
+    });
+    const inherited = { ...DEFAULT_TEXT_STYLE, direction: "rtl" as const };
+    expect((await drawn(el, 400, inherited)).map((r) => r.x)).toEqual([0]);
+  });
+});

--- a/tests/unit/renderer/text-bidi.test.ts
+++ b/tests/unit/renderer/text-bidi.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { TextRenderer } from "../../../src/lib/renderer/text-renderer.ts";
 import { FontStyle, PDFObjectManager } from "../../../src/lib/utils/pdf-object-manager.ts";
 import { TextElement } from "../../../src/lib/elements/text-element.ts";
 import { HorizontalAlignment } from "../../../src/lib/elements/pdf-element.ts";
-import { unitVerticals } from "../support/metrics.ts";
+import { testMetrics } from "../support/metrics.ts";
 import { DEFAULT_TEXT_STYLE, type ResolvedTextStyle } from "../../../src/lib/text/text-style.ts";
 import type { TextRun } from "../../../src/lib/ir/display-list.ts";
 import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
@@ -16,17 +16,9 @@ const HE_VISUAL = [...HE].reverse().join("");
 
 const om = () =>
   ({
-    getStringWidth: vi.fn((t: string) => [...t].length * 10),
-    getCharWidth: vi.fn(() => 10),
-    getFontVerticals: unitVerticals,
-    getFontDecoration: () => ({
-      underlinePosition: -0.1,
-      underlineThickness: 0.05,
-      capHeight: 0.7,
-      xHeight: 0.5,
-    }),
-    kerningEnabled: false,
-    getKernPairs: (t: string) => Array.from({ length: Math.max(0, [...t].length - 1) }, () => 0),
+    // The metric half comes from the shared helper, so this file only stubs what a RENDERER needs
+    // beyond measuring. Every glyph is 10 wide at size 10, which makes an x readable as a glyph count.
+    ...testMetrics({ getStringWidth: (t) => [...t].length * 10, getCharWidth: () => 10 }),
     struct: { enabled: false },
     shapeText: () => undefined,
     isCustomFont: () => false,
@@ -34,6 +26,7 @@ const om = () =>
     getEmojiSource: () => undefined,
     getEmojiFont: () => undefined,
     getEmojiImageSource: () => undefined,
+    // Not a real PDFObjectManager - the renderer only reaches for the members above.
   }) as unknown as PDFObjectManager;
 
 /** The text runs a `TextElement` produces, in the order the page draws them. */
@@ -213,6 +206,9 @@ describe("a shaped run and the colour-emoji split", () => {
       (n): n is TextRun => n.type === "text",
     );
     expect(runs).toHaveLength(1);
-    expect(runs[0].glyphs).toHaveLength([...content].length);
+    // The whole run, not a piece of it: its own logical text and the full glyph sequence the stub
+    // shaper produced (one glyph per code point, numbered in order).
+    expect(runs[0].text).toBe(content);
+    expect(runs[0].glyphs).toEqual([...content].map((_, i) => 2000 + i));
   });
 });

--- a/tests/unit/renderer/text-bidi.test.ts
+++ b/tests/unit/renderer/text-bidi.test.ts
@@ -28,6 +28,7 @@ const om = () =>
     kerningEnabled: false,
     getKernPairs: (t: string) => Array.from({ length: Math.max(0, [...t].length - 1) }, () => 0),
     struct: { enabled: false },
+    shapeText: () => undefined,
     isCustomFont: () => false,
     getColorFont: () => undefined,
     getEmojiSource: () => undefined,
@@ -130,5 +131,51 @@ describe("direction inherits like every other text style", () => {
     });
     const inherited = { ...DEFAULT_TEXT_STYLE, direction: "rtl" as const };
     expect((await drawn(el, 400, inherited)).map((r) => r.x)).toEqual([0]);
+  });
+});
+
+describe("shaping sees the LOGICAL text, and its glyphs are drawn in visual order", () => {
+  // The bug this pins: bidi reverses a right-to-left run for drawing, and shaping the REVERSED text
+  // gives every letter the form of its mirror-image neighbours. Measured on Arabic in DejaVu Sans, a
+  // word came out 42.5pt instead of 34.4pt - and both the measuring and the drawing were wrong
+  // together, so nothing looked inconsistent. Shape the logical text, reverse the GLYPHS.
+  const HE_LOGICAL = HE;
+
+  const shapingOm = (seen: string[]) =>
+    ({
+      ...om(),
+      // Pretend the font shapes: one glyph per code point, numbered so order is readable.
+      shapeText: (text: string) => {
+        seen.push(text);
+        return [...text].map((c, i) => ({
+          glyph: 1000 + i,
+          advance: 10,
+          codePoints: [c.codePointAt(0)!],
+        }));
+      },
+    }) as unknown as PDFObjectManager;
+
+  it("hands the shaper the text as it was written, not as it is drawn", async () => {
+    const seen: string[] = [];
+    const el = new TextElement({ content: HE_LOGICAL, fontSize: 10, fontFamily: "Helvetica" });
+    el.calculateLayout(BoxConstraints.tight(400, 400), { x: 0, y: 0 }, {
+      metrics: shapingOm(seen),
+    } as never);
+    await TextRenderer.render(el, shapingOm(seen));
+    expect(seen).toContain(HE_LOGICAL);
+    expect(seen).not.toContain([...HE_LOGICAL].reverse().join(""));
+  });
+
+  it("reverses the resulting glyphs, so a right-to-left run still draws right to left", async () => {
+    const el = new TextElement({ content: HE_LOGICAL, fontSize: 10, fontFamily: "Helvetica" });
+    const manager = shapingOm([]);
+    el.calculateLayout(BoxConstraints.tight(400, 400), { x: 0, y: 0 }, {
+      metrics: manager,
+    } as never);
+    const runs = (await TextRenderer.render(el, manager)).filter(
+      (n): n is TextRun => n.type === "text",
+    );
+    // Shaped logically as 1000,1001,1002,1003 - drawn in the reverse of that.
+    expect(runs[0].glyphs).toEqual([1003, 1002, 1001, 1000]);
   });
 });

--- a/tests/unit/renderer/text-bidi.test.ts
+++ b/tests/unit/renderer/text-bidi.test.ts
@@ -179,3 +179,40 @@ describe("shaping sees the LOGICAL text, and its glyphs are drawn in visual orde
     expect(runs[0].glyphs).toEqual([1003, 1002, 1001, 1000]);
   });
 });
+
+describe("a shaped run and the colour-emoji split", () => {
+  it("is passed through whole, never cut into pieces that inherit the full glyph list", async () => {
+    // The expansion walks CODE POINTS, while `glyphs` is a drawn-order list where a ligature is one
+    // glyph for several of them - so no slice is correct, and spreading the run onto each piece would
+    // draw every glyph again in each. Latin around the emoji, so bidi leaves it as ONE run and the
+    // colour glyph is the only thing that could cut it.
+    const colourFont = {
+      unitsPerEm: 1000,
+      getGlyphIndex: (cp: number) => (cp === 0x1f600 ? 7 : 0),
+      getColorGlyph: (gid: number) =>
+        gid === 7 ? [{ glyphId: 7, paint: { type: "solid", color: null } }] : null,
+      getGlyphPath: () => [], // empty outline: the split is what matters, not the drawing
+    };
+    const manager = {
+      ...om(),
+      shapeText: (text: string) =>
+        [...text].map((c, i) => ({
+          glyph: 2000 + i,
+          advance: 10,
+          codePoints: [c.codePointAt(0)!],
+        })),
+      getColorFont: () => colourFont,
+    } as unknown as PDFObjectManager;
+
+    const content = "ab\u{1F600}cd";
+    const el = new TextElement({ content, fontSize: 10, fontFamily: "Helvetica" });
+    el.calculateLayout(BoxConstraints.tight(400, 400), { x: 0, y: 0 }, {
+      metrics: manager,
+    } as never);
+    const runs = (await TextRenderer.render(el, manager)).filter(
+      (n): n is TextRun => n.type === "text",
+    );
+    expect(runs).toHaveLength(1);
+    expect(runs[0].glyphs).toHaveLength([...content].length);
+  });
+});

--- a/tests/unit/renderer/text-renderer.test.ts
+++ b/tests/unit/renderer/text-renderer.test.ts
@@ -15,6 +15,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getCharWidth: vi.fn().mockReturnValue(5),
       getFontVerticals: unitVerticals,
       struct: { enabled: false },
+      shapeText: () => undefined,
     } as unknown as PDFObjectManager;
 
     // "Hello World" is 11 glyphs * 5 = 55 wide; width 100 leaves it on one line.
@@ -36,6 +37,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getCharWidth: vi.fn().mockReturnValue(5), // Used for empty spaces = 25
       getFontVerticals: unitVerticals,
       struct: { enabled: false },
+      shapeText: () => undefined,
     } as unknown as PDFObjectManager;
 
     const textHeight = TextRenderer.calculateTextHeight(
@@ -56,6 +58,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getCharWidth: vi.fn().mockReturnValue(5),
       getFontVerticals: unitVerticals,
       struct: { enabled: false },
+      shapeText: () => undefined,
     } as unknown as PDFObjectManager;
 
     const segments = [
@@ -100,6 +103,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getCharWidth: vi.fn().mockReturnValue(5),
       getFontVerticals: unitVerticals,
       struct: { enabled: false },
+      shapeText: () => undefined,
     } as unknown as PDFObjectManager;
 
     const result = PdfBackend.serialize(
@@ -141,6 +145,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getCharWidth: vi.fn().mockReturnValue(5),
       getFontVerticals: unitVerticals,
       struct: { enabled: false },
+      shapeText: () => undefined,
     } as unknown as PDFObjectManager;
 
     const result = PdfBackend.serialize(
@@ -179,6 +184,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getCharWidth: vi.fn().mockReturnValue(0), // For empty spaces: 0
       getFontVerticals: unitVerticals,
       struct: { enabled: false },
+      shapeText: () => undefined,
     } as unknown as PDFObjectManager;
 
     const result = PdfBackend.serialize(
@@ -220,6 +226,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getCharWidth: vi.fn().mockReturnValue(0),
       getFontVerticals: unitVerticals,
       struct: { enabled: false },
+      shapeText: () => undefined,
     } as unknown as PDFObjectManager;
 
     const result = PdfBackend.serialize(
@@ -258,6 +265,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getCharWidth: vi.fn().mockReturnValue(0),
       getFontVerticals: unitVerticals,
       struct: { enabled: false },
+      shapeText: () => undefined,
     } as unknown as PDFObjectManager;
 
     const result = PdfBackend.serialize(
@@ -315,6 +323,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getCharWidth: vi.fn().mockReturnValue(10),
       getFontVerticals: unitVerticals,
       struct: { enabled: false },
+      shapeText: () => undefined,
     } as unknown as PDFObjectManager;
 
     const result = PdfBackend.serialize(
@@ -371,6 +380,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getCharWidth: vi.fn().mockReturnValue(0), // For empty spaces: 0
       getFontVerticals: unitVerticals,
       struct: { enabled: false },
+      shapeText: () => undefined,
     } as unknown as PDFObjectManager;
 
     const result = PdfBackend.serialize(

--- a/tests/unit/support/gsub-builder.ts
+++ b/tests/unit/support/gsub-builder.ts
@@ -1,0 +1,158 @@
+// Builds a GSUB table byte by byte, from the spec rather than from a font file - so the reader is
+// tested against the format, and the tests still run in a fresh clone where no font is committed.
+
+export const be16 = (v: number) => [(v >>> 8) & 255, v & 255];
+export const be32 = (v: number) => [(v >>> 24) & 255, (v >>> 16) & 255, (v >>> 8) & 255, v & 255];
+export const tag = (t: string) => [...t].map((c) => c.charCodeAt(0));
+
+/** Coverage format 1: an explicit glyph list. */
+export const coverage1 = (glyphs: number[]) => [
+  ...be16(1),
+  ...be16(glyphs.length),
+  ...glyphs.flatMap(be16),
+];
+
+/** Coverage format 2: ranges, so the range branch of the reader is exercised too. */
+export const coverage2 = (ranges: [number, number, number][]) => [
+  ...be16(2),
+  ...be16(ranges.length),
+  ...ranges.flatMap(([s, e, i]) => [...be16(s), ...be16(e), ...be16(i)]),
+];
+
+/** SingleSubst format 1: every covered glyph shifts by one delta. */
+export const single1 = (cov: number[], delta: number) => {
+  const head = [...be16(1), ...be16(6), ...be16(delta & 0xffff)];
+  return [...head, ...cov];
+};
+
+/** SingleSubst format 2: one replacement listed per covered glyph. */
+export const single2 = (cov: number[], subs: number[]) => {
+  const head = [
+    ...be16(2),
+    ...be16(6 + subs.length * 2),
+    ...be16(subs.length),
+    ...subs.flatMap(be16),
+  ];
+  return [...head, ...cov];
+};
+
+/** LigatureSubst: `sets[i]` belongs to the i-th covered glyph; each entry is [result, ...rest]. */
+export const ligature = (cov: number[], sets: number[][][]) => {
+  const fixed = 6 + sets.length * 2;
+  const setBlobs: number[][] = sets.map((set) => {
+    const ligs = set.map(([glyph, ...rest]) => [
+      ...be16(glyph),
+      ...be16(rest.length + 1),
+      ...rest.flatMap(be16),
+    ]);
+    let at = 2 + ligs.length * 2;
+    const offsets: number[] = [];
+    for (const l of ligs) {
+      offsets.push(at);
+      at += l.length;
+    }
+    return [...be16(ligs.length), ...offsets.flatMap(be16), ...ligs.flat()];
+  });
+
+  let at = fixed + cov.length;
+  const setOffsets: number[] = [];
+  for (const b of setBlobs) {
+    setOffsets.push(at);
+    at += b.length;
+  }
+  return [
+    ...be16(1),
+    ...be16(fixed), // coverage sits right after the fixed part
+    ...be16(sets.length),
+    ...setOffsets.flatMap(be16),
+    ...cov,
+    ...setBlobs.flat(),
+  ];
+};
+
+/** A type-7 extension wrapping a real subtable, which is how a large font reaches past 64 KB. */
+export const extension = (realType: number, inner: number[]) => [
+  ...be16(1),
+  ...be16(realType),
+  ...be32(8), // the inner subtable starts right after this 8-byte header
+  ...inner,
+];
+
+export interface LookupSpec {
+  type: number;
+  subtables: number[][];
+}
+
+/** Assemble a whole GSUB table: one script, its features, and the lookups they point at. */
+export function buildGsub(
+  features: { tag: string; lookups: number[] }[],
+  lookups: LookupSpec[],
+): Uint8Array {
+  // --- LookupList
+  const lookupBlobs = lookups.map((l) => {
+    const fixed = 6 + l.subtables.length * 2;
+    let at = fixed;
+    const offsets: number[] = [];
+    for (const s of l.subtables) {
+      offsets.push(at);
+      at += s.length;
+    }
+    return [
+      ...be16(l.type),
+      ...be16(0),
+      ...be16(l.subtables.length),
+      ...offsets.flatMap(be16),
+      ...l.subtables.flat(),
+    ];
+  });
+  let at = 2 + lookupBlobs.length * 2;
+  const lookupOffsets: number[] = [];
+  for (const b of lookupBlobs) {
+    lookupOffsets.push(at);
+    at += b.length;
+  }
+  const lookupList = [
+    ...be16(lookupBlobs.length),
+    ...lookupOffsets.flatMap(be16),
+    ...lookupBlobs.flat(),
+  ];
+
+  // --- FeatureList
+  const featureBlobs = features.map((f) => [
+    ...be16(0),
+    ...be16(f.lookups.length),
+    ...f.lookups.flatMap(be16),
+  ]);
+  at = 2 + features.length * 6;
+  const featureOffsets: number[] = [];
+  for (const b of featureBlobs) {
+    featureOffsets.push(at);
+    at += b.length;
+  }
+  const featureList = [
+    ...be16(features.length),
+    ...features.flatMap((f, i) => [...tag(f.tag), ...be16(featureOffsets[i])]),
+    ...featureBlobs.flat(),
+  ];
+
+  // --- ScriptList: one script, default LangSys listing every feature by index
+  const langSys = [
+    ...be16(0), // lookupOrder, always null
+    ...be16(0xffff), // no required feature
+    ...be16(features.length),
+    ...features.flatMap((_, i) => be16(i)),
+  ];
+  const script = [...be16(4), ...be16(0), ...langSys]; // defaultLangSys right after the 4-byte header
+  const scriptList = [...be16(1), ...tag("arab"), ...be16(2 + 6), ...script];
+
+  const headerSize = 10;
+  return Uint8Array.from([
+    ...be32(0x00010000),
+    ...be16(headerSize),
+    ...be16(headerSize + scriptList.length),
+    ...be16(headerSize + scriptList.length + featureList.length),
+    ...scriptList,
+    ...featureList,
+    ...lookupList,
+  ]);
+}

--- a/tests/unit/support/gsub-builder.ts
+++ b/tests/unit/support/gsub-builder.ts
@@ -87,6 +87,7 @@ export interface LookupSpec {
 export function buildGsub(
   features: { tag: string; lookups: number[] }[],
   lookups: LookupSpec[],
+  named = false,
 ): Uint8Array {
   // --- LookupList
   const lookupBlobs = lookups.map((l) => {
@@ -135,14 +136,19 @@ export function buildGsub(
     ...featureBlobs.flat(),
   ];
 
-  // --- ScriptList: one script, default LangSys listing every feature by index
+  // --- ScriptList: one script, its LangSys listing every feature by index
   const langSys = [
     ...be16(0), // lookupOrder, always null
     ...be16(0xffff), // no required feature
     ...be16(features.length),
     ...features.flatMap((_, i) => be16(i)),
   ];
-  const script = [...be16(4), ...be16(0), ...langSys]; // defaultLangSys right after the 4-byte header
+  // Two shapes a real font may use. Default: the LangSys sits right after the 4-byte header. Named:
+  // there is NO default and one LangSysRecord (tag + offset) points at it - the layout whose offset
+  // field lives at +8, which is easy to read from the wrong place.
+  const script = named
+    ? [...be16(0), ...be16(1), ...tag("ARA "), ...be16(4 + 6), ...langSys]
+    : [...be16(4), ...be16(0), ...langSys];
   const scriptList = [...be16(1), ...tag("arab"), ...be16(2 + 6), ...script];
 
   const headerSize = 10;

--- a/tests/unit/text/arabic.test.ts
+++ b/tests/unit/text/arabic.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { joiningType, joiningForms, needsJoining } from "../../../src/lib/text/arabic.ts";
+
+// Joining decides WHICH of the four forms a letter takes; GSUB then decides which glyph that form is.
+// These tests are about the first half only, so they read as letters and forms, never as glyph ids.
+
+const cps = (text: string): number[] => [...text].map((c) => c.codePointAt(0)!);
+const forms = (text: string): string[] => joiningForms(cps(text)).map((f) => f ?? "-");
+
+describe("the joining type of a character", () => {
+  it("knows the three kinds that matter", () => {
+    expect(joiningType(0x0628)).toBe("D"); // beh joins on both sides
+    expect(joiningType(0x0627)).toBe("R"); // alef joins only to its right
+    expect(joiningType(0x0041)).toBe("U"); // a Latin A joins nothing
+  });
+
+  it("knows the two that are invisible to joining", () => {
+    expect(joiningType(0x064b)).toBe("T"); // fathatan, a mark sitting on a letter
+    expect(joiningType(0x0640)).toBe("C"); // tatweel, which causes a join without being a letter
+    expect(joiningType(0x200d)).toBe("C"); // ZWJ, the same thing by other means
+  });
+
+  it("covers the scripts beyond Arabic that join the same way", () => {
+    expect(joiningType(0x0710)).toBe("R"); // Syriac alaph
+    expect(joiningType(0x0712)).toBe("D"); // Syriac beth
+    expect(joiningType(0x07ca)).toBe("D"); // N'Ko a
+    expect(joiningType(0x1e900)).toBe("D"); // Adlam alif
+  });
+
+  it("says U for anything outside the table, which is the standard's own default", () => {
+    expect(joiningType(0x0020)).toBe("U");
+    expect(joiningType(0x1f600)).toBe("U");
+    expect(joiningType(0x05d0)).toBe("U"); // Hebrew does not join
+  });
+});
+
+describe("the four forms of a word", () => {
+  it("shapes a plain dual-joining word", () => {
+    // beh-beh-beh: first joins left only, middle joins both, last joins right only.
+    expect(forms("ببب")).toEqual(["init", "medi", "fina"]);
+  });
+
+  it("breaks the join after a right-joining letter", () => {
+    // alef joins to what precedes it but NOT to what follows, so the beh after it starts fresh.
+    expect(forms("باب")).toEqual(["init", "fina", "isol"]);
+  });
+
+  it("leaves a lone letter isolated", () => {
+    expect(forms("ب")).toEqual(["isol"]);
+    expect(forms("ا")).toEqual(["isol"]);
+  });
+
+  it("does not join across a space", () => {
+    expect(forms("بب بب")).toEqual(["init", "fina", "-", "init", "fina"]);
+  });
+
+  it("shapes a real sentence the way the font's own presentation forms do", () => {
+    // "marhaban bil'alam". Checked letter by letter against the glyphs NotoNaskhArabic, NotoSansArabic
+    // and DejaVuSans map their U+FExx presentation-form code points to.
+    expect(forms("مرحبا بالعالم")).toEqual([
+      "init",
+      "fina",
+      "init",
+      "medi",
+      "fina",
+      "-",
+      "init",
+      "fina",
+      "init",
+      "medi",
+      "fina",
+      "init",
+      "fina",
+    ]);
+  });
+});
+
+describe("the characters that are invisible to joining", () => {
+  it("lets a letter join straight through a combining mark", () => {
+    // A fatha on the first beh must not break the join to the second - the mark is transparent.
+    expect(forms("بَب")).toEqual(["init", "-", "fina"]);
+  });
+
+  it("joins through a tatweel, which is what a keshide is for", () => {
+    // The tatweel takes no form of its own but makes both neighbours behave as if joined.
+    expect(forms("بـب")).toEqual(["init", "-", "fina"]);
+  });
+
+  it("lets ZWJ force a joining form on a letter standing alone", () => {
+    expect(forms("ب‍")).toEqual(["init", "-"]);
+    expect(forms("‍ب")).toEqual(["-", "fina"]);
+  });
+});
+
+describe("the fast path", () => {
+  it("is false for text with nothing to join", () => {
+    expect(needsJoining(cps("Invoice 2026"))).toBe(false);
+    expect(needsJoining(cps("שלום"))).toBe(false); // Hebrew is right-to-left but does not join
+  });
+
+  it("is true as soon as one joining letter appears", () => {
+    expect(needsJoining(cps("total مرحبا"))).toBe(true);
+  });
+});

--- a/tests/unit/text/bidi.test.ts
+++ b/tests/unit/text/bidi.test.ts
@@ -145,3 +145,14 @@ describe("the logical text a run remembers", () => {
     expect(run.rtl).toBe(false);
   });
 });
+
+describe("mirrored characters and the logical text", () => {
+  it("keeps the author's own bracket in `logical`, not its mirror", () => {
+    // The drawn text has the bracket MIRRORED (rule L4). `logical` feeds shaping and, through it,
+    // `ToUnicode` - so a mirrored character there would put a bracket in the extracted text that
+    // nobody wrote.
+    const [run] = visualRuns(`(${HE})`, "rtl");
+    expect(run.text).toBe(`(${HE_VISUAL})`); // drawn: closing bracket first, depicted as an opening one
+    expect(run.logical).toBe(`(${HE})`); // written: exactly what was passed in
+  });
+});

--- a/tests/unit/text/bidi.test.ts
+++ b/tests/unit/text/bidi.test.ts
@@ -9,7 +9,9 @@ const HE_VISUAL = [...HE].reverse().join("");
 
 describe("the fast path", () => {
   it("leaves plain Latin text as one untouched run", () => {
-    expect(visualRuns("Invoice 2026")).toEqual([{ text: "Invoice 2026", rtl: false }]);
+    expect(visualRuns("Invoice 2026")).toEqual([
+      { text: "Invoice 2026", logical: "Invoice 2026", rtl: false },
+    ]);
   });
 
   it("spots text that could reorder, and text that cannot", () => {
@@ -23,9 +25,10 @@ describe("a right-to-left run inside left-to-right text", () => {
   it("draws the Hebrew backwards, between the Latin around it", () => {
     const runs = visualRuns(`Hello ${HE} world`);
     expect(runs).toEqual([
-      { text: "Hello ", rtl: false },
-      { text: HE_VISUAL, rtl: true },
-      { text: " world", rtl: false },
+      { text: "Hello ", logical: "Hello ", rtl: false },
+      // The drawn text is reversed; `logical` gives back what was written, which is what shaping needs.
+      { text: HE_VISUAL, logical: HE, rtl: true },
+      { text: " world", logical: " world", rtl: false },
     ]);
   });
 
@@ -40,7 +43,7 @@ describe("a right-to-left run inside left-to-right text", () => {
 describe("a right-to-left base direction", () => {
   it("puts a Latin word at the LEFT, since the line starts on the right", () => {
     const runs = visualRuns(`${HE} abc`, "rtl");
-    expect(runs[0]).toEqual({ text: "abc", rtl: false });
+    expect(runs[0]).toEqual({ text: "abc", logical: "abc", rtl: false });
     const last = runs[runs.length - 1];
     expect(last.rtl).toBe(true);
     // The space between them is a NEUTRAL and resolves to the surrounding right-to-left level, so it
@@ -119,8 +122,26 @@ describe("spans keep their identity through the reordering", () => {
       "ltr",
     );
     expect(runs).toEqual([
-      { text: "a", rtl: false, source: 1 },
-      { text: "", rtl: false, source: 2 },
+      { text: "a", logical: "a", rtl: false, source: 1 },
+      { text: "", logical: "", rtl: false, source: 2 },
     ]);
+  });
+});
+
+describe("the logical text a run remembers", () => {
+  it("gives back what was written, not what is drawn", () => {
+    // SHAPING needs this. A letter's form comes from its neighbours, and reversing swaps them - so
+    // shaping the drawn text produces the mirror-image form of every letter (measured on Arabic: a
+    // word 8pt too wide). Shape `logical`, then reverse the GLYPHS.
+    const [run] = visualRuns(HE, "rtl");
+    expect(run.text).toBe(HE_VISUAL);
+    expect(run.logical).toBe(HE);
+    expect(run.rtl).toBe(true);
+  });
+
+  it("is the same string for a left-to-right run", () => {
+    const [run] = visualRuns("abc");
+    expect(run.logical).toBe(run.text);
+    expect(run.rtl).toBe(false);
   });
 });

--- a/tests/unit/text/bidi.test.ts
+++ b/tests/unit/text/bidi.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { visualRuns, visualRunsOf, needsBidi } from "../../../src/lib/text/bidi.ts";
+
+// UAX #9 decides the ORDER characters appear in, not their shapes. These tests read as what a reader
+// would SEE, left to right - which is exactly what `visualRuns` returns.
+
+const HE = "שלום"; // shalom, logical order
+const HE_VISUAL = [...HE].reverse().join("");
+
+describe("the fast path", () => {
+  it("leaves plain Latin text as one untouched run", () => {
+    expect(visualRuns("Invoice 2026")).toEqual([{ text: "Invoice 2026", rtl: false }]);
+  });
+
+  it("spots text that could reorder, and text that cannot", () => {
+    expect(needsBidi("Invoice 2026")).toBe(false);
+    expect(needsBidi(`total ${HE}`)).toBe(true);
+    expect(needsBidi("‏")).toBe(true); // an explicit right-to-left mark
+  });
+});
+
+describe("a right-to-left run inside left-to-right text", () => {
+  it("draws the Hebrew backwards, between the Latin around it", () => {
+    const runs = visualRuns(`Hello ${HE} world`);
+    expect(runs).toEqual([
+      { text: "Hello ", rtl: false },
+      { text: HE_VISUAL, rtl: true },
+      { text: " world", rtl: false },
+    ]);
+  });
+
+  it("puts the whole line back together in the same characters", () => {
+    const runs = visualRuns(`Hello ${HE} world`);
+    expect([...runs.map((r) => r.text).join("")].sort().join("")).toBe(
+      [...`Hello ${HE} world`].sort().join(""),
+    );
+  });
+});
+
+describe("a right-to-left base direction", () => {
+  it("puts a Latin word at the LEFT, since the line starts on the right", () => {
+    const runs = visualRuns(`${HE} abc`, "rtl");
+    expect(runs[0]).toEqual({ text: "abc", rtl: false });
+    const last = runs[runs.length - 1];
+    expect(last.rtl).toBe(true);
+    // The space between them is a NEUTRAL and resolves to the surrounding right-to-left level, so it
+    // belongs to this run rather than the Latin one.
+    expect(last.text).toBe(` ${HE_VISUAL}`);
+  });
+
+  it("keeps a number left to right inside right-to-left text", () => {
+    // Digits are weak: they read left to right even when everything around them does not.
+    const runs = visualRuns(`${HE} 123 ${HE}`, "rtl");
+    expect(runs.some((r) => r.text.includes("123"))).toBe(true);
+    expect(runs.every((r) => !r.text.includes("321"))).toBe(true);
+  });
+
+  it("mirrors a bracket, so the pair still reads as a pair on screen", () => {
+    // Rule L4. Logical: `H ( H )`. Reversing puts the CLOSING bracket leftmost, and mirroring then
+    // depicts it as an opening one - so the reader still sees "(...)" and not ")...(". Without this the
+    // brackets come out backwards, which is what an empty mirroring map silently produced.
+    const line = visualRuns(`${HE} (${HE})`, "rtl")
+      .map((r) => r.text)
+      .join("");
+    expect(line).toBe(`(${HE_VISUAL}) ${HE_VISUAL}`);
+  });
+});
+
+describe("astral characters survive the reversal", () => {
+  it("keeps an emoji whole inside a right-to-left run", () => {
+    // A surrogate PAIR is two code units at one level; reversing naively splits it into two broken
+    // halves, and the emoji becomes garbage. This is the case that made the pair-rejoin necessary.
+    const runs = visualRuns(`${HE}\u{1F600}${HE}`, "rtl");
+    const line = runs.map((r) => r.text).join("");
+    expect(line).toContain("\u{1F600}");
+    expect(line.codePointAt(line.indexOf("\u{1F600}"))).toBe(0x1f600);
+  });
+});
+
+describe("spans keep their identity through the reordering", () => {
+  it("runs the algorithm over the WHOLE line, not each span on its own", () => {
+    // Two spans, one Latin one Hebrew. Reordering each in isolation would leave them in source order;
+    // running over the joined line is what puts the Hebrew where a reader expects it.
+    const runs = visualRunsOf(
+      [
+        { text: "Total: ", source: "latin" },
+        { text: HE, source: "hebrew" },
+      ],
+      "rtl",
+    );
+    // Drawn left to right: the Hebrew, then ": " (neutrals, which take the surrounding right-to-left
+    // level and so are drawn reversed), then "Total". An Israeli reader starts at the right and gets
+    // "Total: shalom" - which is the point.
+    expect(runs.map((r) => r.text)).toEqual([HE_VISUAL, " :", "Total"]);
+    expect(runs.map((r) => r.source)).toEqual(["hebrew", "latin", "latin"]);
+    expect(runs.map((r) => r.rtl)).toEqual([true, true, false]);
+  });
+
+  it("splits a run where the span changes, so each keeps its own font", () => {
+    const runs = visualRunsOf(
+      [
+        { text: HE, source: "a" },
+        { text: HE, source: "b" },
+      ],
+      "rtl",
+    );
+    expect(runs.map((r) => r.source)).toEqual(["b", "a"]);
+    expect(runs.every((r) => r.rtl)).toBe(true);
+  });
+
+  it("hands the pieces back verbatim when there is nothing to reorder", () => {
+    // Empty spans included: the fast path must be a pass-through, or a document that never touches
+    // bidi would change its bytes just by this code existing.
+    const runs = visualRunsOf(
+      [
+        { text: "a", source: 1 },
+        { text: "", source: 2 },
+      ],
+      "ltr",
+    );
+    expect(runs).toEqual([
+      { text: "a", rtl: false, source: 1 },
+      { text: "", rtl: false, source: 2 },
+    ]);
+  });
+});

--- a/tests/unit/text/shape.test.ts
+++ b/tests/unit/text/shape.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { shapeRun, type ShapingFont } from "../../../src/lib/text/shape.ts";
+import { GsubTable } from "../../../src/lib/utils/gsub.ts";
+import { buildGsub, coverage1, single1, ligature } from "../support/gsub-builder.ts";
+
+// Shaping is where Unicode's answer (WHICH form) meets the font's answer (which GLYPH). The font here
+// is a stand-in with a made-up glyph numbering, so the tests read as "the initial form of beh", not as
+// "glyph 5259" - and they stay true whatever real font is used.
+
+const BEH = 0x0628; // dual-joining
+const ALEF = 0x0627; // right-joining
+const LAM = 0x0644; // dual-joining
+const A = 0x0061;
+
+// Base glyphs: one per letter. The joining forms live 100/200/300 above the base, so a test can read
+// "beh + 100" as "the initial beh" - which is exactly what the delta-based lookups below produce.
+const base: Record<number, number> = { [BEH]: 10, [ALEF]: 20, [LAM]: 30, [A]: 40 };
+const INIT = 100,
+  MEDI = 200,
+  FINA = 300;
+const LAM_ALEF = 999;
+
+const gsub = new GsubTable(
+  buildGsub(
+    [
+      { tag: "init", lookups: [0] },
+      { tag: "medi", lookups: [1] },
+      { tag: "fina", lookups: [2] },
+      { tag: "rlig", lookups: [3] },
+    ],
+    [
+      { type: 1, subtables: [single1(coverage1([10, 20, 30]), INIT)] },
+      { type: 1, subtables: [single1(coverage1([10, 30]), MEDI)] },
+      { type: 1, subtables: [single1(coverage1([10, 20, 30]), FINA)] },
+      // The initial lam followed by the final alef collapses - which IS lam-alef, the one ligature
+      // Arabic is not allowed to draw apart.
+      { type: 4, subtables: [ligature(coverage1([30 + INIT]), [[[LAM_ALEF, 20 + FINA]]])] },
+    ],
+  ),
+  0,
+);
+
+/** Every glyph is 100 units wide except the ligature, so a merge is visible in the advance too. */
+const font: ShapingFont = {
+  gsub: () => gsub,
+  getGlyphIndex: (cp) => base[cp] ?? 0,
+  getAdvanceWidth: (glyph) => (glyph === LAM_ALEF ? 150 : 100),
+};
+
+const shape = (text: string) =>
+  shapeRun(
+    [...text].map((c) => c.codePointAt(0)!),
+    font,
+  );
+
+describe("nothing to shape", () => {
+  it("leaves Latin alone, so no existing document changes", () => {
+    expect(shape("abc")).toBeUndefined();
+  });
+
+  it("leaves a font without the script alone", () => {
+    const noArabic: ShapingFont = { ...font, gsub: () => undefined };
+    expect(shapeRun([BEH, BEH], noArabic)).toBeUndefined();
+  });
+});
+
+describe("joining forms become glyphs", () => {
+  it("gives each letter of a word its own form", () => {
+    // beh-beh-beh: initial, medial, final.
+    expect(shape("ببب")!.map((g) => g.glyph)).toEqual([10 + INIT, 10 + MEDI, 10 + FINA]);
+  });
+
+  it("leaves a lone letter in its base (isolated) glyph", () => {
+    // There is no `isol` lookup here, which is the normal case: the plain glyph already IS that form.
+    expect(shape("ب")!.map((g) => g.glyph)).toEqual([10]);
+  });
+
+  it("breaks the join after a right-joining letter", () => {
+    // beh-alef-beh: the alef ends the connection, so the second beh starts a new one.
+    expect(shape("باب")!.map((g) => g.glyph)).toEqual([10 + INIT, 20 + FINA, 10]);
+  });
+
+  it("keeps one code point per glyph when nothing merges", () => {
+    expect(shape("ببب")!.map((g) => g.codePoints)).toEqual([[BEH], [BEH], [BEH]]);
+  });
+});
+
+describe("required ligatures", () => {
+  it("collapses lam-alef into one glyph", () => {
+    const shaped = shape("لا")!;
+    expect(shaped.map((g) => g.glyph)).toEqual([LAM_ALEF]);
+  });
+
+  it("carries BOTH code points on the merged glyph, or copied text would lose a letter", () => {
+    expect(shape("لا")!.map((g) => g.codePoints)).toEqual([[LAM, ALEF]]);
+  });
+
+  it("takes the advance of the ligature, not of the parts it replaced", () => {
+    // 150, not 2 x 100 - the whole reason a joined word is narrower than an unjoined one.
+    expect(shape("لا")!.reduce((w, g) => w + g.advance, 0)).toBe(150);
+  });
+
+  it("only merges where the ligature actually matches", () => {
+    // alef-lam is not lam-alef: the same two letters the other way round must stay two glyphs.
+    expect(shape("ال")!.length).toBe(2);
+  });
+});
+
+describe("the advance a shaped run reports", () => {
+  it("is the sum of the SHAPED glyphs, which is what makes measured equal drawn", () => {
+    expect(shape("ببب")!.reduce((w, g) => w + g.advance, 0)).toBe(300);
+  });
+});

--- a/tests/unit/utils/gsub.test.ts
+++ b/tests/unit/utils/gsub.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { GsubTable } from "../../../src/lib/utils/gsub.ts";
+
+// The table is BUILT here rather than committed. The only real fonts in this repo live in the
+// gitignored `claude-data/`, so a fixture-based test would fail in a fresh clone - the same reason
+// the WOFF tests build their container. Building it also means every offset in the reader is
+// exercised against a layout we wrote from the spec, not against one font's habits.
+
+import {
+  buildGsub,
+  coverage1,
+  coverage2,
+  single1,
+  single2,
+  ligature,
+  extension,
+} from "../support/gsub-builder.ts";
+
+describe("finding a feature's lookups", () => {
+  const table = new GsubTable(
+    buildGsub(
+      [
+        { tag: "init", lookups: [0] },
+        { tag: "fina", lookups: [1] },
+      ],
+      [
+        { type: 1, subtables: [single1(coverage1([10, 11]), 100)] },
+        { type: 1, subtables: [single1(coverage1([10]), 200)] },
+      ],
+    ),
+    0,
+  );
+
+  it("reports the script it carries", () => {
+    expect(table.hasScript("arab")).toBe(true);
+    expect(table.hasScript("latn")).toBe(false);
+  });
+
+  it("maps a feature tag to its lookup indices", () => {
+    expect(table.lookups("arab", "init")).toEqual([0]);
+    expect(table.lookups("arab", "fina")).toEqual([1]);
+  });
+
+  it("returns nothing for a feature or script the font does not have", () => {
+    expect(table.lookups("arab", "medi")).toEqual([]);
+    expect(table.lookups("latn", "init")).toEqual([]);
+  });
+});
+
+describe("single substitution - the joining forms themselves", () => {
+  const table = new GsubTable(
+    buildGsub(
+      [
+        { tag: "init", lookups: [0] },
+        { tag: "medi", lookups: [1] },
+        { tag: "fina", lookups: [2] },
+      ],
+      [
+        { type: 1, subtables: [single1(coverage1([10, 11, 12]), 100)] },
+        { type: 1, subtables: [single2(coverage1([10, 11]), [55, 66])] },
+        { type: 1, subtables: [single1(coverage2([[20, 24, 0]]), 500)] },
+      ],
+    ),
+    0,
+  );
+
+  it("format 1 shifts a covered glyph by the delta", () => {
+    expect(table.substituteSingle(0, 10)).toBe(110);
+    expect(table.substituteSingle(0, 12)).toBe(112);
+  });
+
+  it("format 2 uses the replacement listed for that glyph", () => {
+    expect(table.substituteSingle(1, 10)).toBe(55);
+    expect(table.substituteSingle(1, 11)).toBe(66);
+  });
+
+  it("reads a range-based coverage as well as a listed one", () => {
+    expect(table.substituteSingle(2, 20)).toBe(520);
+    expect(table.substituteSingle(2, 24)).toBe(524);
+  });
+
+  it("says null for a glyph the lookup does not cover, which means the feature does not apply", () => {
+    expect(table.substituteSingle(0, 99)).toBeNull();
+    expect(table.substituteSingle(2, 25)).toBeNull();
+  });
+});
+
+describe("ligature substitution - lam-alef and friends", () => {
+  const table = new GsubTable(
+    buildGsub(
+      [{ tag: "rlig", lookups: [0] }],
+      [
+        {
+          type: 4,
+          subtables: [
+            ligature(coverage1([10]), [
+              [
+                [900, 20], // 10 + 20      -> 900
+                [901, 20, 30], // 10 + 20 + 30 -> 901
+              ],
+            ]),
+          ],
+        },
+      ],
+    ),
+    0,
+  );
+
+  it("collapses a matching run and says how many glyphs it swallowed", () => {
+    expect(table.substituteLigature(0, [10, 20, 99], 0)).toEqual({ glyph: 900, consumed: 2 });
+  });
+
+  it("prefers the LONGER ligature when both match", () => {
+    // The two-glyph one also matches here; taking it would leave a stray glyph behind and is the
+    // classic way a ligature table is read wrong.
+    expect(table.substituteLigature(0, [10, 20, 30], 0)).toEqual({ glyph: 901, consumed: 3 });
+  });
+
+  it("matches at an offset, not just at the start", () => {
+    expect(table.substituteLigature(0, [5, 10, 20], 1)).toEqual({ glyph: 900, consumed: 2 });
+  });
+
+  it("says null when the run does not match, or would run past the end", () => {
+    expect(table.substituteLigature(0, [10, 99], 0)).toBeNull();
+    expect(table.substituteLigature(0, [10], 0)).toBeNull(); // needs a second glyph it does not have
+  });
+});
+
+describe("type 7 - the extension wrapper real fonts hide lookups behind", () => {
+  const table = new GsubTable(
+    buildGsub(
+      [{ tag: "init", lookups: [0] }],
+      [{ type: 7, subtables: [extension(1, single1(coverage1([10]), 100))] }],
+    ),
+    0,
+  );
+
+  it("unwraps to the real type, so a caller never learns it was wrapped", () => {
+    expect(table.lookupType(0)).toBe(1);
+    expect(table.substituteSingle(0, 10)).toBe(110);
+  });
+});
+
+describe("a lookup type we do not implement", () => {
+  const table = new GsubTable(
+    buildGsub([{ tag: "rlig", lookups: [0] }], [{ type: 6, subtables: [[0, 0]] }]),
+    0,
+  );
+
+  it("is reported rather than guessed at", () => {
+    expect(table.lookupType(0)).toBe(6);
+    expect(table.substituteSingle(0, 10)).toBeNull();
+    expect(table.substituteLigature(0, [10, 20], 0)).toBeNull();
+  });
+});

--- a/tests/unit/utils/gsub.test.ts
+++ b/tests/unit/utils/gsub.test.ts
@@ -47,6 +47,24 @@ describe("finding a feature's lookups", () => {
   });
 });
 
+describe("a script with no DEFAULT language system", () => {
+  // Some fonts declare only a named LangSys (`ARA `) and no default. Its offset lives at a different
+  // place in the script table, and reading it from the wrong one silently finds no features at all.
+  const table = new GsubTable(
+    buildGsub(
+      [{ tag: "init", lookups: [0] }],
+      [{ type: 1, subtables: [single1(coverage1([10]), 100)] }],
+      true,
+    ),
+    0,
+  );
+
+  it("falls back to the first named one instead of giving up", () => {
+    expect(table.lookups("arab", "init")).toEqual([0]);
+    expect(table.substituteSingle(0, 10)).toBe(110);
+  });
+});
+
 describe("single substitution - the joining forms themselves", () => {
   const table = new GsubTable(
     buildGsub(


### PR DESCRIPTION
## Summary

jasy now supports hebrew and arabic fonts (RTL)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bidirectional text support for mixed-language and right-to-left content.
  * Added Arabic and related-script shaping, including joining forms and ligatures.
  * Added writing-direction-aware alignment with configurable text direction.
  * Improved custom-font rendering, measurement, and accessibility mapping for shaped text.
  * Preserved correct visual ordering and styling across mixed-direction text segments.
* **Tests**
  * Expanded coverage for bidirectional text, Arabic shaping, ligatures, alignment, and styled text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->