### PR TITLE
feat: §14 - service date "from" - "to"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,8 +230,8 @@ rendering. This is the standing visual check; prefer it over one-off `scripts/ru
 - `pnpm test` — Vitest (watch). `pnpm exec vitest run` for a one-shot CI-style run.
   `pnpm run test:coverage` for coverage. Unit tests live in **`tests/unit/`**, mirroring the `src/lib/`
   structure (`tests/unit/{common,elements,renderer,utils}/…`). `src/` is pure production code — the
-  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **1053 tests, green** —
-  what the root run covers: core 908, `@jasy/cli` 37, `@jasy/vue` 33, `@jasy/e-invoice` 27. `@jasy/nuxt`
+  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **1066 tests, green** —
+  what the root run covers: core 908, `@jasy/cli` 37, `@jasy/vue` 33, `@jasy/e-invoice` 38. `@jasy/nuxt`
   is excluded from it (`vitest.config.ts`) and runs on its own.
 - `pnpm run build` — `tsc` → `dist/`.
 - `pnpm run lint` (oxlint) + `pnpm run fmt:check` (oxfmt `--check`); `pnpm run fmt` formats. **Run `pnpm run fmt`
@@ -668,6 +668,18 @@ wordWidth > maxWidth` and forgot the SPACE that would join the word. It went uns
   A code point no family in the stack has stays with the first one and shows its `.notdef`, as a browser
   does — dropping it would make the text read differently than it was written.
 
+- ✅ **Invoicing period, BG-14 + BG-26** (2026-08-02, `@jasy/e-invoice`) — `invoice.period` and
+  `line.period` (`{ start, end }`) emit `ram:BillingSpecifiedPeriod` in CII and `cac:InvoicePeriod` in
+  UBL, at document AND line level. Why it matters: §14 Abs. 4 Nr. 6 UStG wants a delivery DATE or a
+  PERIOD, and for a recurring monthly service the period is the truthful one. The XRechnung rule says
+  it word for word — delivery date OR document period OR a period on **every** line — so the
+  pre-check (`xrechnungProblems`) enforces exactly that, `every` and not `some`, and also refuses a
+  period that ends before it starts.
+  The position in the XSD sequence is load-bearing (after the trade taxes, before the allowances);
+  proved by rendering a real invoice and running it through our own KoSIT schematron, not by reading
+  the spec twice. Found while auditing four rejected SumUp invoices for Flo: none carried BT-72 or
+  BG-14, the period was free text in the item description only.
+
 Genuine remaining gaps / deferred:
 
 1. **Absolute positioning — Stages 1+2 built** (2026-06-21). CSS-style: `Box({ relative: true })` is a
@@ -744,7 +756,7 @@ below), `@jasy/cli`@alpha.6, `@jasy/vue`@alpha.7, `@jasy/nuxt`@alpha.6** (the al
 page-break control — the termination guard, `PageBreak`, `breakBefore`/`breakAfter`, `keepTogether` — plus
 kerning turned on by default). Repo public + locked, full CI + changelog +
 bots in place (see Repo facts). The engine is **feature-complete for the alpha** — inheritance, `onOverflow`,
