### PR TITLE
feat: implement font fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,7 @@ rendering. This is the standing visual check; prefer it over one-off `scripts/ru
 - `pnpm test` — Vitest (watch). `pnpm exec vitest run` for a one-shot CI-style run.
   `pnpm run test:coverage` for coverage. Unit tests live in **`tests/unit/`**, mirroring the `src/lib/`
   structure (`tests/unit/{common,elements,renderer,utils}/…`). `src/` is pure production code — the
-  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **1036 tests, green** —
+  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **1053 tests, green** —
   what the root run covers: core 908, `@jasy/cli` 37, `@jasy/vue` 33, `@jasy/e-invoice` 27. `@jasy/nuxt`
   is excluded from it (`vitest.config.ts`) and runs on its own.
 - `pnpm run build` — `tsc` → `dist/`.
@@ -652,6 +652,22 @@ wordWidth > maxWidth` and forgot the SPACE that would join the word. It went uns
   The breaker's growing tail of positional arguments became one `LineOptions` bag ({ wordSpacing,
   indent, shrink }).
 
+- ✅ **Font fallback stack** (2026-08-02) — `Text({ font: ["Inter", "NotoSansCJK"] })`: each code point
+  is drawn by the first family in the list that has a glyph for it, so mixed-script text works without
+  splitting it by hand. Inheritable like every other text style; a single name behaves exactly as before.
+  The decision that made it small: the fallback resolves the content into **spans**, one per family
+  (`text/font-fallback.ts` → `splitByFont`). That is the shape a styled `span` already has, so breaking,
+  bidi, shaping and drawing all handle it with no new code — instead of a second per-code-point
+  mechanism beside the existing ones.
+  Coverage is `FontMetrics.hasGlyph`: an embedded face answers from its `cmap`, a standard-14 one from
+  what Windows-1252 encodes (`isWindows1252`), which is exactly what its `/Widths` array indexes.
+  Two things that had to be right: the split happens in the LAYOUT pass and is REMEMBERED
+  (`TextElement.resolved`), because the render pass has no metrics and would otherwise draw everything
+  in the first family — measured ≠ drawn again; and it iterates CODE POINTS, or a BMP-only family would
+  keep both halves of an astral character and draw it from a font that does not have it.
+  A code point no family in the stack has stays with the first one and shows its `.notdef`, as a browser
+  does — dropping it would make the text read differently than it was written.
+
 Genuine remaining gaps / deferred:
 
 1. **Absolute positioning — Stages 1+2 built** (2026-06-21). CSS-style: `Box({ relative: true })` is a
@@ -728,7 +744,7 @@ below), `@jasy/cli`@alpha.6, `@jasy/vue`@alpha.7, `@jasy/nuxt`@alpha.6** (the al
 page-break control — the termination guard, `PageBreak`, `breakBefore`/`breakAfter`, `keepTogether` — plus
 kerning turned on by default). Repo public + locked, full CI + changelog +
 bots in place (see Repo facts). The engine is **feature-complete for the alpha** — inheritance, `onOverflow`,
