### PR TITLE
fix: natural width breaks wrong

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,7 @@ rendering. This is the standing visual check; prefer it over one-off `scripts/ru
 - `pnpm test` — Vitest (watch). `pnpm exec vitest run` for a one-shot CI-style run.
   `pnpm run test:coverage` for coverage. Unit tests live in **`tests/unit/`**, mirroring the `src/lib/`
   structure (`tests/unit/{common,elements,renderer,utils}/…`). `src/` is pure production code — the
-  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **1016 tests, green** —
+  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **1020 tests, green** —
   what the root run covers: core 908, `@jasy/cli` 37, `@jasy/vue` 33, `@jasy/e-invoice` 27. `@jasy/nuxt`
   is excluded from it (`vitest.config.ts`) and runs on its own.
 - `pnpm run build` — `tsc` → `dist/`.
@@ -629,6 +629,11 @@ wordWidth > maxWidth` and forgot the SPACE that would join the word. It went uns
   the identical expression for the test AND for the running total. Pinned by
   `tests/unit/text/single-line-width.test.ts`, whose metrics are deliberately non-binary widths so the
   grouping actually shows.
+  The SEGMENT breaker had the same disease twice over (found by review): its reported `line.width`
+  counted a space for EVERY word, the last one included, so a right-aligned span line sat 16 pt short of
+  its box — and its fit test forgot the joining space, exactly as the string one had. Both now follow
+  the same rule, and a space joins words only INSIDE a segment, since `span("a") + span("b")` draws
+  `ab` with nothing between.
 
 Genuine remaining gaps / deferred:
 
@@ -706,7 +711,7 @@ below), `@jasy/cli`@alpha.6, `@jasy/vue`@alpha.7, `@jasy/nuxt`@alpha.6** (the al
 page-break control — the termination guard, `PageBreak`, `breakBefore`/`breakAfter`, `keepTogether` — plus
 kerning turned on by default). Repo public + locked, full CI + changelog +
 bots in place (see Repo facts). The engine is **feature-complete for the alpha** — inheritance, `onOverflow`,
