### PR TITLE
fix: add period to template (`ZUGFeRD`)

### DIFF
--- a/packages/e-invoice/src/i18n.ts
+++ b/packages/e-invoice/src/i18n.ts
@@ -29,6 +29,7 @@ export interface InvoiceLabels {
   invoiceNumber: string;
   invoiceDate: string;
   deliveryDate: string;
+  servicePeriod: string;
   dueDate: string;
   customerReference: string;
   orderNumber: string;
@@ -61,6 +62,7 @@ const de: InvoiceLabels = {
   invoiceNumber: "Rechnungsnummer",
   invoiceDate: "Rechnungsdatum",
   deliveryDate: "Lieferdatum",
+  servicePeriod: "Leistungszeitraum",
   dueDate: "Fälligkeit",
   customerReference: "Kundenreferenz",
   orderNumber: "Bestellnummer",
@@ -93,6 +95,7 @@ const en: InvoiceLabels = {
   invoiceNumber: "Invoice no.",
   invoiceDate: "Invoice date",
   deliveryDate: "Delivery date",
+  servicePeriod: "Service period",
   dueDate: "Due date",
   customerReference: "Customer reference",
   orderNumber: "Order no.",
@@ -125,6 +128,7 @@ const fr: InvoiceLabels = {
   invoiceNumber: "N° de facture",
   invoiceDate: "Date de facture",
   deliveryDate: "Date de livraison",
+  servicePeriod: "Période de prestation",
   dueDate: "Échéance",
   customerReference: "Référence client",
   orderNumber: "N° de commande",
@@ -155,6 +159,12 @@ export interface Formatters {
   percent(ratePercent: number): string;
   /** An ISO date "YYYY-MM-DD" in the locale's short form (UTC, so no timezone drift). */
   date(iso: string): string;
+  /**
+   * A service period (BG-14/BG-26) for the eye. One covering exactly one whole calendar month reads
+   * AS that month ("Juni 2026") - the form §31 Abs. 4 UStDV allows in place of a day. The XML is
+   * untouched and keeps both ends, which is what BT-73/BT-74 require.
+   */
+  period(start: string, end: string): string;
 }
 
 export function makeFormatters(locale: Locale = "de", currency: string): Formatters {
@@ -168,10 +178,26 @@ export function makeFormatters(locale: Locale = "de", currency: string): Formatt
     day: "2-digit",
     timeZone: "UTC",
   });
+  const month = new Intl.DateTimeFormat(tag, { year: "numeric", month: "long", timeZone: "UTC" });
+  const utc = (iso: string) => new Date(`${iso}T00:00:00Z`);
   return {
     money: (n) => money.format(n),
     number: (n) => number.format(n),
     percent: (ratePercent) => percent.format(ratePercent / 100),
-    date: (iso) => date.format(new Date(`${iso}T00:00:00Z`)),
+    date: (iso) => date.format(utc(iso)),
+    period: (start, end) =>
+      wholeMonth(start, end)
+        ? month.format(utc(start))
+        : `${date.format(utc(start))} - ${date.format(utc(end))}`,
   };
+}
+
+/** Whether a period is exactly one calendar month, start to end - the case that reads as "Juni 2026". */
+function wholeMonth(start: string, end: string): boolean {
+  const [startYear, startMonth, startDay] = start.split("-").map(Number);
+  const [endYear, endMonth, endDay] = end.split("-").map(Number);
+  // Day 0 of the FOLLOWING month is the last day of this one; `endMonth` is 1-based, so as a 0-based
+  // index it already names the following month.
+  const lastDay = new Date(Date.UTC(endYear, endMonth, 0)).getUTCDate();
+  return startYear === endYear && startMonth === endMonth && startDay === 1 && endDay === lastDay;
 }

--- a/packages/e-invoice/src/template.ts
+++ b/packages/e-invoice/src/template.ts
@@ -118,6 +118,10 @@ function recipientAndMeta(invoice: Invoice, L: InvoiceLabels, fmt: Formatters): 
   const meta: [string, string | undefined][] = [
     [L.invoiceNumber, invoice.number],
     [L.invoiceDate, fmt.date(invoice.issueDate)],
+    [
+      L.servicePeriod,
+      invoice.period ? fmt.period(invoice.period.start, invoice.period.end) : undefined,
+    ],
     [L.deliveryDate, invoice.delivery?.date ? fmt.date(invoice.delivery.date) : undefined],
     [L.dueDate, invoice.dueDate ? fmt.date(invoice.dueDate) : undefined],
     [L.customerReference, invoice.buyerReference],

--- a/packages/e-invoice/tests/i18n.test.ts
+++ b/packages/e-invoice/tests/i18n.test.ts
@@ -21,3 +21,30 @@ describe("i18n", () => {
     expect(en.date("2026-06-17")).toBe("06/17/2026");
   });
 });
+
+describe("the service period, for the eye", () => {
+  const de = makeFormatters("de", "EUR");
+  const en = makeFormatters("en", "EUR");
+
+  it("reads a whole calendar month AS that month - what §31 Abs. 4 UStDV allows", () => {
+    expect(de.period("2026-06-01", "2026-06-30")).toBe("Juni 2026");
+    expect(en.period("2026-06-01", "2026-06-30")).toBe("June 2026");
+  });
+
+  it("knows how long the month is, rather than assuming 30 or 31", () => {
+    expect(de.period("2026-02-01", "2026-02-28")).toBe("Februar 2026");
+    expect(de.period("2024-02-01", "2024-02-29")).toBe("Februar 2024"); // leap year
+    expect(de.period("2026-01-01", "2026-01-31")).toBe("Januar 2026");
+  });
+
+  it("shows both ends whenever it is NOT a whole month", () => {
+    expect(de.period("2026-06-02", "2026-06-30")).toBe("02.06.2026 - 30.06.2026"); // starts late
+    expect(de.period("2026-06-01", "2026-06-29")).toBe("01.06.2026 - 29.06.2026"); // ends early
+    expect(de.period("2026-06-01", "2026-07-31")).toBe("01.06.2026 - 31.07.2026"); // two months
+    expect(de.period("2025-06-01", "2026-06-30")).toBe("01.06.2025 - 30.06.2026"); // a whole year
+  });
+
+  it("does not drift across a timezone, like the plain date formatter", () => {
+    expect(de.period("2026-06-01", "2026-06-30")).not.toContain("Mai");
+  });
+});

--- a/packages/e-invoice/tests/period.test.ts
+++ b/packages/e-invoice/tests/period.test.ts
@@ -4,6 +4,8 @@ import { toUBL } from "../src/ubl";
 import { computeInvoice } from "../src/compute";
 import { xrechnungProblems } from "../src/profile-check";
 import { Invoice } from "../src/invoice";
+import { defaultInvoiceTemplate } from "../src/template";
+import { resolveLabels, makeFormatters } from "../src/i18n";
 
 // BG-14 (document) and BG-26 (line): the "Leistungszeitraum". German VAT law (§14 Abs. 4 Nr. 6 UStG)
 // wants a delivery DATE or a PERIOD, and for a recurring service the period is the truthful one - a
@@ -118,5 +120,60 @@ describe("the pre-check", () => {
       lines: [{ ...base.lines[0], period: { start: "2026-05-31", end: "2026-05-01" } }],
     };
     expect(xrechnungProblems(back).join(" ")).toMatch(/lines\[0\]\.period \(BG-26\)/);
+  });
+});
+
+describe("the period in the PRINTED invoice", () => {
+  // The point of BG-14 is that both halves of a ZUGFeRD file say the same thing. A period that lives
+  // only in the XML is the same defect as one that lives only in the text, just mirrored - which is
+  // exactly how the four rejected invoices that prompted this failed.
+  const printed = (i: Invoice, locale: "de" | "en" = "de"): string[] => {
+    const doc = defaultInvoiceTemplate(
+      i,
+      computeInvoice(i),
+      resolveLabels(locale),
+      makeFormatters(locale, i.currency),
+    );
+    const out: string[] = [];
+    const seen = new Set<unknown>();
+    const walk = (node: unknown): void => {
+      if (!node || typeof node !== "object" || seen.has(node)) return;
+      seen.add(node);
+      const props = (node as { getProps?: () => { content?: unknown } }).getProps?.();
+      if (typeof props?.content === "string") out.push(props.content);
+      for (const value of Object.values(node)) {
+        if (Array.isArray(value)) value.forEach(walk);
+        else walk(value);
+      }
+    };
+    walk(doc);
+    return out;
+  };
+
+  it("shows the period, labelled, on the document", () => {
+    const text = printed({ ...base, period });
+    expect(text).toContain("Leistungszeitraum");
+    expect(text).toContain("Mai 2026"); // a whole calendar month collapses to its name
+  });
+
+  it("shows both ends when the period is not a whole month", () => {
+    const text = printed({ ...base, period: { start: "2026-05-03", end: "2026-06-14" } });
+    expect(text).toContain("03.05.2026 - 14.06.2026");
+  });
+
+  it("says nothing at all when there is no period", () => {
+    expect(printed(base)).not.toContain("Leistungszeitraum");
+  });
+
+  it("shows a delivery date and a period side by side, since the XML carries both", () => {
+    const text = printed({ ...base, period, delivery: { date: "2026-05-31" } });
+    expect(text).toContain("Leistungszeitraum");
+    expect(text).toContain("Lieferdatum");
+  });
+
+  it("follows the locale", () => {
+    const text = printed({ ...base, period }, "en");
+    expect(text).toContain("Service period");
+    expect(text).toContain("May 2026");
   });
 });