-custom formats, the line-breaker fixes; **1036 tests green** (the root run, i.e. everything but
+custom formats, the line-breaker fixes; **1053 tests green** (the root run, i.e. everything but
 `@jasy/nuxt`). The **landing**
 (`~/projects/jasy-landing` → **jasy.dev**) is built: showroom (12 cards), validator, docs, a home-page
 roadmap section, and a full **SEO + AI-discoverability layer** (OG image, JSON-LD, `robots.txt`,

--- a/src/lib/api/text.ts
+++ b/src/lib/api/text.ts
@@ -17,7 +17,9 @@ export type { TextOverflow };
  *  (locked §7.3) and combine into one engine `FontStyle`. */
 export interface TextStyle {
   size?: number;
-  font?: string;
+  /** Font family, or a STACK: each code point is drawn by the first family in the list that has a
+   *  glyph for it, so `["Inter", "NotoSansCJK"]` sets mixed-script text without splitting it by hand. */
+  font?: string | string[];
   bold?: boolean;
   italic?: boolean;
   color?: ColorInput;
@@ -86,6 +88,14 @@ function toFontStyle(bold?: boolean, italic?: boolean): FontStyle {
   return FontStyle.Normal;
 }
 
+/** The family a run starts in - the first of a stack, or the single name given. */
+const primaryFont = (font?: string | string[]): string | undefined =>
+  Array.isArray(font) ? font[0] : font;
+
+/** The rest of the stack, tried in order for a code point the first family cannot draw. */
+const fallbackFonts = (font?: string | string[]): string[] | undefined =>
+  Array.isArray(font) ? font.slice(1) : undefined;
+
 const ALIGN: Record<NonNullable<TextOptions["align"]>, HorizontalAlignment> = {
   left: HorizontalAlignment.left,
   center: HorizontalAlignment.center,
@@ -122,7 +132,7 @@ export function span(text: string, style: TextStyle = {}): TextSegment {
   return {
     content: text,
     fontSize: toFontSize(style.size),
-    fontFamily: style.font,
+    fontFamily: primaryFont(style.font),
     fontStyle:
       style.bold !== undefined || style.italic !== undefined
         ? toFontStyle(style.bold, style.italic)
@@ -153,7 +163,8 @@ export function Text(content: string | TextSegment[], opts: TextOptions = {}): T
   return new TextElement({
     content: body,
     fontSize: toFontSize(opts.size),
-    fontFamily: opts.font,
+    fontFamily: primaryFont(opts.font),
+    fontFallback: fallbackFonts(opts.font),
     fontStyle:
       opts.bold !== undefined || opts.italic !== undefined
         ? toFontStyle(opts.bold, opts.italic)
@@ -186,7 +197,9 @@ export function Paragraph(content: string | TextSegment[], opts: TextOptions = {
  *  Unset fields stay out so they keep inheriting. */
 export interface TextDefaults {
   size?: number;
-  font?: string;
+  /** Font family, or a STACK: each code point is drawn by the first family in the list that has a
+   *  glyph for it, so `["Inter", "NotoSansCJK"]` sets mixed-script text without splitting it by hand. */
+  font?: string | string[];
   bold?: boolean;
   italic?: boolean;
   color?: ColorInput;
@@ -213,7 +226,10 @@ export interface TextDefaults {
 export function toTextStyleOverride(opts: TextDefaults): Partial<ResolvedTextStyle> {
   const style: Partial<ResolvedTextStyle> = {};
   if (opts.size !== undefined) style.fontSize = toFontSize(opts.size);
-  if (opts.font !== undefined) style.fontFamily = opts.font;
+  if (opts.font !== undefined) {
+    style.fontFamily = primaryFont(opts.font);
+    style.fontFallback = fallbackFonts(opts.font);
+  }
   if (opts.bold !== undefined || opts.italic !== undefined) {
     style.fontStyle = toFontStyle(opts.bold, opts.italic);
   }

--- a/src/lib/api/text.ts
+++ b/src/lib/api/text.ts
@@ -133,6 +133,7 @@ export function span(text: string, style: TextStyle = {}): TextSegment {
     content: text,
     fontSize: toFontSize(style.size),
     fontFamily: primaryFont(style.font),
+    fontFallback: fallbackFonts(style.font),
     fontStyle:
       style.bold !== undefined || style.italic !== undefined
         ? toFontStyle(style.bold, style.italic)

--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -34,7 +34,7 @@ export interface TextSegment {
   fontStyle?: FontStyle;
   fontColor?: Color;
   fontFamily?: string;
-  /** The rest of the family stack, for code points `fontFamily` cannot draw. */
+  /** The rest of the family stack for THIS run; unset inherits the Text's own. */
   fontFallback?: string[];
   fontSize?: number;
   /** External URL: this segment becomes an inline hyperlink (a /Link annotation over its glyphs). */
@@ -231,7 +231,11 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
    */
   private display(metrics?: FontMetrics): string | TextSegment[] {
     const cased = this.recased();
-    if (this.fontFallback.length === 0 || !metrics) return cased;
+    // A SPAN may bring its own stack, so the element's being empty is not enough to skip the pass.
+    const anyStack =
+      this.fontFallback.length > 0 ||
+      (typeof cased !== "string" && cased.some((seg) => (seg.fontFallback?.length ?? 0) > 0));
+    if (!anyStack || !metrics) return cased;
     // Font fallback turns the content into spans - one per family - which every later pass already
     // knows how to handle. Nothing new downstream.
     const pieces = typeof cased === "string" ? [{ content: cased } as TextSegment] : cased;
@@ -240,7 +244,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       const runs = splitByFont(
         seg.content,
         seg.fontFamily ?? this.fontFamily,
-        this.fontFallback,
+        seg.fontFallback ?? this.fontFallback,
         seg.fontStyle ?? this.fontStyle,
         metrics,
       );

--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -10,6 +10,7 @@ import type { FontMetrics } from "../utils/font-metrics.ts";
 import { BoxConstraints, Offset, Size } from "../layout/box-constraints.ts";
 import type { Direction } from "../text/bidi.ts";
 import { applyTextTransform, type TextTransform } from "../text/text-style.ts";
+import { splitByFont } from "../text/font-fallback.ts";
 import { Fragmentable, FragmentResult } from "../layout/fragmentation.ts";
 import {
   type LineOptions,
@@ -33,6 +34,8 @@ export interface TextSegment {
   fontStyle?: FontStyle;
   fontColor?: Color;
   fontFamily?: string;
+  /** The rest of the family stack, for code points `fontFamily` cannot draw. */
+  fontFallback?: string[];
   fontSize?: number;
   /** External URL: this segment becomes an inline hyperlink (a /Link annotation over its glyphs). */
   href?: string;
@@ -69,6 +72,8 @@ interface TextElementParams {
   /** Unset (undefined) inherits the cascaded size; see ResolvedTextStyle. */
   fontSize?: number;
   fontFamily?: string;
+  /** The rest of the family stack, for code points `fontFamily` cannot draw. */
+  fontFallback?: string[];
   fontStyle?: FontStyle;
   content: string | TextSegment[];
   color?: Color; // optional param
@@ -130,6 +135,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
   private readonly rawSkipInk?: boolean;
   private readonly rawLetterSpacing?: number;
   private readonly rawDirection?: Direction;
+  private readonly rawFontFallback?: string[];
   private readonly rawTextTransform?: TextTransform;
   private readonly rawWordSpacing?: number;
   private readonly rawTextIndent?: number;
@@ -147,6 +153,10 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
   private skipInk!: boolean;
   private letterSpacing!: number;
   private direction!: Direction;
+  private fontFallback!: string[];
+  // What the layout pass resolved the content to (transform applied, split by font). The render pass
+  // has no metrics of its own, so it MUST read the same thing layout measured, not recompute it.
+  private resolved?: string | TextSegment[];
   private textTransform!: TextTransform;
   private wordSpacing!: number;
   private textIndent!: number;
@@ -175,6 +185,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     skipInk,
     letterSpacing,
     direction,
+    fontFallback,
     textTransform,
     wordSpacing,
     textIndent,
@@ -194,6 +205,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     this.rawSkipInk = skipInk;
     this.rawLetterSpacing = letterSpacing;
     this.rawDirection = direction;
+    this.rawFontFallback = fontFallback;
     this.rawTextTransform = textTransform;
     this.rawWordSpacing = finitePoints(wordSpacing, "wordSpacing");
     this.rawTextIndent = finitePoints(textIndent, "textIndent");
@@ -217,7 +229,30 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
    * paragraph can never be measured in one casing and drawn in another (`ABC` and `abc` are not the
    * same width in most fonts).
    */
-  private display(): string | TextSegment[] {
+  private display(metrics?: FontMetrics): string | TextSegment[] {
+    const cased = this.recased();
+    if (this.fontFallback.length === 0 || !metrics) return cased;
+    // Font fallback turns the content into spans - one per family - which every later pass already
+    // knows how to handle. Nothing new downstream.
+    const pieces = typeof cased === "string" ? [{ content: cased } as TextSegment] : cased;
+    const out: TextSegment[] = [];
+    for (const seg of pieces) {
+      const runs = splitByFont(
+        seg.content,
+        seg.fontFamily ?? this.fontFamily,
+        this.fontFallback,
+        seg.fontStyle ?? this.fontStyle,
+        metrics,
+      );
+      if (!runs) out.push(seg);
+      else
+        for (const run of runs) out.push({ ...seg, content: run.text, fontFamily: run.fontFamily });
+    }
+    return out;
+  }
+
+  /** The content with `text-transform` applied, and nothing else. */
+  private recased(): string | TextSegment[] {
     if (this.textTransform === "none") return this.content;
     if (typeof this.content === "string") {
       return applyTextTransform(this.content, this.textTransform).text;
@@ -252,6 +287,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     this.skipInk = this.rawSkipInk ?? ts.skipInk;
     this.letterSpacing = this.rawLetterSpacing ?? ts.letterSpacing;
     this.direction = this.rawDirection ?? ts.direction;
+    this.fontFallback = this.rawFontFallback ?? ts.fontFallback;
     this.textTransform = this.rawTextTransform ?? ts.textTransform;
     this.wordSpacing = this.rawWordSpacing ?? ts.wordSpacing;
     this.textIndent = this.rawTextIndent ?? ts.textIndent;
@@ -265,7 +301,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
    */
   fragment(maxHeight: number, width: number, ctx: LayoutContext): FragmentResult {
     this.resolveStyle(ctx);
-    const content = this.display();
+    const content = this.display(ctx.metrics);
     return typeof content === "string"
       ? this.fragmentString(content, maxHeight, width, ctx)
       : this.fragmentSegments(content, maxHeight, width, ctx);
@@ -400,13 +436,14 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     // Bounded width (e.g. inside a Column) wraps to that width; an unbounded width
     // (e.g. inside a Row) means the text takes its natural single-line width and does
     // not wrap. Columns always bound the width, so this leaves their layout untouched.
+    this.resolved = this.display(ctx.metrics);
     this.width = constraints.hasBoundedWidth
       ? constraints.maxWidth
       : this.naturalWidth(ctx.metrics);
 
     const wrapWidth = this.width ?? 0;
     this.height = TextRenderer.calculateTextHeight(
-      this.display(),
+      this.resolved,
       this.fontSize,
       this.fontFamily,
       this.fontStyle,
@@ -451,7 +488,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       );
     // The FIRST line starts `textIndent` in, so an unbounded box has to be that much wider.
     const indent = Math.max(0, this.textIndent);
-    const content = this.display();
+    const content = this.display(metrics);
     if (typeof content === "string") {
       return (
         indent +
@@ -482,7 +519,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       fontFamily: this.fontFamily,
       fontStyle: this.fontStyle,
       color: this.color,
-      content: this.display(),
+      content: this.resolved ?? this.content,
       textAlignment: this.textAlignment,
       maxLines: this.maxLines,
       orphans: this.orphans,

--- a/src/lib/text/font-fallback.ts
+++ b/src/lib/text/font-fallback.ts
@@ -1,0 +1,63 @@
+import type { FontStyle } from "../utils/pdf-object-manager.ts";
+import type { FontMetrics } from "../utils/font-metrics.ts";
+
+/**
+ * Font FALLBACK: picking, per code point, the first family in a stack that can draw it.
+ *
+ * `Text({ font: ["Inter", "NotoSansCJK"] })` should just work for mixed-script text. Without this a
+ * code point the first family lacks comes out as `.notdef` - the empty box.
+ *
+ * The output is a list of pieces, each in ONE family, which is exactly the shape a styled `span`
+ * already has. So the fallback reuses the whole segment machinery - breaking, bidi, shaping and
+ * drawing all handle per-piece fonts already - instead of adding a second one beside it.
+ */
+
+/** A stretch of text that one family can draw. */
+export interface FontRun {
+  text: string;
+  fontFamily: string;
+}
+
+/**
+ * Split `text` into runs by family. Returns `undefined` when there is nothing to split - no stack, or
+ * the first family draws everything - so a document that never asks for a fallback keeps its old path.
+ *
+ * A code point that NO family in the stack can draw stays with the first one, which then draws its
+ * `.notdef`. That is what a browser does too: the fallback chain ends, and the missing glyph shows.
+ */
+export function splitByFont(
+  text: string,
+  fontFamily: string,
+  fallback: readonly string[],
+  fontStyle: FontStyle,
+  metrics: FontMetrics,
+): FontRun[] | undefined {
+  if (fallback.length === 0) return undefined;
+
+  const familyFor = (codePoint: number): string => {
+    if (metrics.hasGlyph(codePoint, fontFamily, fontStyle)) return fontFamily;
+    for (const family of fallback) {
+      if (metrics.hasGlyph(codePoint, family, fontStyle)) return family;
+    }
+    return fontFamily; // nobody has it - the first family shows the missing glyph
+  };
+
+  const runs: FontRun[] = [];
+  let current = "";
+  let currentFamily = fontFamily;
+
+  for (const ch of text) {
+    const family = familyFor(ch.codePointAt(0)!);
+    if (current !== "" && family !== currentFamily) {
+      runs.push({ text: current, fontFamily: currentFamily });
+      current = "";
+    }
+    currentFamily = family;
+    current += ch;
+  }
+  if (current !== "") runs.push({ text: current, fontFamily: currentFamily });
+
+  // One run in the original family means nothing was substituted; say so, and the caller keeps its
+  // cheaper path.
+  return runs.length === 1 && runs[0].fontFamily === fontFamily ? undefined : runs;
+}

--- a/src/lib/text/font-fallback.ts
+++ b/src/lib/text/font-fallback.ts
@@ -57,7 +57,8 @@ export function splitByFont(
   }
   if (current !== "") runs.push({ text: current, fontFamily: currentFamily });
 
-  // One run in the original family means nothing was substituted; say so, and the caller keeps its
-  // cheaper path.
-  return runs.length === 1 && runs[0].fontFamily === fontFamily ? undefined : runs;
+  // Nothing substituted - no runs at all (empty text), or one in the family we started with. Say so,
+  // and the caller keeps its cheaper path instead of being handed an empty list to draw.
+  const unchanged = runs.length === 0 || (runs.length === 1 && runs[0].fontFamily === fontFamily);
+  return unchanged ? undefined : runs;
 }

--- a/src/lib/text/text-style.ts
+++ b/src/lib/text/text-style.ts
@@ -48,6 +48,8 @@ export function applyTextTransform(
 export interface ResolvedTextStyle {
   fontSize: number;
   fontFamily: string;
+  /** The rest of the family stack: tried, in order, for a code point `fontFamily` cannot draw. */
+  fontFallback: string[];
   fontStyle: FontStyle;
   color: Color;
   textAlignment: HorizontalAlignment;
@@ -82,6 +84,7 @@ export interface ResolvedTextStyle {
 export const DEFAULT_TEXT_STYLE: ResolvedTextStyle = {
   fontSize: 12,
   fontFamily: "Helvetica",
+  fontFallback: [],
   fontStyle: FontStyle.Normal,
   color: new Color(0, 0, 0),
   textAlignment: HorizontalAlignment.start,
@@ -105,6 +108,7 @@ export function mergeTextStyle(
   return {
     fontSize: override.fontSize ?? base.fontSize,
     fontFamily: override.fontFamily ?? base.fontFamily,
+    fontFallback: override.fontFallback ?? base.fontFallback,
     fontStyle: override.fontStyle ?? base.fontStyle,
     color: override.color ?? base.color,
     textAlignment: override.textAlignment ?? base.textAlignment,

--- a/src/lib/utils/font-metrics.ts
+++ b/src/lib/utils/font-metrics.ts
@@ -36,6 +36,9 @@ export interface FontMetrics {
    *  zero next to a space. Only meaningful when `kerningEnabled`. */
   getKernPairs(text: string, fontFamily: string, fontStyle: FontStyle): number[];
 
+  /** Whether this family can draw the code point at all - what picks a face out of a fallback stack. */
+  hasGlyph(codePoint: number, fontFamily: string, fontStyle: FontStyle): boolean;
+
   /** How many glyphs the run will DRAW, when a ligature made that differ from its code-point count.
    *  Absent or `undefined` means "the same", which is every Latin run. */
   shapedGlyphCount?(text: string, fontFamily?: string, fontStyle?: FontStyle): number | undefined;

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -9,7 +9,7 @@ import { mergeSpans, TTFParser } from "./ttf-parser.ts";
 import { isWoff, woffToSfnt } from "./woff.ts";
 import { subsetTTF } from "./ttf-subsetter.ts";
 import { shapeRun, type ShapedGlyph } from "../text/shape.ts";
-import { getArrayBuffer } from "./utf8-to-windows1252-encoder.ts";
+import { getArrayBuffer, isWindows1252 } from "./utf8-to-windows1252-encoder.ts";
 import type { SecurityHandler } from "../crypto/security-handler.ts";
 import type { Gradient, GradientStop } from "../ir/display-list.ts";
 import { isEmojiCodePoint } from "../text/emoji-codepoints.ts";
@@ -850,6 +850,21 @@ endstream`;
   }
 
   // Whether `ttf` has a COLOR glyph for a code point (i.e. it would render it as color emoji).
+  /**
+   * Whether a family can draw this code point at all. An embedded face answers from its `cmap`; a
+   * standard-14 one can only draw what Windows-1252 encodes, which is what its `/Widths` array covers.
+   * Used to pick a family out of a fallback stack, per code point.
+   */
+  hasGlyph(
+    codePoint: number,
+    fontFamily: string,
+    fontStyle: FontStyle = FontStyle.Normal,
+  ): boolean {
+    const ttf = this.getCustomFont(fontFamily, fontStyle);
+    if (ttf) return ttf.getGlyphIndex(codePoint) !== 0;
+    return isWindows1252(codePoint);
+  }
+
   private colorRenders(ttf: TTFParser, codePoint: number): boolean {
     return ttf.getColorGlyph(ttf.getGlyphIndex(codePoint)) !== null;
   }

--- a/src/lib/utils/utf8-to-windows1252-encoder.ts
+++ b/src/lib/utils/utf8-to-windows1252-encoder.ts
@@ -34,6 +34,16 @@ const CP1252_FROM_UNICODE: Record<number, number> = {
   0x0178: 0x9f, // Ÿ Y diaeresis
 };
 
+/**
+ * Whether Windows-1252 can carry this code point - which is exactly what a standard-14 font can draw,
+ * since that is the encoding its `/Widths` array is indexed by. Latin-1 passes straight through,
+ * except the C1 range, which the table above fills with printable punctuation instead.
+ */
+export function isWindows1252(codePoint: number): boolean {
+  if (codePoint in CP1252_FROM_UNICODE) return true;
+  return codePoint <= 0xff && !(codePoint >= 0x80 && codePoint <= 0x9f);
+}
+
 /** Encodes a JavaScript string to a Windows-1252 byte buffer (the PDF text encoding). */
 export function getArrayBuffer(data: string): ArrayBuffer {
   const u8 = new Uint8Array(data.length);

--- a/tests/unit/elements/positioned-element.test.ts
+++ b/tests/unit/elements/positioned-element.test.ts
@@ -16,6 +16,7 @@ const metrics: FontMetrics = {
   getStringWidth: (text) => text.length * 10,
   getCharWidth: () => 0,
   getFontVerticals: unitVerticals,
+  hasGlyph: () => true,
 };
 const ctx = { metrics } as LayoutContext;
 // A `Positioned` refuses to lay out without a frame, so the out-of-flow tests below need one. It is

--- a/tests/unit/elements/positioned-element.test.ts
+++ b/tests/unit/elements/positioned-element.test.ts
@@ -8,16 +8,13 @@ import { LayoutContext } from "../../../src/lib/elements/pdf-element";
 import { BoxConstraints } from "../../../src/lib/layout/box-constraints";
 import { Orientation } from "../../../src/lib/renderer/pdf-config";
 import { PageSize } from "../../../src/lib/constants/page-sizes";
-import type { FontMetrics } from "../../../src/lib/utils/font-metrics";
 import type { PDFObjectManager } from "../../../src/lib/utils/pdf-object-manager";
-import { unitVerticals } from "../support/metrics.ts";
+import { testMetrics } from "../support/metrics.ts";
 
-const metrics: FontMetrics = {
+const metrics = testMetrics({
   getStringWidth: (text) => text.length * 10,
   getCharWidth: () => 0,
-  getFontVerticals: unitVerticals,
-  hasGlyph: () => true,
-};
+});
 const ctx = { metrics } as LayoutContext;
 // A `Positioned` refuses to lay out without a frame, so the out-of-flow tests below need one. It is
 // never drained: they assert what the element does NOT do to the flow, not where the child lands.

--- a/tests/unit/elements/row-element.test.ts
+++ b/tests/unit/elements/row-element.test.ts
@@ -35,6 +35,7 @@ describe("RowElement", () => {
       getStringWidth: (t: string) => t.length * 6,
       getCharWidth: () => 6,
       getFontVerticals: unitVerticals,
+      hasGlyph: () => true,
     } as unknown as FontMetrics;
     const ctx = { metrics, pageConfig: {} } as LayoutContext;
 
@@ -59,6 +60,7 @@ describe("RowElement", () => {
       getStringWidth: (t: string) => t.length * 6,
       getCharWidth: () => 6,
       getFontVerticals: unitVerticals,
+      hasGlyph: () => true,
     } as unknown as FontMetrics;
     const ctx = { metrics, pageConfig: {} } as LayoutContext;
 
@@ -82,6 +84,7 @@ describe("RowElement", () => {
       getStringWidth: (t: string) => t.length * 6,
       getCharWidth: () => 6,
       getFontVerticals: unitVerticals,
+      hasGlyph: () => true,
     } as unknown as FontMetrics;
     const ctx = { metrics, pageConfig: {} } as LayoutContext;
 

--- a/tests/unit/elements/row-element.test.ts
+++ b/tests/unit/elements/row-element.test.ts
@@ -6,7 +6,7 @@ import { TextElement } from "../../../src/lib/elements/text-element";
 import { BoxConstraints } from "../../../src/lib/layout/box-constraints";
 import { LayoutContext } from "../../../src/lib/elements/pdf-element";
 import { FontMetrics } from "../../../src/lib/utils/font-metrics";
-import { unitVerticals } from "../support/metrics.ts";
+import { testMetrics } from "../support/metrics.ts";
 
 const box = (width: number, height: number) =>
   new RectangleElement({ x: 0, y: 0, children: [], width, height, borderWidth: 0 });
@@ -31,12 +31,10 @@ describe("RowElement", () => {
 
   it("a Spacer pushes the last child to the right edge (title … page number)", () => {
     // deterministic metrics: 6 pt per char (string == sum of chars, i.e. no kerning here)
-    const metrics = {
+    const metrics = testMetrics({
       getStringWidth: (t: string) => t.length * 6,
       getCharWidth: () => 6,
-      getFontVerticals: unitVerticals,
-      hasGlyph: () => true,
-    } as unknown as FontMetrics;
+    }) as unknown as FontMetrics;
     const ctx = { metrics, pageConfig: {} } as LayoutContext;
 
     const left = new TextElement({ fontSize: 10, content: "Left" }); // width 24
@@ -56,12 +54,10 @@ describe("RowElement", () => {
   // go through the same `runAdvance`, so they agree by construction. (CSS: a space → never wraps.)
   it("a fixed Text in a Row takes its one-line width, so it never wraps inside its own box", () => {
     // Consistent font: getStringWidth is the sum of getCharWidth. Every glyph, space included, 6 wide.
-    const metrics = {
+    const metrics = testMetrics({
       getStringWidth: (t: string) => t.length * 6,
       getCharWidth: () => 6,
-      getFontVerticals: unitVerticals,
-      hasGlyph: () => true,
-    } as unknown as FontMetrics;
+    }) as unknown as FontMetrics;
     const ctx = { metrics, pageConfig: {} } as LayoutContext;
 
     const text = new TextElement({ fontSize: 10, content: "Total due" });
@@ -80,12 +76,10 @@ describe("RowElement", () => {
   // letterSpacing widens the reserved width by one spacing per glyph, and the breaker agrees, so the
   // text still does not re-wrap in its own box.
   it("reserves the letter-spaced width, so a spaced fixed Text still does not wrap", () => {
-    const metrics = {
+    const metrics = testMetrics({
       getStringWidth: (t: string) => t.length * 6,
       getCharWidth: () => 6,
-      getFontVerticals: unitVerticals,
-      hasGlyph: () => true,
-    } as unknown as FontMetrics;
+    }) as unknown as FontMetrics;
     const ctx = { metrics, pageConfig: {} } as LayoutContext;
 
     const text = new TextElement({ fontSize: 10, content: "Total due", letterSpacing: 2 });

--- a/tests/unit/layout/box-fragment.test.ts
+++ b/tests/unit/layout/box-fragment.test.ts
@@ -16,6 +16,7 @@ const metrics: FontMetrics = {
   getStringWidth: (text: string) => [...text].reduce((w, c) => w + (c === " " ? 0 : 10), 0),
   getCharWidth: (c: string) => (c === " " ? 0 : 10),
   getFontVerticals: unitVerticals,
+  hasGlyph: () => true,
 };
 const ctx = { metrics } as LayoutContext;
 

--- a/tests/unit/layout/box-fragment.test.ts
+++ b/tests/unit/layout/box-fragment.test.ts
@@ -6,18 +6,15 @@ import { LineElement } from "../../../src/lib/elements/line-element";
 import { LayoutContext, PDFElement } from "../../../src/lib/elements/pdf-element";
 import { BoxConstraints, Offset, Size } from "../../../src/lib/layout/box-constraints";
 import { packChildren } from "../../../src/lib/layout/fragmentation";
-import type { FontMetrics } from "../../../src/lib/utils/font-metrics";
-import { unitVerticals } from "../support/metrics.ts";
+import { testMetrics } from "../support/metrics.ts";
 
 // Each glyph 10 wide, spaces 0: "aa bb cc dd ee ff" wraps to 3 lines of 10pt at width 50.
-const metrics: FontMetrics = {
+const metrics = testMetrics({
   // Consistent font: getStringWidth is the sum of getCharWidth (as it is in reality). Each glyph is
   // 10 wide, a space is 0, so word widths are len*10 and spaces cost nothing - the arithmetic below.
   getStringWidth: (text: string) => [...text].reduce((w, c) => w + (c === " " ? 0 : 10), 0),
   getCharWidth: (c: string) => (c === " " ? 0 : 10),
-  getFontVerticals: unitVerticals,
-  hasGlyph: () => true,
-};
+});
 const ctx = { metrics } as LayoutContext;
 
 // orphans/widows are switched OFF here on purpose: these suites are about WHERE the fragmenter cuts,

--- a/tests/unit/renderer/text-renderer.test.ts
+++ b/tests/unit/renderer/text-renderer.test.ts
@@ -334,7 +334,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getEmojiImageSource: vi.fn().mockReturnValue(undefined),
       ...testMetrics({
         getStringWidth: vi.fn((content, fontFamily, fontSize) => {
-          return content.length * fontSize; // Einfacher Algorithmus zur Rückgabe der Breite
+          return content.length * fontSize; // one glyph per character, at the font size
         }),
 
         getCharWidth: vi.fn().mockReturnValue(10),
@@ -348,8 +348,8 @@ describe("TextRenderer - calculateTextHeight", () => {
       mockObjectManager,
     );
 
-    expect(result).toContain("/F1 12 Tf"); // Normal font für "Hello"
-    expect(result).toContain("/F2 14 Tf"); // Bold font für "World"
+    expect(result).toContain("/F1 12 Tf"); // the normal font, for "Hello"
+    expect(result).toContain("/F2 14 Tf"); // the bold one, for "World"
     expect(result).toContain("(Hello) Tj");
     expect(result).toContain("(World) Tj");
   });

--- a/tests/unit/renderer/text-renderer.test.ts
+++ b/tests/unit/renderer/text-renderer.test.ts
@@ -14,6 +14,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getStringWidth: vi.fn((t: string) => t.length * 5),
       getCharWidth: vi.fn().mockReturnValue(5),
       getFontVerticals: unitVerticals,
+      hasGlyph: () => true,
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -36,6 +37,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getStringWidth: vi.fn().mockReturnValue(10), // String width is used for each word = 60
       getCharWidth: vi.fn().mockReturnValue(5), // Used for empty spaces = 25
       getFontVerticals: unitVerticals,
+      hasGlyph: () => true,
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -57,6 +59,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getStringWidth: vi.fn().mockReturnValue(10),
       getCharWidth: vi.fn().mockReturnValue(5),
       getFontVerticals: unitVerticals,
+      hasGlyph: () => true,
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -102,6 +105,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getStringWidth: vi.fn().mockReturnValue(10),
       getCharWidth: vi.fn().mockReturnValue(5),
       getFontVerticals: unitVerticals,
+      hasGlyph: () => true,
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -144,6 +148,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getStringWidth: vi.fn().mockReturnValue(10),
       getCharWidth: vi.fn().mockReturnValue(5),
       getFontVerticals: unitVerticals,
+      hasGlyph: () => true,
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -183,6 +188,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getStringWidth: vi.fn((t: string) => t.length * 5),
       getCharWidth: vi.fn(() => 5),
       getFontVerticals: unitVerticals,
+      hasGlyph: () => true,
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -225,6 +231,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getStringWidth: vi.fn((t: string) => t.length * 5),
       getCharWidth: vi.fn(() => 5),
       getFontVerticals: unitVerticals,
+      hasGlyph: () => true,
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -264,6 +271,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getStringWidth: vi.fn().mockReturnValue(0),
       getCharWidth: vi.fn().mockReturnValue(0),
       getFontVerticals: unitVerticals,
+      hasGlyph: () => true,
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -322,6 +330,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       }),
       getCharWidth: vi.fn().mockReturnValue(10),
       getFontVerticals: unitVerticals,
+      hasGlyph: () => true,
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -379,6 +388,7 @@ describe("TextRenderer - calculateTextHeight", () => {
       getStringWidth: vi.fn().mockReturnValue(25), // Here we get the widht of each segment: 50
       getCharWidth: vi.fn().mockReturnValue(0), // For empty spaces: 0
       getFontVerticals: unitVerticals,
+      hasGlyph: () => true,
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;

--- a/tests/unit/renderer/text-renderer.test.ts
+++ b/tests/unit/renderer/text-renderer.test.ts
@@ -5,16 +5,17 @@ import { describe, it, vi, expect } from "vitest";
 import { TextElement } from "../../../src/lib/elements";
 import { HorizontalAlignment } from "../../../src/lib/elements/pdf-element";
 import { Color } from "../../../src/lib/common/color";
-import { unitVerticals } from "../support/metrics.ts";
+import { testMetrics } from "../support/metrics.ts";
 
 describe("TextRenderer - calculateTextHeight", () => {
   it("should calculate the correct text height for a simple string", () => {
     const mockObjectManager = {
       // Consistent font (getStringWidth is the sum of getCharWidth): every glyph, space included, 5 wide.
-      getStringWidth: vi.fn((t: string) => t.length * 5),
-      getCharWidth: vi.fn().mockReturnValue(5),
-      getFontVerticals: unitVerticals,
-      hasGlyph: () => true,
+      ...testMetrics({
+        getStringWidth: vi.fn((t: string) => t.length * 5),
+
+        getCharWidth: vi.fn().mockReturnValue(5),
+      }),
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -34,10 +35,10 @@ describe("TextRenderer - calculateTextHeight", () => {
 
   it("should calculate the correct text height with wrapping", () => {
     const mockObjectManager = {
-      getStringWidth: vi.fn().mockReturnValue(10), // String width is used for each word = 60
-      getCharWidth: vi.fn().mockReturnValue(5), // Used for empty spaces = 25
-      getFontVerticals: unitVerticals,
-      hasGlyph: () => true,
+      ...testMetrics({
+        getStringWidth: vi.fn().mockReturnValue(10), // String width is used for each word = 60
+        getCharWidth: vi.fn().mockReturnValue(5), // Used for empty spaces = 25
+      }),
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -56,10 +57,11 @@ describe("TextRenderer - calculateTextHeight", () => {
 
   it("should calculate the correct text height for TextSegments", () => {
     const mockObjectManager = {
-      getStringWidth: vi.fn().mockReturnValue(10),
-      getCharWidth: vi.fn().mockReturnValue(5),
-      getFontVerticals: unitVerticals,
-      hasGlyph: () => true,
+      ...testMetrics({
+        getStringWidth: vi.fn().mockReturnValue(10),
+
+        getCharWidth: vi.fn().mockReturnValue(5),
+      }),
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -102,10 +104,11 @@ describe("TextRenderer - calculateTextHeight", () => {
       getColorFont: vi.fn().mockReturnValue(undefined),
       getEmojiFont: vi.fn().mockReturnValue(undefined),
       getEmojiImageSource: vi.fn().mockReturnValue(undefined),
-      getStringWidth: vi.fn().mockReturnValue(10),
-      getCharWidth: vi.fn().mockReturnValue(5),
-      getFontVerticals: unitVerticals,
-      hasGlyph: () => true,
+      ...testMetrics({
+        getStringWidth: vi.fn().mockReturnValue(10),
+
+        getCharWidth: vi.fn().mockReturnValue(5),
+      }),
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -145,10 +148,11 @@ describe("TextRenderer - calculateTextHeight", () => {
       getColorFont: vi.fn().mockReturnValue(undefined),
       getEmojiFont: vi.fn().mockReturnValue(undefined),
       getEmojiImageSource: vi.fn().mockReturnValue(undefined),
-      getStringWidth: vi.fn().mockReturnValue(10),
-      getCharWidth: vi.fn().mockReturnValue(5),
-      getFontVerticals: unitVerticals,
-      hasGlyph: () => true,
+      ...testMetrics({
+        getStringWidth: vi.fn().mockReturnValue(10),
+
+        getCharWidth: vi.fn().mockReturnValue(5),
+      }),
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -185,10 +189,11 @@ describe("TextRenderer - calculateTextHeight", () => {
       getColorFont: vi.fn().mockReturnValue(undefined),
       getEmojiFont: vi.fn().mockReturnValue(undefined),
       getEmojiImageSource: vi.fn().mockReturnValue(undefined),
-      getStringWidth: vi.fn((t: string) => t.length * 5),
-      getCharWidth: vi.fn(() => 5),
-      getFontVerticals: unitVerticals,
-      hasGlyph: () => true,
+      ...testMetrics({
+        getStringWidth: vi.fn((t: string) => t.length * 5),
+
+        getCharWidth: vi.fn(() => 5),
+      }),
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -228,10 +233,11 @@ describe("TextRenderer - calculateTextHeight", () => {
       getColorFont: vi.fn().mockReturnValue(undefined),
       getEmojiFont: vi.fn().mockReturnValue(undefined),
       getEmojiImageSource: vi.fn().mockReturnValue(undefined),
-      getStringWidth: vi.fn((t: string) => t.length * 5),
-      getCharWidth: vi.fn(() => 5),
-      getFontVerticals: unitVerticals,
-      hasGlyph: () => true,
+      ...testMetrics({
+        getStringWidth: vi.fn((t: string) => t.length * 5),
+
+        getCharWidth: vi.fn(() => 5),
+      }),
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -268,10 +274,11 @@ describe("TextRenderer - calculateTextHeight", () => {
       getColorFont: vi.fn().mockReturnValue(undefined),
       getEmojiFont: vi.fn().mockReturnValue(undefined),
       getEmojiImageSource: vi.fn().mockReturnValue(undefined),
-      getStringWidth: vi.fn().mockReturnValue(0),
-      getCharWidth: vi.fn().mockReturnValue(0),
-      getFontVerticals: unitVerticals,
-      hasGlyph: () => true,
+      ...testMetrics({
+        getStringWidth: vi.fn().mockReturnValue(0),
+
+        getCharWidth: vi.fn().mockReturnValue(0),
+      }),
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -325,12 +332,13 @@ describe("TextRenderer - calculateTextHeight", () => {
       getColorFont: vi.fn().mockReturnValue(undefined),
       getEmojiFont: vi.fn().mockReturnValue(undefined),
       getEmojiImageSource: vi.fn().mockReturnValue(undefined),
-      getStringWidth: vi.fn((content, fontFamily, fontSize) => {
-        return content.length * fontSize; // Einfacher Algorithmus zur Rückgabe der Breite
+      ...testMetrics({
+        getStringWidth: vi.fn((content, fontFamily, fontSize) => {
+          return content.length * fontSize; // Einfacher Algorithmus zur Rückgabe der Breite
+        }),
+
+        getCharWidth: vi.fn().mockReturnValue(10),
       }),
-      getCharWidth: vi.fn().mockReturnValue(10),
-      getFontVerticals: unitVerticals,
-      hasGlyph: () => true,
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;
@@ -385,10 +393,10 @@ describe("TextRenderer - calculateTextHeight", () => {
       getColorFont: vi.fn().mockReturnValue(undefined),
       getEmojiFont: vi.fn().mockReturnValue(undefined),
       getEmojiImageSource: vi.fn().mockReturnValue(undefined),
-      getStringWidth: vi.fn().mockReturnValue(25), // Here we get the widht of each segment: 50
-      getCharWidth: vi.fn().mockReturnValue(0), // For empty spaces: 0
-      getFontVerticals: unitVerticals,
-      hasGlyph: () => true,
+      ...testMetrics({
+        getStringWidth: vi.fn().mockReturnValue(25), // the width of each segment: 50
+        getCharWidth: vi.fn().mockReturnValue(0), // for empty spaces: 0
+      }),
       struct: { enabled: false },
       shapeText: () => undefined,
     } as unknown as PDFObjectManager;

--- a/tests/unit/renderer/text-style-props.test.ts
+++ b/tests/unit/renderer/text-style-props.test.ts
@@ -179,6 +179,9 @@ describe("the three findings a review caught", () => {
     const el = text([{ content: "hel" }, { content: "lo world" }], {
       textTransform: "capitalize",
     });
+    // The content is resolved by the LAYOUT pass, which is what the renderer then reads.
+    const manager = om();
+    el.calculateLayout(BoxConstraints.tight(400, 400), { x: 0, y: 0 }, context(manager));
     const props = el.getProps() as { content: { content: string }[] };
     expect(props.content.map((c) => c.content).join("")).toBe("Hello World");
   });
@@ -218,9 +221,61 @@ describe("capitalize and punctuation", () => {
     expect(runs.map((r) => r.text).join("")).toBe('(Hello) "World"');
   });
 
-  it("carries that through a span boundary as well", async () => {
+  it("carries that through a span boundary as well", () => {
     const el = text([{ content: "(hel" }, { content: "lo)" }], { textTransform: "capitalize" });
+    const manager = om();
+    el.calculateLayout(BoxConstraints.tight(400, 400), { x: 0, y: 0 }, context(manager));
     const props = el.getProps() as { content: { content: string }[] };
     expect(props.content.map((c) => c.content).join("")).toBe("(Hello)");
+  });
+});
+
+describe("font fallback", () => {
+  // "Latin" holds ASCII only; "CJK" holds the rest. The element must SPLIT the text into spans, one
+  // per family - and it has to do so in the LAYOUT pass, because the renderer has no metrics to
+  // redo it with and would otherwise draw everything in the first family.
+  const stackMetrics = () =>
+    ({
+      ...testMetrics({
+        getStringWidth: (t) => [...t].length * 10,
+        getCharWidth: () => 10,
+        hasGlyph: (cp, family) => (family === "Latin" ? cp < 0x80 : true),
+      }),
+      struct: { enabled: false },
+      shapeText: () => undefined,
+      isCustomFont: () => false,
+      getColorFont: () => undefined,
+      getEmojiSource: () => undefined,
+      getEmojiFont: () => undefined,
+      getEmojiImageSource: () => undefined,
+    }) as unknown as PDFObjectManager;
+
+  it("draws each stretch in the family that has its glyphs", async () => {
+    const el = new TextElement({
+      content: "ab漢字cd",
+      fontSize: 10,
+      fontFamily: "Latin",
+      fontFallback: ["CJK"],
+    });
+    const manager = stackMetrics();
+    el.calculateLayout(BoxConstraints.tight(400, 400), { x: 0, y: 0 }, context(manager));
+    const runs = (await TextRenderer.render(el, manager)).filter(
+      (n): n is TextRun => n.type === "text",
+    );
+    expect(runs.map((r) => [r.text, r.fontFamily])).toEqual([
+      ["ab", "Latin"],
+      ["漢字", "CJK"],
+      ["cd", "Latin"],
+    ]);
+  });
+
+  it("leaves a document without a stack exactly as it was", async () => {
+    const el = new TextElement({ content: "ab漢字", fontSize: 10, fontFamily: "Latin" });
+    const manager = stackMetrics();
+    el.calculateLayout(BoxConstraints.tight(400, 400), { x: 0, y: 0 }, context(manager));
+    const runs = (await TextRenderer.render(el, manager)).filter(
+      (n): n is TextRun => n.type === "text",
+    );
+    expect(runs.map((r) => r.text)).toEqual(["ab漢字"]);
   });
 });

--- a/tests/unit/renderer/text-style-props.test.ts
+++ b/tests/unit/renderer/text-style-props.test.ts
@@ -279,3 +279,37 @@ describe("font fallback", () => {
     expect(runs.map((r) => r.text)).toEqual(["ab漢字"]);
   });
 });
+
+describe("a span brings its own font stack", () => {
+  it("falls back inside that span alone", async () => {
+    // `span(text, { font: ["A", "B"] })` was accepted by the type and silently ignored: the element's
+    // own stack was empty, so the whole pass was skipped.
+    const el = new TextElement({
+      content: [{ content: "ab" }, { content: "漢字", fontFamily: "Latin", fontFallback: ["CJK"] }],
+      fontSize: 10,
+      fontFamily: "Latin",
+    });
+    const manager = {
+      ...testMetrics({
+        getStringWidth: (t) => [...t].length * 10,
+        getCharWidth: () => 10,
+        hasGlyph: (cp, family) => (family === "Latin" ? cp < 0x80 : true),
+      }),
+      struct: { enabled: false },
+      shapeText: () => undefined,
+      isCustomFont: () => false,
+      getColorFont: () => undefined,
+      getEmojiSource: () => undefined,
+      getEmojiFont: () => undefined,
+      getEmojiImageSource: () => undefined,
+    } as unknown as PDFObjectManager;
+    el.calculateLayout(BoxConstraints.tight(400, 400), { x: 0, y: 0 }, context(manager));
+    const runs = (await TextRenderer.render(el, manager)).filter(
+      (n): n is TextRun => n.type === "text",
+    );
+    expect(runs.map((r) => [r.text, r.fontFamily])).toEqual([
+      ["ab", "Latin"],
+      ["漢字", "CJK"],
+    ]);
+  });
+});

--- a/tests/unit/support/metrics.ts
+++ b/tests/unit/support/metrics.ts
@@ -27,6 +27,8 @@ export const testMetrics = (over: Partial<FontMetrics> = {}): FontMetrics => ({
     capHeight: 0.7,
     xHeight: 0.5,
   }),
+  // A stand-in font draws everything, so a fallback stack never fires unless a test says so.
+  hasGlyph: () => true,
   kerningEnabled: false,
   getKernPairs: (text) => Array.from({ length: Math.max(0, [...text].length - 1) }, () => 0),
   ...over,

--- a/tests/unit/text/advance.test.ts
+++ b/tests/unit/text/advance.test.ts
@@ -69,6 +69,7 @@ describe("naturalWidth matches the wrapped width (via the shared primitive)", ()
       getStringWidth: (t) => t.length * 6,
       getCharWidth: () => 6,
       getFontVerticals: () => ({ ascent: 0.8, descent: 0.2, lineGap: 0 }),
+      hasGlyph: () => true,
     };
     const ctx = { metrics: m, pageConfig: {} } as never;
 

--- a/tests/unit/text/advance.test.ts
+++ b/tests/unit/text/advance.test.ts
@@ -1,3 +1,4 @@
+import { testMetrics } from "../support/metrics.ts";
 import { describe, it, expect } from "vitest";
 import { codePointCount, runAdvance } from "../../../src/lib/text/advance";
 import { PDFObjectManager, FontStyle } from "../../../src/lib/utils/pdf-object-manager";
@@ -65,12 +66,11 @@ describe("naturalWidth matches the wrapped width (via the shared primitive)", ()
     // text would re-wrap in its own box. Both call runAdvance, so they agree.
     const { TextElement } = await import("../../../src/lib/elements/text-element");
     const { BoxConstraints } = await import("../../../src/lib/layout/box-constraints");
-    const m: FontMetrics = {
+    const m: FontMetrics = testMetrics({
       getStringWidth: (t) => t.length * 6,
       getCharWidth: () => 6,
       getFontVerticals: () => ({ ascent: 0.8, descent: 0.2, lineGap: 0 }),
-      hasGlyph: () => true,
-    };
+    });
     const ctx = { metrics: m, pageConfig: {} } as never;
 
     const text = new TextElement({ fontSize: 10, content: "one two three", letterSpacing: 2 });

--- a/tests/unit/text/font-fallback.test.ts
+++ b/tests/unit/text/font-fallback.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { splitByFont } from "../../../src/lib/text/font-fallback.ts";
+import { FontStyle } from "../../../src/lib/utils/pdf-object-manager.ts";
+import { testMetrics } from "../support/metrics.ts";
+
+// A fallback stack picks, per CODE POINT, the first family that can draw it. The stand-in below says
+// "Latin" holds ASCII only and "CJK" holds everything else, so a test reads as script coverage rather
+// than as glyph ids.
+
+const metrics = testMetrics({
+  hasGlyph: (cp, family) => (family === "Latin" ? cp < 0x80 : true),
+});
+
+const split = (text: string, stack: string[]) =>
+  splitByFont(text, stack[0], stack.slice(1), FontStyle.Normal, metrics);
+
+describe("nothing to fall back to", () => {
+  it("returns undefined without a stack, so the old path is kept", () => {
+    expect(split("abc", ["Latin"])).toBeUndefined();
+  });
+
+  it("returns undefined when the first family draws everything", () => {
+    expect(split("abc", ["Latin", "CJK"])).toBeUndefined();
+  });
+});
+
+describe("a code point the first family cannot draw", () => {
+  it("goes to the next family in the stack", () => {
+    expect(split("abc漢字", ["Latin", "CJK"])).toEqual([
+      { text: "abc", fontFamily: "Latin" },
+      { text: "漢字", fontFamily: "CJK" },
+    ]);
+  });
+
+  it("switches back when the text does", () => {
+    expect(split("a漢b", ["Latin", "CJK"])).toEqual([
+      { text: "a", fontFamily: "Latin" },
+      { text: "漢", fontFamily: "CJK" },
+      { text: "b", fontFamily: "Latin" },
+    ]);
+  });
+
+  it("keeps adjacent code points of one script in ONE run", () => {
+    const runs = split("漢字漢字", ["Latin", "CJK"])!;
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toEqual({ text: "漢字漢字", fontFamily: "CJK" });
+  });
+
+  it("walks the stack in order, taking the FIRST family that has the glyph", () => {
+    const three = testMetrics({
+      hasGlyph: (cp, family) => (family === "A" ? cp < 0x80 : family === "B" ? cp < 0x100 : true),
+    });
+    expect(splitByFont("aé漢", "A", ["B", "C"], FontStyle.Normal, three)).toEqual([
+      { text: "a", fontFamily: "A" },
+      { text: "é", fontFamily: "B" },
+      { text: "漢", fontFamily: "C" },
+    ]);
+  });
+});
+
+describe("a code point nobody in the stack has", () => {
+  it("stays with the first family, which then shows the missing glyph", () => {
+    // What a browser does: the chain ends and the .notdef box appears. Silently dropping the
+    // character would be worse - the text would then read differently than it was written.
+    const none = testMetrics({ hasGlyph: (cp) => cp < 0x80 });
+    // `undefined` IS that answer: nothing was substituted, so the caller keeps its single-family
+    // path and the first family draws the missing glyph itself.
+    expect(splitByFont("a漢", "Latin", ["AlsoLatin"], FontStyle.Normal, none)).toBeUndefined();
+  });
+});
+
+describe("astral characters", () => {
+  it("are treated as ONE code point, not two halves", () => {
+    // The family below holds the whole BMP and nothing above it - the common shape of a real font.
+    // Asked about UTF-16 UNITS instead, both surrogates of U+20000 look like BMP characters, the
+    // fallback never fires, and the character is drawn from a font that does not have it.
+    const bmpOnly = testMetrics({
+      hasGlyph: (cp, family) => (family === "BMP" ? cp < 0x10000 : true),
+    });
+    expect(splitByFont("a\u{20000}b", "BMP", ["Astral"], FontStyle.Normal, bmpOnly)).toEqual([
+      { text: "a", fontFamily: "BMP" },
+      { text: "\u{20000}", fontFamily: "Astral" },
+      { text: "b", fontFamily: "BMP" },
+    ]);
+  });
+});

--- a/tests/unit/text/font-fallback.test.ts
+++ b/tests/unit/text/font-fallback.test.ts
@@ -84,3 +84,10 @@ describe("astral characters", () => {
     ]);
   });
 });
+
+describe("the edge a review caught", () => {
+  it("says 'nothing to substitute' for empty text, not 'no runs at all'", () => {
+    // Returning `[]` would hand the caller an empty list to draw - the text would vanish.
+    expect(split("", ["Latin", "CJK"])).toBeUndefined();
+  });
+});

--- a/tests/unit/text/line-breaker.test.ts
+++ b/tests/unit/text/line-breaker.test.ts
@@ -11,6 +11,7 @@ const metrics: FontMetrics = {
   getStringWidth: (text) => text.length * 10,
   getCharWidth: () => 0,
   getFontVerticals: unitVerticals,
+  hasGlyph: () => true,
 };
 
 const defaults = {

--- a/tests/unit/text/line-breaker.test.ts
+++ b/tests/unit/text/line-breaker.test.ts
@@ -1,18 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { breakSegmentsIntoLines, wrapStringIntoLines } from "../../../src/lib/text/line-breaker";
 import { FontStyle } from "../../../src/lib/utils/pdf-object-manager";
-import type { FontMetrics } from "../../../src/lib/utils/font-metrics";
-import { unitVerticals } from "../support/metrics.ts";
+import { testMetrics } from "../support/metrics.ts";
 import { lineBoxForSegmentLine } from "../../../src/lib/text/line-metrics";
 
 // Deterministic metrics: every glyph is 10 wide, spaces are 0. Expected line breaks
 // are computed by hand from these, so the test is an oracle, not a snapshot.
-const metrics: FontMetrics = {
+const metrics = testMetrics({
   getStringWidth: (text) => text.length * 10,
   getCharWidth: () => 0,
-  getFontVerticals: unitVerticals,
-  hasGlyph: () => true,
-};
+});
 
 const defaults = {
   fontFamily: "Helvetica",

--- a/tests/unit/text/line-height.test.ts
+++ b/tests/unit/text/line-height.test.ts
@@ -2,17 +2,14 @@ import { describe, it, expect } from "vitest";
 import { TextElement } from "../../../src/lib/elements/text-element";
 import { BoxConstraints } from "../../../src/lib/layout/box-constraints";
 import { LayoutContext } from "../../../src/lib/elements/pdf-element";
-import { FontMetrics } from "../../../src/lib/utils/font-metrics";
 import { Text } from "../../../src/lib/api";
-import { unitVerticals } from "../support/metrics.ts";
+import { testMetrics } from "../support/metrics.ts";
 
 // Every glyph (and the space) is 10pt wide -> "alfa" = 40pt; at width 50 each word lands on its line.
-const metrics = {
+const metrics = testMetrics({
   getStringWidth: (t: string) => t.length * 10,
   getCharWidth: () => 10,
-  getFontVerticals: unitVerticals,
-  hasGlyph: () => true,
-} as unknown as FontMetrics;
+});
 
 const CONTENT = "alfa bram char dent emil"; // wraps to 5 lines at width 50
 
@@ -39,12 +36,11 @@ describe("lineHeight", () => {
     // A face that asks for 0.9 up, 0.3 down and 0.1 of lineGap wants a 1.3 em line box. A 1 em box
     // would be tighter than the font itself declares - which is exactly what the old hard-coded
     // baseline constant did to every embedded font.
-    const tall = {
+    const tall = testMetrics({
       getStringWidth: (t: string) => t.length * 10,
       getCharWidth: () => 10,
       getFontVerticals: () => ({ ascent: 0.9, descent: 0.3, lineGap: 0.1 }),
-      hasGlyph: () => true,
-    } as unknown as FontMetrics;
+    });
     const ctx = { metrics: tall, pageConfig: {} } as LayoutContext;
 
     const natural = new TextElement({ fontSize: 10, content: CONTENT });

--- a/tests/unit/text/line-height.test.ts
+++ b/tests/unit/text/line-height.test.ts
@@ -11,6 +11,7 @@ const metrics = {
   getStringWidth: (t: string) => t.length * 10,
   getCharWidth: () => 10,
   getFontVerticals: unitVerticals,
+  hasGlyph: () => true,
 } as unknown as FontMetrics;
 
 const CONTENT = "alfa bram char dent emil"; // wraps to 5 lines at width 50
@@ -42,6 +43,7 @@ describe("lineHeight", () => {
       getStringWidth: (t: string) => t.length * 10,
       getCharWidth: () => 10,
       getFontVerticals: () => ({ ascent: 0.9, descent: 0.3, lineGap: 0.1 }),
+      hasGlyph: () => true,
     } as unknown as FontMetrics;
     const ctx = { metrics: tall, pageConfig: {} } as LayoutContext;
 

--- a/tests/unit/text/orphans-widows.test.ts
+++ b/tests/unit/text/orphans-widows.test.ts
@@ -127,6 +127,7 @@ describe("through TextElement.fragment", () => {
     getStringWidth: (text: string) => [...text].reduce((w, c) => w + (c === " " ? 0 : 10), 0),
     getCharWidth: (c: string) => (c === " " ? 0 : 10),
     getFontVerticals: unitVerticals,
+    hasGlyph: () => true,
   };
   const ctx = { metrics } as LayoutContext;
   const para = (orphans?: number, widows?: number) =>

--- a/tests/unit/text/orphans-widows.test.ts
+++ b/tests/unit/text/orphans-widows.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { TextElement } from "../../../src/lib/elements/text-element.ts";
 import type { LayoutContext } from "../../../src/lib/elements/pdf-element.ts";
-import type { FontMetrics } from "../../../src/lib/utils/font-metrics.ts";
-import { unitVerticals } from "../support/metrics.ts";
+import { testMetrics } from "../support/metrics.ts";
 import {
   adjustForOrphansWidows,
   DEFAULT_ORPHANS,
@@ -123,12 +122,10 @@ describe("turning it off", () => {
 describe("through TextElement.fragment", () => {
   // The deterministic metrics from the fragment suite: each glyph is 10 wide, spaces are 0, so with
   // maxWidth 50 a six-word paragraph of two-letter words breaks into exactly three lines of ten high.
-  const metrics: FontMetrics = {
+  const metrics = testMetrics({
     getStringWidth: (text: string) => [...text].reduce((w, c) => w + (c === " " ? 0 : 10), 0),
     getCharWidth: (c: string) => (c === " " ? 0 : 10),
-    getFontVerticals: unitVerticals,
-    hasGlyph: () => true,
-  };
+  });
   const ctx = { metrics } as LayoutContext;
   const para = (orphans?: number, widows?: number) =>
     new TextElement({ fontSize: 10, content: "aa bb cc dd ee ff", orphans, widows });

--- a/tests/unit/text/text-fragment.test.ts
+++ b/tests/unit/text/text-fragment.test.ts
@@ -14,6 +14,7 @@ const metrics: FontMetrics = {
   getStringWidth: (text: string) => [...text].reduce((w, c) => w + (c === " " ? 0 : 10), 0),
   getCharWidth: (c: string) => (c === " " ? 0 : 10),
   getFontVerticals: unitVerticals,
+  hasGlyph: () => true,
 };
 const ctx = { metrics } as LayoutContext;
 

--- a/tests/unit/text/text-fragment.test.ts
+++ b/tests/unit/text/text-fragment.test.ts
@@ -3,19 +3,16 @@ import { TextElement } from "../../../src/lib/elements/text-element";
 import { TextSegment } from "../../../src/lib/elements/text-element";
 import { LayoutContext } from "../../../src/lib/elements/pdf-element";
 import { BoxConstraints } from "../../../src/lib/layout/box-constraints";
-import type { FontMetrics } from "../../../src/lib/utils/font-metrics";
-import { unitVerticals } from "../support/metrics.ts";
+import { testMetrics } from "../support/metrics.ts";
 
 // Deterministic metrics: each glyph is 10 wide, spaces are 0. With six 2-char words and
 // maxWidth 50 the greedy breaker yields three lines of two words each.
-const metrics: FontMetrics = {
+const metrics = testMetrics({
   // Consistent font: getStringWidth is the sum of getCharWidth (as it is in reality). Each glyph is
   // 10 wide, a space is 0, so word widths are len*10 and spaces cost nothing - the arithmetic below.
   getStringWidth: (text: string) => [...text].reduce((w, c) => w + (c === " " ? 0 : 10), 0),
   getCharWidth: (c: string) => (c === " " ? 0 : 10),
-  getFontVerticals: unitVerticals,
-  hasGlyph: () => true,
-};
+});
 const ctx = { metrics } as LayoutContext;
 
 const para = (content: string, fontSize = 10) =>

--- a/tests/unit/text/text-truncation.test.ts
+++ b/tests/unit/text/text-truncation.test.ts
@@ -13,6 +13,7 @@ const metrics = {
   getStringWidth: (t: string) => t.length * 10,
   getCharWidth: () => 10,
   getFontVerticals: unitVerticals,
+  hasGlyph: () => true,
 } as unknown as FontMetrics;
 
 const wrap = (text: string, maxWidth: number, maxLines?: number, overflow?: "clip" | "ellipsis") =>

--- a/tests/unit/text/text-truncation.test.ts
+++ b/tests/unit/text/text-truncation.test.ts
@@ -6,15 +6,13 @@ import { LayoutContext } from "../../../src/lib/elements/pdf-element";
 import { FontStyle } from "../../../src/lib/utils/pdf-object-manager";
 import { FontMetrics } from "../../../src/lib/utils/font-metrics";
 import { Text } from "../../../src/lib/api";
-import { unitVerticals } from "../support/metrics.ts";
+import { testMetrics } from "../support/metrics.ts";
 
 // Every glyph (and the space) is 10pt wide, no kerning -> "alfa" = 40pt. Deterministic wrapping.
-const metrics = {
+const metrics = testMetrics({
   getStringWidth: (t: string) => t.length * 10,
   getCharWidth: () => 10,
-  getFontVerticals: unitVerticals,
-  hasGlyph: () => true,
-} as unknown as FontMetrics;
+}) as unknown as FontMetrics;
 
 const wrap = (text: string, maxWidth: number, maxLines?: number, overflow?: "clip" | "ellipsis") =>
   wrapStringIntoLines(


### PR DESCRIPTION
## Summary

Font fallback

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ordered font fallback stacks for text, enabling mixed-language content to select suitable fonts automatically.
  - Added fallback support at the text and span levels, including missing glyph and Unicode handling.
  - Preserved consistent text layout, sizing, and rendering across fallback fonts.

- **Documentation**
  - Documented font fallback behavior and updated test status.

- **Tests**
  - Added coverage for language switching, span-level settings, missing glyphs, and Unicode edge cases.
  - Test suite now records 1,053 passing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->