### PR TITLE
feat: justified text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -594,13 +594,30 @@ agree: true })` → declarative values, not object mutation. Save is an **increm
   the pixel and only Chrome differs, by 3 px on one mark. Also the discretionary `liga` (Latin, nothing
   to do with RTL) and scripts beyond the Arabic family. All in `todo.md`.
 
-- ✅ **Justified text** (2026-08-02) — `Text({ align: "justify" })`. It maps onto
-  `HorizontalAlignment.block`, which had been sitting in the enum with nothing implementing it. A full
-  line's slack is spread over its spaces by MOVING THE PEN, one run per word: the `Tw` operator reaches
-  only the single byte 32, so an embedded Identity-H font could never be stretched that way. The LAST
-  line of a paragraph keeps its natural spacing (print and CSS both), and a shaped piece is never split,
-  so Arabic keeps natural spacing too. Verified against react-pdf: both fill exactly 222.0 pt on the same
-  box. Off by default — 30/30 gallery byte-identical.
+- ✅ **Justified text** (2026-08-02) — `Text({ align: "justify" })`. The enum member is
+  `HorizontalAlignment.justify`; it was called `block` and did nothing, and was renamed while it still
+  had no users. A line's slack is spread over its spaces by MOVING THE PEN, one run per word: the `Tw`
+  operator reaches only the single byte 32, so an embedded Identity-H font could never be stretched that
+  way. A shaped (Arabic) piece is never split, so it keeps natural spacing.
+  The line may also be **SQUEEZED** to keep one more word on it, up to `MAX_SPACE_SHRINK` (a quarter of
+  a space, `text/line-breaker.ts`). Our breaker is GREEDY and spends the whole allowance whenever it
+  saves a line, so the limit is the tightest word space still worth reading rather than TeX's third.
+  The allowance is threaded into BOTH passes (`TextElement.spaceShrink`), or a paragraph would be
+  measured at one line count and drawn at another.
+  The last line is never STRETCHED — the print and CSS rule — but it IS squeezed when the breaker
+  packed it that way, or it would be drawn out of its box. That case only surfaced under mutation
+  testing.
+  Verified against react-pdf: lines 2-6 of the same paragraph are identical, `print` lands on the same
+  line, and both fill exactly 222.0 pt. Line 1 still differs by one word because react-pdf spreads its
+  squeeze over the CHARACTERS as well as the spaces.
+- ✅ **Line-breaker fix: the joining space** (2026-08-02) — the fit test asked `currentWidth +
+wordWidth > maxWidth` and forgot the SPACE that would join the word. It went unseen on the first line,
+  where the paragraph's first word added a space too many and cancelled the error out; after a break
+  `currentWidth` is the bare word, so every following test was short by one space and the line could
+  overrun its box by that much. Found by comparing a justified paragraph with react-pdf — a glyph
+  visibly hanging past the edge. **This one is NOT byte-neutral**: four gallery cases
+  (`07-header-footer`, `12-line-height`, `17-page-numbers`, `19-text-decoration`) now break a word
+  earlier, because they were overflowing before.
 
 Genuine remaining gaps / deferred:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,8 +230,8 @@ rendering. This is the standing visual check; prefer it over one-off `scripts/ru
 - `pnpm test` — Vitest (watch). `pnpm exec vitest run` for a one-shot CI-style run.
   `pnpm run test:coverage` for coverage. Unit tests live in **`tests/unit/`**, mirroring the `src/lib/`
   structure (`tests/unit/{common,elements,renderer,utils}/…`). `src/` is pure production code — the
-  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **996 tests, green** —
-  what the root run covers: core 899, `@jasy/cli` 37, `@jasy/vue` 33, `@jasy/e-invoice` 27. `@jasy/nuxt`
+  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **1005 tests, green** —
+  what the root run covers: core 908, `@jasy/cli` 37, `@jasy/vue` 33, `@jasy/e-invoice` 27. `@jasy/nuxt`
   is excluded from it (`vitest.config.ts`) and runs on its own.
 - `pnpm run build` — `tsc` → `dist/`.
 - `pnpm run lint` (oxlint) + `pnpm run fmt:check` (oxfmt `--check`); `pnpm run fmt` formats. **Run `pnpm run fmt`