--- a/packages/e-invoice/tests/render.test.ts
+++ b/packages/e-invoice/tests/render.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { renderZugferd } from "../src/render";
 import { Invoice } from "../src/invoice";
+import { toCII } from "../src/cii";
+import { computeInvoice } from "../src/compute";
 
 const invoice: Invoice = {
   number: "RE-2026-001",
@@ -8,6 +10,7 @@ const invoice: Invoice = {
   currency: "EUR",
   dueDate: "2026-07-01",
   buyerReference: "04011000-12345-34",
+  period: { start: "2026-06-01", end: "2026-06-30" },
   seller: {
     name: "Muster GmbH",
     vatId: "DE123456789",
@@ -60,5 +63,17 @@ describe("renderZugferd", () => {
     // the returned XML is the EN16931 CII we embedded
     expect(xml).toContain("<rsm:CrossIndustryInvoice");
     expect(xml).toContain("urn:cen.eu:en16931:2017");
+  });
+
+  it("carries the service period into the XML, structured - not as a note", () => {
+    // The sample above sets `period`, so this runs on every build. It is here rather than only in
+    // period.test.ts because the failure mode it guards is a whole-pipeline one: the four SumUp
+    // invoices that prompted BG-14 passed every validator while saying the period in prose only.
+    // The PRINTED half is checked in period.test.ts - it cannot be read back out of the PDF, whose
+    // text is drawn with a subsetted Identity-H font.
+    expect(toCII(invoice, computeInvoice(invoice), "en16931")).toMatch(
+      /BillingSpecifiedPeriod>[\s\S]*?20260601[\s\S]*?20260630/,
+    );
+    expect(invoice.notes ?? []).not.toContainEqual(expect.stringMatching(/Zeitraum|period/i));
   });
 });


### PR DESCRIPTION
## Summary

Add missing period date range to ZUGFeRD template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional service-period details to invoices.
  - Service periods are displayed with localized labels and date formatting in German, English, and French.
  - Full-month periods use a concise localized month-and-year format.
  - Service periods are included as structured data in exported invoice XML.

- **Bug Fixes**
  - Improved timezone-stable period formatting.
  - Prevented service periods from being duplicated in invoice notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->