-custom formats, the line-breaker fixes; **1053 tests green** (the root run, i.e. everything but
+custom formats, the line-breaker fixes; **1066 tests green** (the root run, i.e. everything but
 `@jasy/nuxt`). The **landing**
 (`~/projects/jasy-landing` → **jasy.dev**) is built: showroom (12 cards), validator, docs, a home-page
 roadmap section, and a full **SEO + AI-discoverability layer** (OG image, JSON-LD, `robots.txt`,

--- a/packages/e-invoice/src/cii.ts
+++ b/packages/e-invoice/src/cii.ts
@@ -1,4 +1,12 @@
-import { AllowanceCharge, Buyer, Invoice, InvoiceLine, PostalAddress, Seller } from "./invoice.ts";
+import {
+  AllowanceCharge,
+  Buyer,
+  Invoice,
+  InvoiceLine,
+  PostalAddress,
+  Seller,
+  ServicePeriod,
+} from "./invoice.ts";
 import { ComputedInvoice, VatBreakdownEntry } from "./compute.ts";
 
 // Emits the UN/CEFACT Cross Industry Invoice (CII) XML for the EN16931 profile. The structure is
@@ -149,6 +157,20 @@ function tradeTax(g: VatBreakdownEntry): string {
 }
 
 /** One invoice line (BG-25). `net` is the pre-computed line net amount (BT-131). */
+/**
+ * The service period (BG-14 on the document, BG-26 on a line). The XSD sequence puts it after the
+ * trade taxes and before the allowances, and the schematron checks that order - so where this lands
+ * is load-bearing, not cosmetic.
+ */
+function billingPeriod(p?: ServicePeriod): string {
+  return p
+    ? wrap("ram:BillingSpecifiedPeriod", [
+        wrap("ram:StartDateTime", [date102(p.start)]), // BT-73 / BT-134
+        wrap("ram:EndDateTime", [date102(p.end)]), // BT-74 / BT-135
+      ])
+    : "";
+}
+
 function line(l: InvoiceLine, net: number, index: number): string {
   return wrap("ram:IncludedSupplyChainTradeLineItem", [
     wrap("ram:AssociatedDocumentLineDocument", [
@@ -181,6 +203,7 @@ function line(l: InvoiceLine, net: number, index: number): string {
         el("ram:CategoryCode", l.vat.category), // BT-151
         el("ram:RateApplicablePercent", l.vat.ratePercent ?? 0), // BT-152
       ]),
+      billingPeriod(l.period), // BG-26
       wrap("ram:SpecifiedTradeSettlementLineMonetarySummation", [
         el("ram:LineTotalAmount", amount(net)), // BT-131
       ]),
@@ -289,6 +312,7 @@ export function toCII(
     el("ram:InvoiceCurrencyCode", invoice.currency), // BT-5
     paymentMeans, // BG-16
     ...computed.vatBreakdown.map(tradeTax), // BG-23
+    billingPeriod(invoice.period), // BG-14
     ...(invoice.allowancesCharges ?? []).map(docAllowanceCharge), // BG-20 / BG-21
     paymentTerms,
     totals, // BG-22

--- a/packages/e-invoice/src/invoice.ts
+++ b/packages/e-invoice/src/invoice.ts
@@ -95,6 +95,21 @@ export interface Buyer {
   contact?: Contact; // BG-9
 }
 
+/**
+ * A service period (BG-14 on the document, BG-26 on a line): the span the invoice actually covers.
+ *
+ * German VAT law (§14 Abs. 4 Nr. 6 UStG) wants the Leistungsdatum OR the Leistungszeitraum, and the
+ * XRechnung rule set says the same - `ActualDeliverySupplyChainEvent/OccurrenceDateTime` OR
+ * `BillingSpecifiedPeriod`. A recurring monthly service is honestly a PERIOD, not a single day, so
+ * a maintenance invoice should carry this rather than pick an arbitrary date inside it.
+ */
+export interface ServicePeriod {
+  /** First day of the period (BT-73 on the document, BT-134 on a line). */
+  start: IsoDate;
+  /** Last day, inclusive (BT-74 / BT-135). */
+  end: IsoDate;
+}
+
 /** Where the goods/services were delivered (BG-13). Optional; used when it differs from the buyer. */
 export interface Delivery {
   date?: IsoDate; // BT-72  actual delivery date
@@ -148,6 +163,8 @@ export interface InvoiceLine {
   /** Quantity the net price refers to (BT-149), default 1 - e.g. price "per 100". */
   priceBaseQuantity?: number;
   vat: LineVat; // BG-30  (MANDATORY)
+  /** The period THIS line covers (BG-26). Use it when lines span different months. */
+  period?: ServicePeriod;
   /** Per-line allowances/charges (BG-27 / BG-28). Net line amount BT-131 is computed from these. */
   allowancesCharges?: AllowanceCharge[];
   note?: string; // BT-127
@@ -197,6 +214,12 @@ export interface Invoice {
   seller: Seller; // BG-4  (MANDATORY)
   buyer: Buyer; // BG-7  (MANDATORY)
   delivery?: Delivery; // BG-13
+  /**
+   * The period the whole invoice covers (BG-14) - the "Leistungszeitraum". Either this or
+   * `delivery.date` satisfies §14 Abs. 4 Nr. 6 UStG; for a recurring service the period is the
+   * truthful one.
+   */
+  period?: ServicePeriod;
   /** Payee if different from the seller (BG-10). */
   payeeName?: string; // BT-59
 

--- a/packages/e-invoice/src/profile-check.ts
+++ b/packages/e-invoice/src/profile-check.ts
@@ -38,5 +38,30 @@ export function xrechnungProblems(invoice: Invoice): string[] {
   require(!creditTransfer ||
     payment?.iban, "XRechnung credit transfer needs an IBAN - set invoice.payment.iban (BT-84).");
 
+  // A period that runs backwards is silently accepted by the schema and read as nonsense downstream,
+  // so it is worth catching here where the message can name the field.
+  const periods: [string, { start: string; end: string } | undefined][] = [
+    ["invoice.period (BG-14)", invoice.period],
+    ...invoice.lines.map(
+      (l, i) => [`invoice.lines[${i}].period (BG-26)`, l.period] as [string, typeof l.period],
+    ),
+  ];
+  for (const [where, p] of periods) {
+    if (p && p.end < p.start) {
+      problems.push(`${where} ends before it starts: ${p.start} to ${p.end}.`);
+    }
+  }
+
+  // §14 Abs. 4 Nr. 6 UStG, and the XRechnung rule that mirrors it: a delivery DATE or a PERIOD. The
+  // schematron accepts either, so this only warns when neither is there.
+  // §14 Abs. 4 Nr. 6 UStG, and the XRechnung rule that mirrors it word for word: a delivery date, OR
+  // a document period, OR a period on EVERY line - "some lines" does not satisfy it.
+  require(invoice.delivery?.date ||
+    invoice.period ||
+    (invoice.lines.length > 0 &&
+      invoice.lines.every(
+        (l) => l.period,
+      )), "XRechnung needs a delivery date or a service period - set invoice.delivery.date (BT-72), invoice.period (BG-14), or a period on every line (BG-26).");
+
   return problems;
 }

--- a/packages/e-invoice/src/ubl.ts
+++ b/packages/e-invoice/src/ubl.ts
@@ -1,4 +1,12 @@
-import { AllowanceCharge, Buyer, Invoice, InvoiceLine, PostalAddress, Seller } from "./invoice.ts";
+import {
+  ServicePeriod,
+  AllowanceCharge,
+  Buyer,
+  Invoice,
+  InvoiceLine,
+  PostalAddress,
+  Seller,
+} from "./invoice.ts";
 import { ComputedInvoice, VatBreakdownEntry } from "./compute.ts";
 import { BUSINESS_PROCESS, CiiProfile, GUIDELINE } from "./cii.ts";
 
@@ -144,12 +152,23 @@ function taxSubtotal(g: VatBreakdownEntry, currency: string): string {
   ]);
 }
 
+/** The service period (BG-14 on the document, BG-26 on a line) - UBL's `cac:InvoicePeriod`. */
+function invoicePeriod(p?: ServicePeriod): string {
+  return p
+    ? wrap("cac:InvoicePeriod", [
+        el("cbc:StartDate", p.start), // BT-73 / BT-134
+        el("cbc:EndDate", p.end), // BT-74 / BT-135
+      ])
+    : "";
+}
+
 function invoiceLine(l: InvoiceLine, net: number, index: number, currency: string): string {
   return wrap("cac:InvoiceLine", [
     el("cbc:ID", l.id ?? String(index + 1)), // BT-126
     l.note ? el("cbc:Note", l.note) : "", // BT-127
     el("cbc:InvoicedQuantity", l.quantity, { unitCode: l.unit }), // BT-129 / BT-130
     money("cbc:LineExtensionAmount", net, currency), // BT-131
+    invoicePeriod(l.period), // BG-26
     wrap("cac:Item", [
       el("cbc:Description", l.description), // BT-154
       el("cbc:Name", l.name), // BT-153
@@ -189,6 +208,7 @@ export function toUBL(
     ...(invoice.notes ?? []).map((n) => el("cbc:Note", n)), // BT-22
     el("cbc:DocumentCurrencyCode", cur), // BT-5
     el("cbc:BuyerReference", invoice.buyerReference), // BT-10 (Leitweg-ID)
+    invoicePeriod(invoice.period), // BG-14
     invoice.purchaseOrderRef
       ? wrap("cac:OrderReference", [el("cbc:ID", invoice.purchaseOrderRef)])
       : "", // BT-13

--- a/packages/e-invoice/tests/period.test.ts
+++ b/packages/e-invoice/tests/period.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { toCII } from "../src/cii";
+import { toUBL } from "../src/ubl";
+import { computeInvoice } from "../src/compute";
+import { xrechnungProblems } from "../src/profile-check";
+import { Invoice } from "../src/invoice";
+
+// BG-14 (document) and BG-26 (line): the "Leistungszeitraum". German VAT law (§14 Abs. 4 Nr. 6 UStG)
+// wants a delivery DATE or a PERIOD, and for a recurring service the period is the truthful one - a
+// monthly maintenance fee is not delivered on one day.
+
+const base: Invoice = {
+  number: "RE-1",
+  issueDate: "2026-08-06",
+  currency: "EUR",
+  buyerReference: "04011000-12345-34",
+  seller: {
+    name: "Muster GmbH",
+    vatId: "DE123456789",
+    electronicAddress: "re@muster.de",
+    contact: { name: "Erika Muster", phone: "+49 1", email: "e@muster.de" },
+    address: { line1: "Hauptstr. 1", city: "Berlin", postCode: "10115", country: "DE" },
+  },
+  buyer: {
+    name: "Kunde AG",
+    electronicAddress: "re@kunde.de",
+    address: { city: "München", postCode: "80331", country: "DE" },
+  },
+  lines: [
+    {
+      name: "Wartung",
+      quantity: 1,
+      unit: "C62",
+      netUnitPrice: 500,
+      vat: { category: "S", ratePercent: 19 },
+    },
+  ],
+  payment: { iban: "DE02120300000000202051" },
+  dueDate: "2026-08-20",
+};
+
+const period = { start: "2026-05-01", end: "2026-05-31" } as const;
+const cii = (i: Invoice) => toCII(i, computeInvoice(i), "xrechnung");
+const ubl = (i: Invoice) => toUBL(i, computeInvoice(i), "xrechnung");
+
+describe("the document period (BG-14)", () => {
+  it("writes both ends into the CII settlement", () => {
+    const xml = cii({ ...base, period });
+    expect(xml).toContain("<ram:BillingSpecifiedPeriod>");
+    expect(xml).toMatch(/BillingSpecifiedPeriod>[\s\S]*?20260501[\s\S]*?20260531/);
+  });
+
+  it("writes them into UBL as cac:InvoicePeriod", () => {
+    const xml = ubl({ ...base, period });
+    expect(xml).toContain("<cbc:StartDate>2026-05-01</cbc:StartDate>");
+    expect(xml).toContain("<cbc:EndDate>2026-05-31</cbc:EndDate>");
+  });
+
+  it("emits nothing at all when no period is given", () => {
+    expect(cii(base)).not.toContain("BillingSpecifiedPeriod");
+    expect(ubl(base)).not.toContain("InvoicePeriod");
+  });
+});
+
+describe("the line period (BG-26)", () => {
+  const withLine: Invoice = { ...base, lines: [{ ...base.lines[0], period }] };
+
+  it("sits inside the LINE settlement, not the document one", () => {
+    const xml = cii(withLine);
+    const line = xml.slice(
+      xml.indexOf("<ram:IncludedSupplyChainTradeLineItem>"),
+      xml.indexOf("</ram:IncludedSupplyChainTradeLineItem>"),
+    );
+    expect(line).toContain("<ram:BillingSpecifiedPeriod>");
+    // The document settlement stays clean - the period belongs to that one line.
+    expect(xml.slice(xml.indexOf("<ram:ApplicableHeaderTradeSettlement>"))).not.toContain(
+      "BillingSpecifiedPeriod",
+    );
+  });
+
+  it("does the same in UBL", () => {
+    const xml = ubl(withLine);
+    const line = xml.slice(xml.indexOf("<cac:InvoiceLine>"), xml.indexOf("</cac:InvoiceLine>"));
+    expect(line).toContain("<cac:InvoicePeriod>");
+  });
+});
+
+describe("the pre-check", () => {
+  it("asks for a date or a period, because the law does", () => {
+    expect(xrechnungProblems(base).join(" ")).toMatch(/delivery date or a service period/);
+  });
+
+  it("is satisfied by a document period", () => {
+    expect(xrechnungProblems({ ...base, period })).toEqual([]);
+  });
+
+  it("is satisfied by a delivery date", () => {
+    expect(xrechnungProblems({ ...base, delivery: { date: "2026-05-31" } })).toEqual([]);
+  });
+
+  it("needs the period on EVERY line, not just one", () => {
+    // The XRechnung rule says `every $line satisfies ...`; one line out of two is not enough.
+    const two = { ...base, lines: [{ ...base.lines[0], period }, { ...base.lines[0] }] };
+    expect(xrechnungProblems(two).join(" ")).toMatch(/delivery date or a service period/);
+
+    const both = { ...base, lines: two.lines.map((l) => ({ ...l, period })) };
+    expect(xrechnungProblems(both)).toEqual([]);
+  });
+
+  it("catches a period that runs backwards", () => {
+    const back = { ...base, period: { start: "2026-05-31", end: "2026-05-01" } };
+    expect(xrechnungProblems(back).join(" ")).toMatch(/ends before it starts/);
+  });
+
+  it("names the LINE when that is the one running backwards", () => {
+    const back = {
+      ...base,
+      lines: [{ ...base.lines[0], period: { start: "2026-05-31", end: "2026-05-01" } }],
+    };
+    expect(xrechnungProblems(back).join(" ")).toMatch(/lines\[0\]\.period \(BG-26\)/);
+  });
+});

--- a/packages/e-invoice/tests/xrechnung.test.ts
+++ b/packages/e-invoice/tests/xrechnung.test.ts
@@ -9,6 +9,9 @@ const complete: Invoice = {
   issueDate: "2026-06-18",
   currency: "EUR",
   dueDate: "2026-07-02",
+  // XRechnung insists on a delivery date or a service period; without one this fixture was not
+  // actually complete, which the new pre-check caught.
+  delivery: { date: "2026-06-15" },
   buyerReference: "04011000-12345-34",
   seller: {
     name: "Muster GmbH",


### PR DESCRIPTION
## Summary

Service date must be a "from" and "to" date if using §14. Now we can!

## Type of change

- [ ] Bug fix
- x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document-wide and invoice-line service periods with inclusive start and end dates.
  * Service periods are now included in CII and UBL e-invoice output when provided.

* **Bug Fixes**
  * Improved XRechnung validation for missing, incomplete, or reversed service periods.
  * Delivery-date requirements now support valid document or complete line-level periods.

* **Tests**
  * Added coverage for period serialization, omission, placement, and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->