@@ -594,6 +594,14 @@ agree: true })` → declarative values, not object mutation. Save is an **increm
   the pixel and only Chrome differs, by 3 px on one mark. Also the discretionary `liga` (Latin, nothing
   to do with RTL) and scripts beyond the Arabic family. All in `todo.md`.
 
+- ✅ **Justified text** (2026-08-02) — `Text({ align: "justify" })`. It maps onto
+  `HorizontalAlignment.block`, which had been sitting in the enum with nothing implementing it. A full
+  line's slack is spread over its spaces by MOVING THE PEN, one run per word: the `Tw` operator reaches
+  only the single byte 32, so an embedded Identity-H font could never be stretched that way. The LAST
+  line of a paragraph keeps its natural spacing (print and CSS both), and a shaped piece is never split,
+  so Arabic keeps natural spacing too. Verified against react-pdf: both fill exactly 222.0 pt on the same
+  box. Off by default — 30/30 gallery byte-identical.
+
 Genuine remaining gaps / deferred:
 
 1. **Absolute positioning — Stages 1+2 built** (2026-06-21). CSS-style: `Box({ relative: true })` is a
@@ -670,7 +678,7 @@ below), `@jasy/cli`@alpha.6, `@jasy/vue`@alpha.7, `@jasy/nuxt`@alpha.6** (the al
 page-break control — the termination guard, `PageBreak`, `breakBefore`/`breakAfter`, `keepTogether` — plus
 kerning turned on by default). Repo public + locked, full CI + changelog +
 bots in place (see Repo facts). The engine is **feature-complete for the alpha** — inheritance, `onOverflow`,
-custom formats, the line-breaker fixes; **996 tests green** (the root run, i.e. everything but
+custom formats, the line-breaker fixes; **1005 tests green** (the root run, i.e. everything but
 `@jasy/nuxt`). The **landing**
 (`~/projects/jasy-landing` → **jasy.dev**) is built: showroom (12 cards), validator, docs, a home-page
 roadmap section, and a full **SEO + AI-discoverability layer** (OG image, JSON-LD, `robots.txt`,

--- a/src/lib/api/text.ts
+++ b/src/lib/api/text.ts
@@ -41,7 +41,7 @@ export interface TextStyle {
 
 export interface TextOptions extends TextStyle {
   /** Text-internal alignment (left/center/right) - independent of a parent's `cross` (§5). */
-  align?: "left" | "center" | "right";
+  align?: "left" | "center" | "right" | "justify";
   /** Cap the number of wrapped lines (default: unlimited - the text grows down as far as it needs,
    *  paginating onto the next page). Needs a bounded width (a Column/Expanded/`Box({ width })`). */
   maxLines?: number;
@@ -76,6 +76,7 @@ const ALIGN: Record<NonNullable<TextOptions["align"]>, HorizontalAlignment> = {
   left: HorizontalAlignment.left,
   center: HorizontalAlignment.center,
   right: HorizontalAlignment.right,
+  justify: HorizontalAlignment.justify,
 };
 
 /**
@@ -171,7 +172,7 @@ export interface TextDefaults {
   bold?: boolean;
   italic?: boolean;
   color?: ColorInput;
-  align?: "left" | "center" | "right";
+  align?: "left" | "center" | "right" | "justify";
   lineHeight?: number;
   underline?: boolean;
   strikethrough?: boolean;

--- a/src/lib/elements/pdf-element.ts
+++ b/src/lib/elements/pdf-element.ts
@@ -265,7 +265,8 @@ export enum HorizontalAlignment {
   left = "LEFT",
   right = "RIGHT",
   center = "CENTER",
-  block = "BLOCK",
+  /** CSS `text-align: justify` - both edges line up, the last line of a paragraph excepted. */
+  justify = "JUSTIFY",
 }
 
 export enum VerticalAlignment {

--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -11,6 +11,7 @@ import { BoxConstraints, Offset, Size } from "../layout/box-constraints.ts";
 import type { Direction } from "../text/bidi.ts";
 import { Fragmentable, FragmentResult } from "../layout/fragmentation.ts";
 import {
+  MAX_SPACE_SHRINK,
   wrapStringIntoLines,
   breakSegmentsIntoLines,
   segmentLinesToSegments,
@@ -161,6 +162,12 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     this.applyStyle(ctx.textStyle ?? DEFAULT_TEXT_STYLE);
   }
 
+  /** Justified lines may be squeezed to keep a word; every other alignment gets no slack. Read by the
+   *  breaker in BOTH passes, or a measured line and a drawn one would disagree about where it ends. */
+  private spaceShrink(): number {
+    return this.textAlignment === HorizontalAlignment.justify ? MAX_SPACE_SHRINK : 0;
+  }
+
   private applyStyle(ts: ResolvedTextStyle): void {
     this.fontSize = this.rawFontSize ?? ts.fontSize;
     this.fontFamily = this.rawFontFamily ?? ts.fontFamily;
@@ -206,6 +213,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       this.maxLines,
       this.overflow,
       this.letterSpacing,
+      this.spaceShrink(),
     );
 
     const box = lineBoxForString(
@@ -327,6 +335,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       this.overflow,
       this.lineHeight,
       this.letterSpacing,
+      this.spaceShrink(),
     );
 
     // Top-left coordinates (y = top of the text box). The baseline offset and the

--- a/src/lib/renderer/text-renderer.ts
+++ b/src/lib/renderer/text-renderer.ts
@@ -14,13 +14,14 @@ import { IRNode, TextRun, PathCommand, Gradient, Line, Link } from "../ir/displa
 import { isEmojiCodePoint } from "../text/emoji-codepoints.ts";
 import { emojiImageNode } from "./emoji-image.ts";
 import {
+  MAX_SPACE_SHRINK,
   wrapStringIntoLines,
   breakSegmentsIntoLines,
   SegmentLine,
   TextOverflow,
 } from "../text/line-breaker.ts";
 import { lineBoxForSegmentLine, lineBoxForString } from "../text/line-metrics.ts";
-import { runAdvance } from "../text/advance.ts";
+import { runAdvance, type RunFont } from "../text/advance.ts";
 import { visualRuns, visualRunsOf, type Direction } from "../text/bidi.ts";
 import {
   DecorationStroke,
@@ -43,6 +44,7 @@ export class TextRenderer {
     overflow?: TextOverflow,
     lineHeight?: number,
     letterSpacing = 0,
+    spaceShrink = 0,
   ): number {
     // Plain string: every wrapped line gets the same box.
     if (typeof content === "string") {
@@ -56,6 +58,7 @@ export class TextRenderer {
         maxLines,
         overflow,
         letterSpacing,
+        spaceShrink,
       );
       const box = lineBoxForString(objectManager, fontFamily, fontStyle, fontSize, lineHeight);
       return lines.length * box.height;
@@ -391,6 +394,70 @@ export class TextRenderer {
       return 0;
     };
 
+    /**
+     * Justification: how much extra to put in EACH space of a line so it reaches the full width.
+     * The LAST line of a paragraph keeps its natural spacing, as it does in CSS and in print - a
+     * justified last line is the classic sign of a broken text engine.
+     *
+     * Spaces are stretched by moving the pen, not by the `Tw` operator: `Tw` applies only to the
+     * single byte 32, so an embedded (Identity-H) font would ignore it entirely.
+     */
+    const justifyExtra = (line: string, naturalWidth: number, isLast: boolean): number => {
+      if (align !== HorizontalAlignment.justify) return 0;
+      const gaps = [...line].filter((c) => c === " ").length;
+      if (gaps === 0) return 0;
+      const slack = maxWidth - naturalWidth;
+      // Negative slack is real now: the breaker keeps a word when the line can be SQUEEZED to hold
+      // it, so justification has to deliver that squeeze. The floor is the same limit the breaker
+      // used, which is what stops a line it never promised from being crushed.
+      const spaceWidth = runAdvance(
+        objectManager,
+        " ",
+        { fontFamily, fontSize, fontStyle },
+        letterSpacing,
+      );
+      const extra = Math.max(slack / gaps, -spaceWidth * MAX_SPACE_SHRINK);
+      // The last line is never STRETCHED - the rule print and CSS follow. It may still be SQUEEZED:
+      // the breaker was allowed to pack it that way, and drawing it loose would push it out of its box.
+      return isLast ? Math.min(0, extra) : extra;
+    };
+
+    /**
+     * Push one drawn piece and return the advance it took. When the line is justified the pen jumps an
+     * extra `extra` at every space, which means one run per word - the only way that works for an
+     * embedded font, whose spaces `Tw` cannot reach.
+     *
+     * A SHAPED piece is never split: its glyph list is in drawn order with ligatures merged, so no
+     * slice of it is correct. Such a piece keeps its natural spacing.
+     */
+    const emitPiece = (
+      piece: { text: string; glyphs?: number[] },
+      x: number,
+      extra: number,
+      style: Omit<TextRun, "type" | "x" | "text" | "glyphs">,
+      runFont: RunFont,
+      spacing: number,
+    ): number => {
+      const push = (at: number, text: string, glyphs?: number[]): void => {
+        runs.push({ type: "text", x: at, text, ...(glyphs ? { glyphs } : {}), ...style });
+      };
+      if (extra === 0 || piece.glyphs || !piece.text.includes(" ")) {
+        push(x, piece.text, piece.glyphs);
+        return runAdvance(objectManager, piece.text, runFont, spacing);
+      }
+      const spaceWidth = runAdvance(objectManager, " ", runFont, spacing);
+      const words = piece.text.split(" ");
+      let pen = x;
+      words.forEach((word, i) => {
+        if (word !== "") {
+          push(pen, word);
+          pen += runAdvance(objectManager, word, runFont, spacing);
+        }
+        if (i < words.length - 1) pen += spaceWidth + extra;
+      });
+      return pen - x;
+    };
+
     // The decoration strokes for one drawn run, at the geometry ITS OWN font declares. A mixed-size
     // line therefore gets a thicker line under the bigger span, which is what a browser does too.
     const decorate = (
@@ -511,6 +578,9 @@ export class TextRenderer {
         maxLines,
         overflow,
         letterSpacing,
+        // The SAME slack the measure pass used (`TextElement.spaceShrink`), or a line would be
+        // measured one width and drawn another.
+        align === HorizontalAlignment.justify ? MAX_SPACE_SHRINK : 0,
       );
       // yPosition is the top of the text box (top-left). The line box seats its own baseline; lines
       // then stack by that box's height. Same numbers as calculateTextHeight, by construction.
@@ -520,21 +590,24 @@ export class TextRenderer {
         let x = initialX + alignmentOffset(lineWidth);
         const baseline = yPosition + box.baseline + box.height * index;
         // Latin-only text in an `ltr` paragraph comes back as one unchanged piece.
+        const extra = justifyExtra(line, lineWidth, index === lines.length - 1);
         for (const part of visualRuns(line, direction)) {
           const piece = shapedPiece(part, fontFamily, fontStyle);
-          const partWidth = runAdvance(objectManager, piece.text, font, letterSpacing);
-          runs.push({
-            type: "text",
+          const partWidth = emitPiece(
+            piece,
             x,
-            y: baseline,
-            text: piece.text,
-            ...(piece.glyphs ? { glyphs: piece.glyphs } : {}),
-            fontFamily,
-            fontStyle,
-            fontSize,
-            color,
-            ...(letterSpacing ? { letterSpacing } : {}),
-          });
+            extra,
+            {
+              y: baseline,
+              fontFamily,
+              fontStyle,
+              fontSize,
+              color,
+              ...(letterSpacing ? { letterSpacing } : {}),
+            },
+            font,
+            letterSpacing,
+          );
           decorate(
             piece.text,
             x,
@@ -559,8 +632,13 @@ export class TextRenderer {
     // the previous segment's kerning-free advance. Each line drops by its OWN leading
     // (tallest font on that line), so mixed-font lines space correctly and the drawn
     // height matches the measured height.
-    const pushLine = (line: SegmentLine, lineY: number): void => {
+    const pushLine = (line: SegmentLine, lineY: number, isLast: boolean): void => {
       let x = initialX + alignmentOffset(line.width);
+      const extra = justifyExtra(
+        line.segments.map((seg) => seg.content).join(""),
+        line.width,
+        isLast,
+      );
       // Across span boundaries, so a Hebrew span is ordered against its neighbours rather than inside
       // itself. Each run keeps the segment it came from, and with it that span's style.
       const ordered = visualRunsOf(
@@ -575,29 +653,26 @@ export class TextRenderer {
         const segLetterSpacing = segment.letterSpacing ?? letterSpacing;
         const piece = shapedPiece(part, family, style);
         const runText = piece.text;
-        const advance = runAdvance(
-          objectManager,
-          runText,
+        const runColor = segment.fontColor || color;
+        const drawn = emitPiece(
+          piece,
+          x,
+          extra,
+          {
+            y: lineY,
+            fontFamily: family,
+            fontStyle: style,
+            fontSize: size,
+            color: runColor,
+            ...(segLetterSpacing ? { letterSpacing: segLetterSpacing } : {}),
+          },
           { fontFamily: family, fontSize: size, fontStyle: style },
           segLetterSpacing,
         );
-        const runColor = segment.fontColor || color;
-        runs.push({
-          type: "text",
-          x,
-          y: lineY,
-          text: runText,
-          ...(piece.glyphs ? { glyphs: piece.glyphs } : {}),
-          fontFamily: family,
-          fontStyle: style,
-          fontSize: size,
-          color: runColor,
-          ...(segLetterSpacing ? { letterSpacing: segLetterSpacing } : {}),
-        });
         decorate(
           runText,
           x,
-          advance,
+          drawn,
           lineY,
           family,
           style,
@@ -616,13 +691,13 @@ export class TextRenderer {
             type: "link",
             x,
             y: lineY - v.ascent * size,
-            width: advance,
+            width: drawn,
             height: (v.ascent + v.descent) * size,
             href: segment.href,
             dest: segment.dest,
           });
         }
-        x += advance;
+        x += drawn;
       });
     };
 
@@ -633,18 +708,15 @@ export class TextRenderer {
     // measure path (calculateTextHeight) uses, or segmented spaced text mis-wraps (measured != drawn).
     const defaults = { fontFamily, fontSize, fontStyle, letterSpacing };
     let top = yPosition;
-    for (const line of breakSegmentsIntoLines(
-      content,
-      defaults,
-      maxWidth,
-      objectManager,
-      maxLines,
-      overflow,
-    )) {
+    // Materialised, because justification has to know which line is the LAST one of the paragraph.
+    const segmentLines = [
+      ...breakSegmentsIntoLines(content, defaults, maxWidth, objectManager, maxLines, overflow),
+    ];
+    segmentLines.forEach((line, index) => {
       const box = lineBoxForSegmentLine(line, defaults, objectManager, lineHeight);
-      pushLine(line, top + box.baseline);
+      pushLine(line, top + box.baseline, index === segmentLines.length - 1);
       top += box.height;
-    }
+    });
 
     return { runs, links, decorations };
   }

--- a/src/lib/text/line-breaker.ts
+++ b/src/lib/text/line-breaker.ts
@@ -3,6 +3,20 @@ import type { FontMetrics } from "../utils/font-metrics.ts";
 import type { TextSegment } from "../elements/text-element.ts";
 import { runAdvance } from "./advance.ts";
 
+/**
+ * How far a JUSTIFIED line's spaces may be squeezed to keep one more word on it.
+ *
+ * A quarter, because our breaker is GREEDY: it will use the whole allowance every time that saves a
+ * line, so the limit has to be the tightest word space still worth reading - about three quarters of
+ * natural, the usual typographic floor. TeX allows a third, but its badness model rarely spends it.
+ * For reference, react-pdf reaches -19% in practice (measured: a 3.18pt space squeezed to 2.58pt),
+ * which this covers. Its packing can still differ by a word, because it spreads the squeeze over the
+ * CHARACTERS as well as the spaces.
+ *
+ * Only justified text uses it: under any other alignment a squeezed line would simply overflow.
+ */
+export const MAX_SPACE_SHRINK = 1 / 4;
+
 /** Default font for segments that don't override it. */
 export interface SegmentDefaults {
   fontFamily: string;
@@ -45,9 +59,11 @@ export function wrapStringIntoLines(
   maxLines?: number,
   overflow?: TextOverflow,
   letterSpacing = 0,
+  shrink = 0,
 ): string[] {
   let currentLine = "";
   let currentWidth = 0;
+  let gaps = 0; // spaces on the current line, which is what a justified line can squeeze
   const lines: string[] = [];
 
   const font = { fontFamily, fontSize, fontStyle };
@@ -58,16 +74,32 @@ export function wrapStringIntoLines(
     const wordWidth = runAdvance(metrics, word, font, letterSpacing);
     const spaceWidth = runAdvance(metrics, " ", font, letterSpacing);
 
-    // Break before a word that won't fit - but only once the line has content. A single word wider
-    // than maxWidth must sit on its (empty) line and overflow, not push a phantom empty line before
-    // it (which would over-count the height by a line and shift the text down at render).
-    if (currentWidth + wordWidth > maxWidth && currentLine !== "") {
+    // Break before a word that won't fit - counting the SPACE that would join it, which the old test
+    // forgot. It went unnoticed on the first line, where the very first word added a space too many
+    // and cancelled the error out; after a break `currentWidth` is the bare word, so every following
+    // test was short by one space and the line could overrun its box by that much.
+    //
+    // A single word wider than maxWidth still sits on its (empty) line and overflows, rather than
+    // pushing a phantom empty line before it (which would over-count the height by a line).
+    if (currentLine === "") {
+      currentLine = word;
+      currentWidth = wordWidth;
+      gaps = 0;
+      // How much a JUSTIFIED line may be squeezed to keep one more word: the spaces already on the
+      // line plus the one that would join it, each giving up at most `shrink` of its width. Zero for
+      // every other alignment, where a squeezed line would simply overflow instead.
+    } else if (
+      currentWidth + spaceWidth + wordWidth - (gaps + 1) * spaceWidth * shrink >
+      maxWidth
+    ) {
       lines.push(currentLine.trim());
       currentLine = word;
       currentWidth = wordWidth;
+      gaps = 0;
     } else {
-      currentLine += index === 0 ? word : " " + word;
-      currentWidth += wordWidth + spaceWidth;
+      currentLine += " " + word;
+      currentWidth += spaceWidth + wordWidth;
+      gaps += 1;
     }
   });
 

--- a/tests/unit/renderer/text-justify.test.ts
+++ b/tests/unit/renderer/text-justify.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import { TextRenderer } from "../../../src/lib/renderer/text-renderer.ts";
+import { PDFObjectManager } from "../../../src/lib/utils/pdf-object-manager.ts";
+import { TextElement } from "../../../src/lib/elements/text-element.ts";
+import { HorizontalAlignment } from "../../../src/lib/elements/pdf-element.ts";
+import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
+import { testMetrics } from "../support/metrics.ts";
+import type { TextRun } from "../../../src/lib/ir/display-list.ts";
+
+// Justification spreads a line's leftover space into its SPACES. Every glyph here is 10 wide at size
+// 10 and a space is 10 too, so a run's x reads as "how many glyphs came before me" and the stretch is
+// arithmetic anyone can check by hand.
+
+const om = () =>
+  ({
+    ...testMetrics({ getStringWidth: (t) => [...t].length * 10, getCharWidth: () => 10 }),
+    struct: { enabled: false },
+    shapeText: () => undefined,
+    isCustomFont: () => false,
+    getColorFont: () => undefined,
+    getEmojiSource: () => undefined,
+    getEmojiFont: () => undefined,
+    getEmojiImageSource: () => undefined,
+  }) as unknown as PDFObjectManager;
+
+/** The text runs of a paragraph laid out in a box `width` wide, in drawing order. */
+const drawn = async (content: string, width: number, align?: HorizontalAlignment) => {
+  const el = new TextElement({
+    content,
+    fontSize: 10,
+    fontFamily: "Helvetica",
+    textAlignment: align,
+  });
+  const manager = om();
+  el.calculateLayout(BoxConstraints.tight(width, 400), { x: 0, y: 0 }, {
+    metrics: manager,
+  } as never);
+  const runs = (await TextRenderer.render(el, manager)).filter(
+    (n): n is TextRun => n.type === "text",
+  );
+  return runs.map((r) => ({ x: r.x, y: r.y, text: r.text }));
+};
+
+/** Lines, as the y they sit on. */
+const byLine = (runs: { x: number; y: number; text: string }[]) => {
+  const lines = new Map<number, { x: number; text: string }[]>();
+  for (const r of runs) lines.set(r.y, [...(lines.get(r.y) ?? []), { x: r.x, text: r.text }]);
+  return [...lines.entries()].sort((a, b) => a[0] - b[0]).map(([, v]) => v);
+};
+
+describe("a justified paragraph", () => {
+  // "aa bb cc" is 8 glyphs = 80pt natural; in a 100pt box there is 20pt of slack and two spaces,
+  // so each space grows by 10 - the words land at 0, 40 and 80.
+  it("spreads the slack evenly into the spaces, so the line fills the box", async () => {
+    const runs = await drawn("aa bb cc dd", 100, HorizontalAlignment.justify);
+    const lines = byLine(runs);
+    expect(lines[0].map((r) => r.text)).toEqual(["aa", "bb", "cc"]);
+    expect(lines[0].map((r) => r.x)).toEqual([0, 40, 80]);
+  });
+
+  it("leaves the LAST line alone, as print and CSS do", async () => {
+    // The last line must have a SPACE of its own, or the rule is never reached and the test is hollow.
+    // "aa bb cc" fills line one; "dd ee" is the last and keeps its natural 50pt instead of filling 100.
+    const lines = byLine(await drawn("aa bb cc dd ee", 100, HorizontalAlignment.justify));
+    expect(lines).toHaveLength(2);
+    // ONE run, spaces and all: a justified line is split into words, so a single run IS the proof
+    // that this one was left alone.
+    expect(lines[1]).toEqual([{ x: 0, text: "dd ee" }]);
+  });
+
+  it("emits one run per word, which is what an embedded font needs", async () => {
+    // `Tw` only reaches the single byte 32, so an Identity-H font could never be stretched that way.
+    // Moving the pen per word works for every font.
+    const lines = byLine(await drawn("aa bb cc dd", 100, HorizontalAlignment.justify));
+    expect(lines[0]).toHaveLength(3);
+  });
+});
+
+describe("when justification must NOT kick in", () => {
+  it("leaves a line without spaces alone", async () => {
+    const lines = byLine(await drawn("aaaa", 100, HorizontalAlignment.justify));
+    expect(lines[0]).toEqual([{ x: 0, text: "aaaa" }]);
+  });
+
+  it("leaves a too-long word alone, which is the only way a line can overflow", async () => {
+    // The breaker only ever overflows a SINGLE word, and a single word has no spaces - so a justified
+    // line can never be asked to shrink. That is why the clamp in `justifyExtra` has no reachable
+    // path; it is kept as a guard, not as behaviour, and this test pins the reason.
+    const lines = byLine(await drawn("aaaaaa bb", 40, HorizontalAlignment.justify));
+    expect(lines[0]).toEqual([{ x: 0, text: "aaaaaa" }]);
+  });
+
+  it("changes nothing for the default alignment", async () => {
+    const plain = await drawn("aa bb cc dd", 100);
+    expect(byLine(plain)[0]).toEqual([{ x: 0, text: "aa bb cc" }]);
+  });
+});
+
+describe("squeezing a line to keep one more word", () => {
+  // Four words of 20 with three spaces of 10 is 110 natural. The allowance is a quarter of each
+  // space, 7.5 in total, so the line fits a box of 105 but not one of 100.
+  it("keeps the word when the squeeze is enough, and the spaces come in", async () => {
+    // A line AFTER it, or the squeezed one would be the last and keep its natural spacing.
+    const lines = byLine(await drawn("aa bb cc dd ee ff", 105, HorizontalAlignment.justify));
+    expect(lines[0].map((r) => r.text)).toEqual(["aa", "bb", "cc", "dd"]);
+    // 5pt short over three gaps: each space gives up 1.67 and lands at 8.33 instead of 10.
+    expect(lines[0].map((r) => Math.round(r.x * 100) / 100)).toEqual([0, 28.33, 56.67, 85]);
+  });
+
+  it("gives up when the squeeze is not enough", async () => {
+    // The same words in a 100pt box: 110 natural minus the 7.5 allowance is still over.
+    const lines = byLine(await drawn("aa bb cc dd ee ff", 100, HorizontalAlignment.justify));
+    expect(lines[0].map((r) => r.text)).toEqual(["aa", "bb", "cc"]);
+  });
+
+  it("never squeezes text that is not justified - it would just overflow", async () => {
+    const lines = byLine(await drawn("aa bb cc dd", 105));
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toEqual([{ x: 0, text: "aa bb cc" }]);
+  });
+});
+
+describe("the measure pass and the draw pass must agree", () => {
+  it("counts the same lines it draws, squeeze included", async () => {
+    // The squeeze changes how many lines a paragraph takes. If only the DRAW pass knew about it, the
+    // element would reserve one line too many and every following element would sit too low - the
+    // "measured equals drawn" rule, one feature further on.
+    // Eight words: four to a line when squeezed (2 lines), three when not (3 lines). So the line
+    // COUNT differs, which is what makes this test able to fail.
+    const content = "aa bb cc dd ee ff gg hh";
+    const el = new TextElement({
+      content,
+      fontSize: 10,
+      fontFamily: "Helvetica",
+      textAlignment: HorizontalAlignment.justify,
+    });
+    const manager = om();
+    el.calculateLayout(BoxConstraints.tight(105, 400), { x: 0, y: 0 }, {
+      metrics: manager,
+    } as never);
+
+    const measured = (el.getProps() as { height: number }).height;
+    const drawnLines = byLine(await drawn(content, 105, HorizontalAlignment.justify)).length;
+    // The unit-metrics line box is exactly one em, so the height IS the line count times the size.
+    expect(measured).toBe(drawnLines * 10);
+  });
+});
+
+describe("a squeezed LAST line", () => {
+  it("is drawn squeezed, because that is how the breaker packed it", async () => {
+    // Eight words of 20 with spaces of 10: four fit a 105pt box only when squeezed. The SECOND line
+    // is the last, and it was packed with that same allowance - drawing it at natural spacing would
+    // push it 5pt out of the box.
+    const lines = byLine(await drawn("aa bb cc dd ee ff gg hh", 105, HorizontalAlignment.justify));
+    expect(lines).toHaveLength(2);
+    expect(lines[1].map((r) => r.text)).toEqual(["ee", "ff", "gg", "hh"]);
+    const last = lines[1];
+    expect(last[last.length - 1].x + 20).toBeLessThanOrEqual(105);
+  });
+});


### PR DESCRIPTION
## Summary

It's now possible to write justified (blocked) text.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added justified text alignment for PDF text.
  * Justified lines expand word spacing to fill available width.
  * Supports limited spacing compression to fit additional words.
  * Preserves natural spacing on final lines where possible.
  * Works with plain text, segmented content, links, and text decorations.

* **Tests**
  * Added comprehensive coverage for justified text layout and rendering.
  * Updated documented test totals to 1,005 passing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->