-custom formats, the line-breaker fixes; **1016 tests green** (the root run, i.e. everything but
+custom formats, the line-breaker fixes; **1020 tests green** (the root run, i.e. everything but
 `@jasy/nuxt`). The **landing**
 (`~/projects/jasy-landing` → **jasy.dev**) is built: showroom (12 cards), validator, docs, a home-page
 roadmap section, and a full **SEO + AI-discoverability layer** (OG image, JSON-LD, `robots.txt`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,7 @@ rendering. This is the standing visual check; prefer it over one-off `scripts/ru
 - `pnpm test` — Vitest (watch). `pnpm exec vitest run` for a one-shot CI-style run.
   `pnpm run test:coverage` for coverage. Unit tests live in **`tests/unit/`**, mirroring the `src/lib/`
   structure (`tests/unit/{common,elements,renderer,utils}/…`). `src/` is pure production code — the
-  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **1005 tests, green** —
+  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **1016 tests, green** —
   what the root run covers: core 908, `@jasy/cli` 37, `@jasy/vue` 33, `@jasy/e-invoice` 27. `@jasy/nuxt`
   is excluded from it (`vitest.config.ts`) and runs on its own.
 - `pnpm run build` — `tsc` → `dist/`.
@@ -619,6 +619,17 @@ wordWidth > maxWidth` and forgot the SPACE that would join the word. It went uns
   (`07-header-footer`, `12-line-height`, `17-page-numbers`, `19-text-decoration`) now break a word
   earlier, because they were overflowing before.
 
+- ✅ **`singleLineWidth` — the box and the breaker agree to the last bit** (2026-08-02) — a `Text` in a
+  `Row` is sized by its natural single-line width, and the breaker then decides whether that line fits.
+  Both sum the same words and spaces, but they GROUPED the additions differently — `(word + space)` per
+  word versus `word + (space + word)` — and floating-point addition is not associative. The box came out
+  one bit narrower than the line it was made for, so the text wrapped inside it. A gallery footer split
+  onto two lines from exactly that.
+  One exported function in `text/line-breaker.ts` now owns the sum, and the breaker's own fit test uses
+  the identical expression for the test AND for the running total. Pinned by
+  `tests/unit/text/single-line-width.test.ts`, whose metrics are deliberately non-binary widths so the
+  grouping actually shows.
+
 Genuine remaining gaps / deferred:
 
 1. **Absolute positioning — Stages 1+2 built** (2026-06-21). CSS-style: `Box({ relative: true })` is a
@@ -695,7 +706,7 @@ below), `@jasy/cli`@alpha.6, `@jasy/vue`@alpha.7, `@jasy/nuxt`@alpha.6** (the al
 page-break control — the termination guard, `PageBreak`, `breakBefore`/`breakAfter`, `keepTogether` — plus
 kerning turned on by default). Repo public + locked, full CI + changelog +
 bots in place (see Repo facts). The engine is **feature-complete for the alpha** — inheritance, `onOverflow`,
-custom formats, the line-breaker fixes; **1005 tests green** (the root run, i.e. everything but
+custom formats, the line-breaker fixes; **1016 tests green** (the root run, i.e. everything but
 `@jasy/nuxt`). The **landing**
 (`~/projects/jasy-landing` → **jasy.dev**) is built: showroom (12 cards), validator, docs, a home-page
 roadmap section, and a full **SEO + AI-discoverability layer** (OG image, JSON-LD, `robots.txt`,

--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -11,6 +11,7 @@ import { BoxConstraints, Offset, Size } from "../layout/box-constraints.ts";
 import type { Direction } from "../text/bidi.ts";
 import { Fragmentable, FragmentResult } from "../layout/fragmentation.ts";
 import {
+  singleLineWidth,
   MAX_SPACE_SHRINK,
   wrapStringIntoLines,
   breakSegmentsIntoLines,
@@ -24,7 +25,6 @@ import {
   type OrphanWidowRule,
 } from "../text/orphans-widows.ts";
 import { lineBoxForSegmentLine, lineBoxForString } from "../text/line-metrics.ts";
-import { runAdvance } from "../text/advance.ts";
 import { HorizontalAlignment, LayoutContext, SizedPDFElement } from "./pdf-element.ts";
 export interface TextSegment {
   content: string;
@@ -353,25 +353,20 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
    *  - enough to tip a borderline string (e.g. "20 Jun 2026", wider than "04 Jul 2026" only because
    *  'n' beats 'l') one bit over its own width, dropping the last word onto a second line. */
   private naturalWidth(metrics: FontMetrics): number {
+    // The breaker's own sum, to the last bit - see `singleLineWidth`.
     const oneLine = (
       text: string,
       family: string,
       size: number,
       style: FontStyle,
       letterSpacing: number,
-    ): number => {
-      const font = { fontFamily: family, fontSize: size, fontStyle: style };
-      const words = text.split(" ");
-      const space = runAdvance(metrics, " ", font, letterSpacing);
-      let width = 0;
-      words.forEach((word, i) => {
-        const w = runAdvance(metrics, word, font, letterSpacing);
-        // Group (word + space) as one term, exactly like the breaker - see the note above. Both use
-        // the same `runAdvance`, so the two agree bit for bit even with letterSpacing.
-        width += i < words.length - 1 ? w + space : w;
-      });
-      return width;
-    };
+    ): number =>
+      singleLineWidth(
+        text,
+        { fontFamily: family, fontSize: size, fontStyle: style },
+        metrics,
+        letterSpacing,
+      );
     if (typeof this.content === "string") {
       return oneLine(
         this.content,

--- a/src/lib/text/line-breaker.ts
+++ b/src/lib/text/line-breaker.ts
@@ -186,19 +186,25 @@ export function breakSegmentsIntoLines(
 
     words.forEach((word, wordIndex) => {
       const wordWidth = runAdvance(metrics, word, font, letterSpacing);
+      // A space joins this word to what precedes it only INSIDE a segment; segments butt together
+      // with nothing between them, which is what `span("a") + span("b")` draws.
+      const joiner = wordIndex > 0 ? spaceWidth : 0;
+      // ONE expression for the test and for the running total, grouped exactly as `singleLineWidth`
+      // groups it - see the note there. A width built any other way can be a bit off the one the box
+      // was sized with, and the text wraps inside a box made to hold it.
+      const candidate = width + (joiner + wordWidth);
 
       // Same guard as the string path: don't open a phantom empty line for an over-wide first word -
       // place it (overflowing) on the current empty line instead.
-      if (width + wordWidth > maxWidth && width > 0) {
+      if (candidate > maxWidth && width > 0) {
         lines.push({ segments: lineSegments, width });
-        width = 0;
+        width = wordWidth;
         lineSegments = [];
         combined = word;
-        width += wordWidth + spaceWidth;
         lineSegments.push({ ...segment, content: combined });
       } else {
         combined += wordIndex === 0 ? word : " " + word;
-        width += wordWidth + spaceWidth;
+        width = candidate;
         if (lineSegments.length === 0) {
           lineSegments.push({ ...segment, fontFamily: family, content: combined });
         }

--- a/src/lib/text/line-breaker.ts
+++ b/src/lib/text/line-breaker.ts
@@ -49,6 +49,31 @@ export interface SegmentLine {
  * rendering call this, so they can never disagree. Depends only on `FontMetrics`,
  * not the PDF byte writer - the future fragmentation pass can reuse it.
  */
+/**
+ * The width of `text` set as ONE line, accumulated in EXACTLY the order `wrapStringIntoLines` builds a
+ * line: the first word, then `+ (space + word)` each time. The order matters because floating-point
+ * addition is not associative - a box sized by a differently-grouped sum can be one bit too small for
+ * the very line the breaker then measures, and the text wraps inside a box made to fit it. That is not
+ * hypothetical: it is what split a footer sized to its own content.
+ */
+export function singleLineWidth(
+  text: string,
+  font: { fontFamily: string; fontSize: number; fontStyle: FontStyle },
+  metrics: FontMetrics,
+  letterSpacing = 0,
+): number {
+  const space = runAdvance(metrics, " ", font, letterSpacing);
+  return text
+    .split(" ")
+    .reduce(
+      (width, word, i) =>
+        i === 0
+          ? runAdvance(metrics, word, font, letterSpacing)
+          : width + (space + runAdvance(metrics, word, font, letterSpacing)),
+      0,
+    );
+}
+
 export function wrapStringIntoLines(
   text: string,
   fontFamily: string,
@@ -68,7 +93,7 @@ export function wrapStringIntoLines(
 
   const font = { fontFamily, fontSize, fontStyle };
   const words = text.split(" ");
-  words.forEach((word, index) => {
+  words.forEach((word) => {
     // Word and space advances come from the one shared primitive (`advance.ts`), the same one
     // `naturalWidth` uses - so a bounded and an unbounded layout of the same text agree bit for bit.
     const wordWidth = runAdvance(metrics, word, font, letterSpacing);
@@ -81,6 +106,8 @@ export function wrapStringIntoLines(
     //
     // A single word wider than maxWidth still sits on its (empty) line and overflows, rather than
     // pushing a phantom empty line before it (which would over-count the height by a line).
+    const candidate = currentWidth + (spaceWidth + wordWidth);
+
     if (currentLine === "") {
       currentLine = word;
       currentWidth = wordWidth;
@@ -88,17 +115,17 @@ export function wrapStringIntoLines(
       // How much a JUSTIFIED line may be squeezed to keep one more word: the spaces already on the
       // line plus the one that would join it, each giving up at most `shrink` of its width. Zero for
       // every other alignment, where a squeezed line would simply overflow instead.
-    } else if (
-      currentWidth + spaceWidth + wordWidth - (gaps + 1) * spaceWidth * shrink >
-      maxWidth
-    ) {
+      // ONE expression, used for the test AND for the running total. Adding the same three numbers in
+      // a different order gives a different last bit, and a line that lands exactly on `maxWidth` is
+      // then broken by that bit alone - which is how a footer sized to its own text wrapped.
+    } else if (candidate - (gaps + 1) * spaceWidth * shrink > maxWidth) {
       lines.push(currentLine.trim());
       currentLine = word;
       currentWidth = wordWidth;
       gaps = 0;
     } else {
       currentLine += " " + word;
-      currentWidth += spaceWidth + wordWidth;
+      currentWidth = candidate;
       gaps += 1;
     }
   });

--- a/tests/unit/text/single-line-width.test.ts
+++ b/tests/unit/text/single-line-width.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { singleLineWidth, wrapStringIntoLines } from "../../../src/lib/text/line-breaker.ts";
+import { FontStyle } from "../../../src/lib/utils/pdf-object-manager.ts";
+import { testMetrics } from "../support/metrics.ts";
+
+// The invariant: a box sized by `singleLineWidth` always holds that line. It reads as arithmetic, but
+// it is really about the ORDER of the additions - floating point is not associative, and a sum grouped
+// differently can be one bit smaller than the one the breaker computes. A footer sized to its own text
+// wrapped because of exactly that bit.
+
+const font = { fontFamily: "X", fontSize: 10, fontStyle: FontStyle.Normal };
+
+/** Widths chosen so the sums do NOT come out even in binary - the whole point of the test. */
+const metrics = testMetrics({
+  getStringWidth: (t) => [...t].reduce((w, c) => w + (c === " " ? 2.502 : 4.407), 0),
+  getCharWidth: (c) => (c === " " ? 2.502 : 4.407),
+});
+
+const SAMPLES = [
+  "ACME Ltd - 1 Example Street",
+  "a bb ccc dddd eeeee",
+  "one two",
+  "single",
+  "a b c d e f g h i j k l m n o p",
+];
+
+describe("a box sized by singleLineWidth holds its line", () => {
+  for (const text of SAMPLES) {
+    it(`fits ${JSON.stringify(text)} on one line at exactly its own width`, () => {
+      const w = singleLineWidth(text, font, metrics);
+      expect(wrapStringIntoLines(text, "X", 10, FontStyle.Normal, w, metrics)).toEqual([text]);
+    });
+  }
+
+  it("still wraps a hair below that width, so the test is not vacuous", () => {
+    const text = SAMPLES[0];
+    const w = singleLineWidth(text, font, metrics);
+    expect(wrapStringIntoLines(text, "X", 10, FontStyle.Normal, w - 0.001, metrics).length).toBe(2);
+  });
+});

--- a/tests/unit/text/single-line-width.test.ts
+++ b/tests/unit/text/single-line-width.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { singleLineWidth, wrapStringIntoLines } from "../../../src/lib/text/line-breaker.ts";
+import {
+  breakSegmentsIntoLines,
+  singleLineWidth,
+  wrapStringIntoLines,
+} from "../../../src/lib/text/line-breaker.ts";
 import { FontStyle } from "../../../src/lib/utils/pdf-object-manager.ts";
 import { testMetrics } from "../support/metrics.ts";
 
@@ -36,5 +40,46 @@ describe("a box sized by singleLineWidth holds its line", () => {
     const text = SAMPLES[0];
     const w = singleLineWidth(text, font, metrics);
     expect(wrapStringIntoLines(text, "X", 10, FontStyle.Normal, w - 0.001, metrics).length).toBe(2);
+  });
+});
+
+describe("styled spans get the same treatment", () => {
+  // The segment breaker had it twice over: its reported line width carried a trailing space that is
+  // never drawn (so a centred or justified span line sat a space off), and it accumulated in a
+  // different order from the natural width the box is sized with.
+  const spans = (parts: string[]) =>
+    parts.map((content) => ({
+      content,
+      fontFamily: "X",
+      fontSize: 10,
+      fontStyle: FontStyle.Normal,
+    }));
+  const defaults = { fontFamily: "X", fontSize: 10, fontStyle: FontStyle.Normal, letterSpacing: 0 };
+
+  it("reports a line's width WITHOUT a trailing space", () => {
+    const [line] = breakSegmentsIntoLines(spans(["aa bb"]), defaults, 1000, metrics);
+    expect(line.width).toBeCloseTo(singleLineWidth("aa bb", font, metrics), 10);
+  });
+
+  it("holds a multi-word span at exactly its own natural width", () => {
+    const text = "ACME Ltd - 1 Example Street";
+    const w = singleLineWidth(text, font, metrics);
+    expect(breakSegmentsIntoLines(spans([text]), defaults, w, metrics)).toHaveLength(1);
+  });
+
+  it("counts the joining space when deciding, so a span line cannot overrun its box", () => {
+    // Half a space narrower than the text needs. Forgetting the joiner in the fit test lets the last
+    // word stay and the line overflows - the same defect the string breaker had.
+    const text = "aa bb cc";
+    const w = singleLineWidth(text, font, metrics) - 1;
+    const lines = breakSegmentsIntoLines(spans([text]), defaults, w, metrics);
+    expect(lines).toHaveLength(2);
+    for (const line of lines) expect(line.width).toBeLessThanOrEqual(w);
+  });
+
+  it("joins two spans with no space between them, as they are drawn", () => {
+    // `span("ab") + span("cd")` draws "abcd" - the breaker must not invent a gap.
+    const [line] = breakSegmentsIntoLines(spans(["ab", "cd"]), defaults, 1000, metrics);
+    expect(line.width).toBeCloseTo(singleLineWidth("abcd", font, metrics), 10);
   });
 });


### PR DESCRIPTION
## Summary

Texts breaks to fast and wrong. This fix lets it break correctly

## Related issue(s)

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [ ] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text width calculations to prevent unintended wrapping caused by floating-point differences.
  * Ensured natural single-line widths match the line-breaker’s fit calculations.
  * Preserved accurate spacing and letter-spacing behavior during wrapping.

* **Tests**
  * Added coverage for width consistency, including precision-sensitive text metrics and near-limit widths.

* **Documentation**
  * Updated test counts and documented the single-line width calculation fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->