### PR TITLE
fix: layout issues, missing fields (template)

### DIFF
--- a/packages/e-invoice/src/i18n.ts
+++ b/packages/e-invoice/src/i18n.ts
@@ -8,6 +8,7 @@ export type Locale = "de" | "en" | "fr";
 /** Every label the default template draws. A custom language = supply a full `InvoiceLabels`. */
 export interface InvoiceLabels {
   invoice: string;
+  creditNote: string;
   position: string;
   description: string;
   quantity: string;
@@ -44,6 +45,10 @@ export interface InvoiceLabels {
   pageOf: string;
   contactPerson: string;
   email: string;
+  vatBreakdown: string;
+  taxableBase: string;
+  taxAmount: string;
+  amountsIn: string;
   vatId: string;
   taxNumber: string;
   registration: string;
@@ -52,6 +57,7 @@ export interface InvoiceLabels {
 
 const de: InvoiceLabels = {
   invoice: "Rechnung",
+  creditNote: "Gutschrift",
   position: "Pos",
   description: "Beschreibung",
   quantity: "Menge",
@@ -88,6 +94,10 @@ const de: InvoiceLabels = {
   pageOf: "von",
   contactPerson: "Ansprechpartner",
   email: "E-Mail",
+  vatBreakdown: "Steueraufschlüsselung",
+  taxableBase: "Netto",
+  taxAmount: "Steuer",
+  amountsIn: "Alle Beträge in",
   vatId: "USt-IdNr",
   taxNumber: "Steuernr",
   registration: "Reg.",
@@ -96,6 +106,7 @@ const de: InvoiceLabels = {
 
 const en: InvoiceLabels = {
   invoice: "Invoice",
+  creditNote: "Credit note",
   position: "No.",
   description: "Description",
   quantity: "Qty",
@@ -132,6 +143,10 @@ const en: InvoiceLabels = {
   pageOf: "of",
   contactPerson: "Contact",
   email: "Email",
+  vatBreakdown: "VAT breakdown",
+  taxableBase: "Net",
+  taxAmount: "Tax",
+  amountsIn: "All amounts in",
   vatId: "VAT ID",
   taxNumber: "Tax no.",
   registration: "Reg.",
@@ -140,6 +155,7 @@ const en: InvoiceLabels = {
 
 const fr: InvoiceLabels = {
   invoice: "Facture",
+  creditNote: "Avoir",
   position: "N°",
   description: "Description",
   quantity: "Qté",
@@ -176,6 +192,10 @@ const fr: InvoiceLabels = {
   pageOf: "sur",
   contactPerson: "Interlocuteur",
   email: "E-mail",
+  vatBreakdown: "Détail de la TVA",
+  taxableBase: "Net",
+  taxAmount: "Taxe",
+  amountsIn: "Tous les montants en",
   vatId: "N° TVA",
   taxNumber: "N° fiscal",
   registration: "Immatriculation",
@@ -203,6 +223,8 @@ export interface Formatters {
   percent(ratePercent: number): string;
   /** An ISO date "YYYY-MM-DD" in the locale's short form (UTC, so no timezone drift). */
   date(iso: string): string;
+  /** The currency spelled out in the invoice language, e.g. "Euro" - BT-5 as a word, not a code. */
+  currencyName(): string;
   /**
    * A service period (BG-14/BG-26) for the eye. One covering exactly one whole calendar month reads
    * AS that month ("Juni 2026") - the form §31 Abs. 4 UStDV allows in place of a day. The XML is
@@ -224,11 +246,14 @@ export function makeFormatters(locale: Locale = "de", currency: string): Formatt
   });
   const month = new Intl.DateTimeFormat(tag, { year: "numeric", month: "long", timeZone: "UTC" });
   const utc = (iso: string) => new Date(`${iso}T00:00:00Z`);
+  // Intl knows the names in every locale; a table of our own would be one more thing to keep right.
+  const currencyNames = new Intl.DisplayNames([tag], { type: "currency" });
   return {
     money: (n) => money.format(n),
     number: (n) => number.format(n),
     percent: (ratePercent) => percent.format(ratePercent / 100),
     date: (iso) => date.format(utc(iso)),
+    currencyName: () => currencyNames.of(currency) ?? currency,
     period: (start, end) =>
       wholeMonth(start, end)
         ? month.format(utc(start))

--- a/packages/e-invoice/src/i18n.ts
+++ b/packages/e-invoice/src/i18n.ts
@@ -33,6 +33,17 @@ export interface InvoiceLabels {
   dueDate: string;
   customerReference: string;
   orderNumber: string;
+  contractReference: string;
+  buyerVatId: string;
+  deliverTo: string;
+  payee: string;
+  paymentMeans: string;
+  itemNumber: string;
+  perQuantity: string;
+  page: string;
+  pageOf: string;
+  contactPerson: string;
+  email: string;
   vatId: string;
   taxNumber: string;
   registration: string;
@@ -66,6 +77,17 @@ const de: InvoiceLabels = {
   dueDate: "Fälligkeit",
   customerReference: "Kundenreferenz",
   orderNumber: "Bestellnummer",
+  contractReference: "Vertragsnummer",
+  buyerVatId: "USt-IdNr. Kunde",
+  deliverTo: "Lieferanschrift",
+  payee: "Zahlungsempfänger",
+  paymentMeans: "Zahlungsart",
+  itemNumber: "Art.-Nr.",
+  perQuantity: "je",
+  page: "Seite",
+  pageOf: "von",
+  contactPerson: "Ansprechpartner",
+  email: "E-Mail",
   vatId: "USt-IdNr",
   taxNumber: "Steuernr",
   registration: "Reg.",
@@ -99,6 +121,17 @@ const en: InvoiceLabels = {
   dueDate: "Due date",
   customerReference: "Customer reference",
   orderNumber: "Order no.",
+  contractReference: "Contract reference",
+  buyerVatId: "Buyer VAT ID",
+  deliverTo: "Delivery address",
+  payee: "Payee",
+  paymentMeans: "Payment method",
+  itemNumber: "Item no.",
+  perQuantity: "per",
+  page: "Page",
+  pageOf: "of",
+  contactPerson: "Contact",
+  email: "Email",
   vatId: "VAT ID",
   taxNumber: "Tax no.",
   registration: "Reg.",
@@ -132,6 +165,17 @@ const fr: InvoiceLabels = {
   dueDate: "Échéance",
   customerReference: "Référence client",
   orderNumber: "N° de commande",
+  contractReference: "Référence du contrat",
+  buyerVatId: "N° TVA client",
+  deliverTo: "Adresse de livraison",
+  payee: "Bénéficiaire",
+  paymentMeans: "Mode de paiement",
+  itemNumber: "Réf. article",
+  perQuantity: "par",
+  page: "Page",
+  pageOf: "sur",
+  contactPerson: "Interlocuteur",
+  email: "E-mail",
   vatId: "N° TVA",
   taxNumber: "N° fiscal",
   registration: "Immatriculation",

--- a/packages/e-invoice/src/index.ts
+++ b/packages/e-invoice/src/index.ts
@@ -8,7 +8,7 @@ export type { ComputedInvoice, VatBreakdownEntry } from "./compute.ts";
 export { toCII } from "./cii.ts";
 export { toUBL } from "./ubl.ts";
 export type { CiiProfile } from "./cii.ts";
-export { xrechnungProblems } from "./profile-check.ts";
+export { en16931Problems, xrechnungProblems } from "./profile-check.ts";
 export { bundledFonts } from "./fonts.ts";
 export { facturxXmp } from "./xmp.ts";
 export type { XmpOptions } from "./xmp.ts";

--- a/packages/e-invoice/src/profile-check.ts
+++ b/packages/e-invoice/src/profile-check.ts
@@ -5,6 +5,31 @@ import { Invoice } from "./invoice.ts";
 // the invoice ever reaches a KoSIT/Schematron gate that would reject it with a cryptic rule id.
 // This is a helper, not the authority: the official validator (KoSIT / veraPDF) stays the final gate.
 
+/**
+ * Problems that would make ANY profile fail, so they are checked whatever the user asked for.
+ *
+ * EN 16931 BR-AE-3 / BR-IC-3: an invoice carrying a reverse-charge (AE) or intra-community (K) VAT
+ * category must state BOTH VAT identifiers. German law says the same in §14a Abs. 1 UStG. Such a
+ * file is rejected by the official validator anyway - catching it here names the missing field
+ * instead of handing back a rule id.
+ */
+export function en16931Problems(invoice: Invoice): string[] {
+  const problems: string[] = [];
+  const categories = new Set(invoice.lines.map((l) => l.vat.category));
+  const needsBothVatIds = categories.has("AE") || categories.has("K");
+
+  if (needsBothVatIds) {
+    const which = categories.has("AE") ? "Reverse charge (AE)" : "Intra-community supply (K)";
+    if (!invoice.seller.vatId) {
+      problems.push(`${which} needs the seller VAT ID - set invoice.seller.vatId (BT-31).`);
+    }
+    if (!invoice.buyer.vatId) {
+      problems.push(`${which} needs the buyer VAT ID - set invoice.buyer.vatId (BT-48).`);
+    }
+  }
+  return problems;
+}
+
 /** Plain-language problems that would make `invoice` fail XRechnung. Empty array = good to go. */
 export function xrechnungProblems(invoice: Invoice): string[] {
   const problems: string[] = [];
@@ -12,6 +37,7 @@ export function xrechnungProblems(invoice: Invoice): string[] {
     if (!ok) problems.push(message);
   };
   const { seller, buyer, payment } = invoice;
+  problems.push(...en16931Problems(invoice));
 
   require(invoice.buyerReference, "XRechnung needs the Leitweg-ID - set invoice.buyerReference (BT-10).");
 

--- a/packages/e-invoice/src/profile-check.ts
+++ b/packages/e-invoice/src/profile-check.ts
@@ -1,4 +1,5 @@
 import { Invoice } from "./invoice.ts";
+import { computeInvoice } from "./compute.ts";
 
 // A friendly pre-flight for the XRechnung (German B2G) profile: it lists, in plain language, the
 // fields XRechnung makes mandatory on top of EN16931 - so the user gets actionable guidance BEFORE
@@ -8,25 +9,50 @@ import { Invoice } from "./invoice.ts";
 /**
  * Problems that would make ANY profile fail, so they are checked whatever the user asked for.
  *
- * EN 16931 BR-AE-3 / BR-IC-3: an invoice carrying a reverse-charge (AE) or intra-community (K) VAT
- * category must state BOTH VAT identifiers. German law says the same in §14a Abs. 1 UStG. Such a
- * file is rejected by the official validator anyway - catching it here names the missing field
- * instead of handing back a rule id.
+ * The wording of each rule below was read out of the vendored EN 16931 schematron, not recalled:
+ * the alternatives it allows are load-bearing. Requiring a VAT id where the standard also accepts a
+ * tax number would REJECT a valid invoice, and this check throws - a false positive costs the user
+ * more than a missing one.
  */
 export function en16931Problems(invoice: Invoice): string[] {
   const problems: string[] = [];
-  const categories = new Set(invoice.lines.map((l) => l.vat.category));
-  const needsBothVatIds = categories.has("AE") || categories.has("K");
+  const { seller, buyer } = invoice;
 
-  if (needsBothVatIds) {
-    const which = categories.has("AE") ? "Reverse charge (AE)" : "Intra-community supply (K)";
-    if (!invoice.seller.vatId) {
-      problems.push(`${which} needs the seller VAT ID - set invoice.seller.vatId (BT-31).`);
+  // The categories PRESENT, taken from the computed breakdown (BG-23) rather than from the lines:
+  // BR-AE-03 / BR-AE-04 apply to a document-level allowance or charge too, and those form their own
+  // breakdown group even when no line carries the category. Reading the breakdown is reading exactly
+  // what the rules are written against.
+  const categories = new Set(computeInvoice(invoice).vatBreakdown.map((v) => v.category));
+
+  // BR-AE-02/03/04: reverse charge. Both sides need AN identifier, and the standard accepts
+  // alternatives - the seller's tax number does, and so does the buyer's legal registration id.
+  if (categories.has("AE")) {
+    if (!seller.vatId && !seller.taxNumber) {
+      problems.push(
+        "Reverse charge (AE) needs a seller identifier - set invoice.seller.vatId (BT-31) or invoice.seller.taxNumber (BT-32).",
+      );
     }
-    if (!invoice.buyer.vatId) {
-      problems.push(`${which} needs the buyer VAT ID - set invoice.buyer.vatId (BT-48).`);
+    if (!buyer.vatId && !buyer.legalRegistrationId) {
+      problems.push(
+        "Reverse charge (AE) needs a buyer identifier - set invoice.buyer.vatId (BT-48) or invoice.buyer.legalRegistrationId (BT-47).",
+      );
     }
   }
+
+  // BR-IC-02: an intra-community supply is stricter - the buyer's VAT ID, and nothing else, will do.
+  if (categories.has("K")) {
+    if (!seller.vatId) {
+      problems.push(
+        "Intra-community supply (K) needs the seller VAT ID - set invoice.seller.vatId (BT-31).",
+      );
+    }
+    if (!buyer.vatId) {
+      problems.push(
+        "Intra-community supply (K) needs the buyer VAT ID - set invoice.buyer.vatId (BT-48); a legal registration id is not enough here.",
+      );
+    }
+  }
+
   // BR-E-10 / BR-AE-10 / BR-IC-10 / BR-G-10 / BR-O-10: every category that charges no (or zero) VAT
   // must SAY why. Without it the official validator rejects the file, and the paper is legally
   // deficient too - §14a Abs. 5 UStG prescribes the reverse-charge wording word for word.

--- a/packages/e-invoice/src/profile-check.ts
+++ b/packages/e-invoice/src/profile-check.ts
@@ -27,8 +27,25 @@ export function en16931Problems(invoice: Invoice): string[] {
       problems.push(`${which} needs the buyer VAT ID - set invoice.buyer.vatId (BT-48).`);
     }
   }
+  // BR-E-10 / BR-AE-10 / BR-IC-10 / BR-G-10 / BR-O-10: every category that charges no (or zero) VAT
+  // must SAY why. Without it the official validator rejects the file, and the paper is legally
+  // deficient too - §14a Abs. 5 UStG prescribes the reverse-charge wording word for word.
+  const given = invoice.vatExemptionReasons ?? {};
+  for (const category of NEEDS_EXEMPTION_REASON) {
+    if (!categories.has(category)) continue;
+    const reason = given[category];
+    if (!reason?.text && !reason?.code) {
+      problems.push(
+        `Category ${category} needs an exemption reason - set invoice.vatExemptionReasons.${category}.text (BT-120) or .code (BT-121).`,
+      );
+    }
+  }
+
   return problems;
 }
+
+/** The VAT categories EN 16931 requires an exemption reason for. `S` and `Z` are taxed, so not those. */
+const NEEDS_EXEMPTION_REASON = ["E", "AE", "K", "G", "O"] as const;
 
 /** Plain-language problems that would make `invoice` fail XRechnung. Empty array = good to go. */
 export function xrechnungProblems(invoice: Invoice): string[] {

--- a/packages/e-invoice/src/render.ts
+++ b/packages/e-invoice/src/render.ts
@@ -9,7 +9,7 @@ import { bundledFonts } from "./fonts.ts";
 import { facturxXmp } from "./xmp.ts";
 import { defaultInvoiceTemplate } from "./template.ts";
 import { InvoiceLabels, Locale, makeFormatters, resolveLabels } from "./i18n.ts";
-import { xrechnungProblems } from "./profile-check.ts";
+import { en16931Problems, xrechnungProblems } from "./profile-check.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ICC_PATH = path.resolve(__dirname, "..", "assets", "icc", "sRGB.icc");
@@ -47,6 +47,12 @@ export async function renderZugferd(
   options: RenderZugferdOptions = {},
 ): Promise<ZugferdResult> {
   const profile = options.profile ?? "en16931";
+  // Rules that hold in every profile (BR-AE-3 / BR-IC-3) - the official validator would reject the
+  // file anyway, so failing here names the missing field instead of returning a rule id later.
+  const universal = en16931Problems(invoice);
+  if (universal.length > 0 && profile !== "xrechnung") {
+    throw new Error(`Invoice is not EN 16931-ready:\n  - ${universal.join("\n  - ")}`);
+  }
   if (profile === "xrechnung") {
     // Catch the missing B2G-mandatory fields here, with guidance - not as a cryptic Schematron reject.
     const problems = xrechnungProblems(invoice);

--- a/packages/e-invoice/src/template.ts
+++ b/packages/e-invoice/src/template.ts
@@ -3,22 +3,24 @@ import {
   Column,
   Divider,
   Document,
+  PageBuilder,
   Expanded,
   Page,
   type PDFDocumentElement,
   type PDFElement,
   Row,
-  Spacer,
   Table,
   Text,
 } from "@jasy/pdf";
-import { Invoice, PostalAddress, Seller } from "./invoice.ts";
+import { Delivery, Invoice, PostalAddress, Seller } from "./invoice.ts";
 import { ComputedInvoice, VatBreakdownEntry } from "./compute.ts";
 import { Formatters, InvoiceLabels } from "./i18n.ts";
 
-// The built-in invoice layout: a complete, §14-UStG-aware invoice that renders EVERYTHING the
-// Invoice carries (legal mandatory fields + bank details + payment reference + legal footer), not
-// just a pretty subset. All visible chrome comes from `labels`, all amounts/dates from `fmt` (locale)
+// The built-in invoice layout: a complete, §14-UStG-aware invoice that renders everything the
+// Invoice carries. That is not a promise in prose - `tests/completeness.test.ts` sets EVERY field to
+// a marker and insists each one reaches the page, and the handful left off are listed there with a
+// reason. It matters because a ZUGFeRD file has two halves: a value that reaches the XML and not the
+// paper makes the document contradict itself, and no validator checks that. All visible chrome comes from `labels`, all amounts/dates from `fmt` (locale)
 // - the invoice DATA stays in the user's language. The recipient block sits where a DIN-5008 window
 // envelope expects it. Override the whole layout via `renderZugferd(invoice, { pdf })`.
 
@@ -70,9 +72,10 @@ export function defaultInvoiceTemplate(
       [
         recipientAndMeta(invoice, L, fmt),
         Text(`${L.invoice} ${invoice.number}`, { size: 21, bold: true, color: INK }),
+        ...deliverTo(invoice.delivery, L),
         ...notes(invoice),
         lineItemsTable(invoice, c, L, fmt),
-        totals(c, L, fmt, valueLine),
+        totals(invoice, c, L, fmt, valueLine),
         paymentPanel(invoice, L, fmt),
       ],
     ),
@@ -83,16 +86,21 @@ export function defaultInvoiceTemplate(
 function sellerHeader(seller: Seller, L: InvoiceLabels): PDFElement {
   const contact = [
     ...addressLines(seller.address),
+    seller.contact?.name,
     seller.contact?.phone && `${L.phone} ${seller.contact.phone}`,
     seller.contact?.email,
   ].filter((s): s is string => Boolean(s));
 
-  return Row({ align: "start" }, [
-    Column({ gap: 1 }, [
-      Text(seller.name, { size: 18, bold: true, color: BRAND }),
-      ...(seller.tradingName ? [Text(seller.tradingName, { size: 10, color: MUTED })] : []),
-    ]),
-    Spacer(),
+  // The name is Expanded, NOT shrink-wrapped: a long company name would otherwise take its natural
+  // single-line width and push the contact block clean off the page, where the viewer clips it.
+  return Row({ align: "start", gap: 16 }, [
+    Expanded(
+      { flex: 1 },
+      Column({ gap: 1 }, [
+        Text(seller.name, { size: 18, bold: true, color: BRAND }),
+        ...(seller.tradingName ? [Text(seller.tradingName, { size: 10, color: MUTED })] : []),
+      ]),
+    ),
     Box({ width: 220 }, [
       Column(
         { gap: 1 },
@@ -100,6 +108,24 @@ function sellerHeader(seller: Seller, L: InvoiceLabels): PDFElement {
       ),
     ]),
   ]);
+}
+
+/** A deliver-to party/address (BT-70 / BG-15) when goods go somewhere other than the buyer. */
+function deliverTo(delivery: Delivery | undefined, L: InvoiceLabels): PDFElement[] {
+  const lines = [
+    delivery?.recipientName,
+    ...(delivery?.address ? addressLines(delivery.address) : []),
+  ].filter((s): s is string => Boolean(s));
+
+  // ONE element, not loose lines: the page flow has a 16pt gap and would space the address apart.
+  return lines.length === 0
+    ? []
+    : [
+        Column({ gap: 1 }, [
+          Text(L.deliverTo, { size: 8, bold: true, color: MUTED }),
+          ...lines.map((l) => Text(l, { size: 9, color: INK })),
+        ]),
+      ];
 }
 
 // --- recipient address (left, window-envelope position) + invoice meta (right) ---
@@ -126,6 +152,14 @@ function recipientAndMeta(invoice: Invoice, L: InvoiceLabels, fmt: Formatters): 
     [L.dueDate, invoice.dueDate ? fmt.date(invoice.dueDate) : undefined],
     [L.customerReference, invoice.buyerReference],
     [L.orderNumber, invoice.purchaseOrderRef],
+    [L.contractReference, invoice.contractRef],
+    // BT-48 belongs on the paper (§14a Abs. 1 UStG for reverse charge), but NOT under the address:
+    // that block shows through a DIN 5008 window, which may hold nothing but the postal address.
+    [L.buyerVatId, buyer.vatId],
+    [L.registration, buyer.legalRegistrationId],
+    [L.contactPerson, buyer.contact?.name],
+    [L.phone, buyer.contact?.phone],
+    [L.email, buyer.contact?.email],
   ];
   const metaBox = Box({ bg: PANEL, padding: { x: 12, y: 10 }, radius: 4, width: 210 }, [
     Column(
@@ -161,15 +195,32 @@ function lineItemsTable(
     Text(s, { size: 9, bold: true, color: BRAND, align });
 
   const rows = invoice.lines.map((line, i) => {
+    const itemIds = [line.sellerItemId, line.buyerItemId, line.standardItemId]
+      .filter((s): s is string => Boolean(s))
+      .join(" · ");
+    // BT-97/BT-104: a discount has to say WHY. §14 Abs. 4 Nr. 7 wants an agreed reduction named.
+    const lineAdjustments = (line.allowancesCharges ?? []).map(
+      (ac) =>
+        `${ac.reason ?? (ac.isCharge ? L.charge : L.allowance)}  ${ac.isCharge ? "" : "-"}${fmt.money(ac.amount)}`,
+    );
+    const sub = (t: string) => Text(t, { size: 8, color: MUTED });
+
     const descr = Column({ gap: 1 }, [
       Text(line.name, { size: 9.5, color: INK }),
-      ...(line.description ? [Text(line.description, { size: 8, color: MUTED })] : []),
+      ...(line.description ? [sub(line.description)] : []),
+      ...(itemIds ? [sub(`${L.itemNumber} ${itemIds}`)] : []),
+      ...(line.note ? [sub(line.note)] : []), // BT-127
+      ...lineAdjustments.map(sub),
     ]);
     return [
       Text(line.id ?? String(i + 1), { size: 9.5, color: MUTED }),
       descr,
       right(`${fmt.number(line.quantity)} ${line.unit}`),
-      right(fmt.money(line.netUnitPrice)),
+      right(
+        line.priceBaseQuantity && line.priceBaseQuantity !== 1
+          ? `${fmt.money(line.netUnitPrice)} ${L.perQuantity} ${fmt.number(line.priceBaseQuantity)} ${line.unit}`
+          : fmt.money(line.netUnitPrice),
+      ),
       right(fmt.percent(line.vat.ratePercent ?? 0)),
       right(fmt.money(c.lineNets[i]), true),
     ];
@@ -195,6 +246,7 @@ function lineItemsTable(
 
 // --- totals + VAT breakdown, right-aligned ---
 function totals(
+  invoice: Invoice,
   c: ComputedInvoice,
   L: InvoiceLabels,
   fmt: Formatters,
@@ -205,8 +257,15 @@ function totals(
 
   if (hasDocAC) {
     lines.push(valueLine(L.subtotal, fmt.money(c.lineTotal)));
-    if (c.allowanceTotal > 0) lines.push(valueLine(L.allowance, `-${fmt.money(c.allowanceTotal)}`));
-    if (c.chargeTotal > 0) lines.push(valueLine(L.charge, fmt.money(c.chargeTotal)));
+    // One line EACH, carrying its reason (BT-97 / BT-104). Two anonymous sums hid why money moved.
+    for (const ac of invoice.allowancesCharges ?? []) {
+      lines.push(
+        valueLine(
+          ac.reason ?? (ac.isCharge ? L.charge : L.allowance),
+          `${ac.isCharge ? "" : "-"}${fmt.money(ac.amount)}`,
+        ),
+      );
+    }
   }
   lines.push(valueLine(L.netTotal, fmt.money(c.taxBasisTotal)));
 
@@ -242,17 +301,21 @@ function paymentPanel(invoice: Invoice, L: InvoiceLabels, fmt: Formatters): PDFE
     ...(invoice.dueDate
       ? [Text(`${L.payableBy} ${fmt.date(invoice.dueDate)}`, { size: 9, color: INK })]
       : []),
+    ...(p?.meansText ? [Text(`${L.paymentMeans}  ${p.meansText}`, { size: 9, color: INK })] : []),
     ...(p?.terms ? [Text(p.terms, { size: 9, color: MUTED })] : []),
   ];
   const right: PDFElement[] = [
     Text(L.bankDetails, { size: 10, bold: true, color: INK }),
+    ...(invoice.payeeName
+      ? [Text(`${L.payee}  ${invoice.payeeName}`, { size: 9, color: INK })]
+      : []),
     ...(p?.accountName ? [Text(p.accountName, { size: 9, color: INK })] : []),
     ...(p?.iban ? [Text(`IBAN  ${p.iban}`, { size: 9, color: INK })] : []),
     ...(p?.bic ? [Text(`BIC  ${p.bic}`, { size: 9, color: INK })] : []),
     Text(`${L.remittance}  ${reference}`, { size: 9, color: MUTED }),
   ];
 
-  return Box({ bg: PANEL, padding: { x: 14, y: 12 }, radius: 4 }, [
+  return Box({ bg: PANEL, padding: { x: 14, y: 12 }, radius: 4, keepTogether: true }, [
     Row({ gap: 24, align: "start" }, [
       Expanded({ flex: 1 }, Column({ gap: 2 }, left)),
       Expanded({ flex: 1 }, Column({ gap: 2 }, right)),
@@ -289,5 +352,12 @@ function legalFooter(seller: Seller, L: InvoiceLabels): PDFElement {
         seller.electronicAddress,
       ]),
     ]),
+    PageBuilder(({ pageNumber, pageCount }) =>
+      Text(`${L.page} ${pageNumber} ${L.pageOf} ${pageCount}`, {
+        size: 7.5,
+        color: MUTED,
+        align: "right",
+      }),
+    ),
   ]);
 }

--- a/packages/e-invoice/src/template.ts
+++ b/packages/e-invoice/src/template.ts
@@ -128,6 +128,26 @@ function deliverTo(delivery: Delivery | undefined, L: InvoiceLabels): PDFElement
       ];
 }
 
+/**
+ * One label/value line of the information block.
+ *
+ * A long value gets its OWN line. Side by side it would take its natural single-line width and run
+ * back over the label - and a real invoice number like "INV-MRHG2EXG-2026/012-SD" carries no space,
+ * so no line breaker can help: there is nowhere to break. Stacking gives it the full panel width.
+ */
+function metaRow(label: string, value: string): PDFElement {
+  if (value.length > 18) {
+    return Column({ gap: 0 }, [
+      Text(label, { size: 9, color: MUTED }),
+      Text(value, { size: 9, color: INK, bold: true, align: "right" }),
+    ]);
+  }
+  return Row({ gap: 6, align: "start" }, [
+    Expanded({ flex: 1 }, Text(label, { size: 9, color: MUTED })),
+    Text(value, { size: 9, color: INK, bold: true, align: "right" }),
+  ]);
+}
+
 // --- recipient address (left, window-envelope position) + invoice meta (right) ---
 function recipientAndMeta(invoice: Invoice, L: InvoiceLabels, fmt: Formatters): PDFElement {
   const { seller, buyer } = invoice;
@@ -166,12 +186,7 @@ function recipientAndMeta(invoice: Invoice, L: InvoiceLabels, fmt: Formatters): 
       { gap: 3 },
       meta
         .filter((m): m is [string, string] => Boolean(m[1]))
-        .map(([label, value]) =>
-          Row({}, [
-            Expanded({ flex: 1 }, Text(label, { size: 9, color: MUTED })),
-            Text(value, { size: 9, color: INK, bold: true, align: "right" }),
-          ]),
-        ),
+        .map(([label, value]) => metaRow(label, value)),
     ),
   ]);
 

--- a/packages/e-invoice/src/template.ts
+++ b/packages/e-invoice/src/template.ts
@@ -71,7 +71,11 @@ export function defaultInvoiceTemplate(
       },
       [
         recipientAndMeta(invoice, L, fmt),
-        Text(`${L.invoice} ${invoice.number}`, { size: 21, bold: true, color: INK }),
+        Text(`${invoice.type === 381 ? L.creditNote : L.invoice} ${invoice.number}`, {
+          size: 21,
+          bold: true,
+          color: INK,
+        }),
         ...deliverTo(invoice.delivery, L),
         ...notes(invoice),
         lineItemsTable(invoice, c, L, fmt),
@@ -269,22 +273,71 @@ function totals(
   }
   lines.push(valueLine(L.netTotal, fmt.money(c.taxBasisTotal)));
 
-  for (const v of c.vatBreakdown)
-    lines.push(valueLine(vatLabel(v, L, fmt), fmt.money(v.taxAmount)));
+  if (hasVatBreakdown(c)) {
+    lines.push(valueLine(L.vat, fmt.money(c.taxTotal)));
+  } else {
+    for (const v of c.vatBreakdown)
+      lines.push(valueLine(vatLabel(v, L, fmt), fmt.money(v.taxAmount)));
+  }
 
   lines.push(Divider({ color: HAIR, margin: { y: 2 } }));
   lines.push(valueLine(L.grandTotal, fmt.money(c.grandTotal), { strong: true, size: 11 }));
   if (c.paidAmount > 0) lines.push(valueLine(L.alreadyPaid, `-${fmt.money(c.paidAmount)}`));
   lines.push(valueLine(L.amountDue, fmt.money(c.duePayable), { strong: true, size: 12 }));
+  lines.push(
+    Text(`${L.amountsIn} ${fmt.currencyName()} (${invoice.currency})`, {
+      size: 7.5,
+      color: MUTED,
+      align: "right",
+    }),
+  );
 
+  return Row({ align: "start", gap: 16 }, [
+    Expanded({ flex: 1 }, Column({ gap: 2 }, vatBreakdown(c, L, fmt))),
+    Box({ width: 250 }, [Column({ gap: 3 }, lines)]),
+  ]);
+}
+
+/**
+ * The VAT breakdown (BG-23) as a block of its own, with each category's REASON directly beneath it.
+ *
+ * §14 Abs. 4 Nr. 8 UStG wants the rate and the tax amount on the entgelt; with two rates in play the
+ * running totals column cannot show the taxable base per rate, only the tax. A single ordinary rate
+ * needs none of this - the totals column already says everything - so the block appears only when it
+ * carries information: several rates, or a category (AE/K/E/…) whose exemption reason must be read.
+ */
+function vatBreakdown(c: ComputedInvoice, L: InvoiceLabels, fmt: Formatters): PDFElement[] {
   const exemptions = c.vatBreakdown
     .filter((v) => v.exemption?.text)
     .map((v) => Text(`${v.category}: ${v.exemption!.text}`, { size: 8, color: MUTED }));
 
-  return Row({ align: "start" }, [
-    Expanded({ flex: 1 }, Column({ gap: 2 }, exemptions)),
-    Box({ width: 250 }, [Column({ gap: 3 }, lines)]),
-  ]);
+  if (!hasVatBreakdown(c)) return exemptions;
+
+  const cell = (t: string, w: number, bold = false) =>
+    Box({ width: w }, [Text(t, { size: 8.5, color: bold ? INK : MUTED, bold, align: "right" })]);
+  const row = (label: string, base: string, tax: string, bold = false) =>
+    Row({ gap: 8, align: "start" }, [
+      Expanded({ flex: 1 }, Text(label, { size: 8.5, color: bold ? INK : MUTED, bold })),
+      cell(base, 74, bold),
+      cell(tax, 62, bold),
+    ]);
+
+  return [
+    Column({ gap: 3 }, [
+      Text(L.vatBreakdown, { size: 9, bold: true, color: INK }),
+      row("", L.taxableBase, L.taxAmount),
+      Divider({ color: HAIR }),
+      ...c.vatBreakdown.map((v) =>
+        row(vatLabel(v, L, fmt), fmt.money(v.taxableAmount), fmt.money(v.taxAmount), true),
+      ),
+      ...(exemptions.length > 0 ? [Box({ height: 2 }, []), ...exemptions] : []),
+    ]),
+  ];
+}
+
+/** Whether the breakdown earns its own block, rather than being said once in the totals column. */
+function hasVatBreakdown(c: ComputedInvoice): boolean {
+  return c.vatBreakdown.length > 1 || c.vatBreakdown.some((v) => v.category !== "S");
 }
 
 function vatLabel(v: VatBreakdownEntry, L: InvoiceLabels, fmt: Formatters): string {

--- a/packages/e-invoice/src/template.ts
+++ b/packages/e-invoice/src/template.ts
@@ -67,15 +67,11 @@ export function defaultInvoiceTemplate(
         gap: 16,
         // header (letterhead) + legal footer are page bands → they repeat on every physical page.
         header: Column({ gap: 8 }, [sellerHeader(seller, L), Divider({ color: HAIR })]),
-        footer: legalFooter(seller, L),
+        footer: legalFooter(invoice, L),
       },
       [
         recipientAndMeta(invoice, L, fmt),
-        Text(`${invoice.type === 381 ? L.creditNote : L.invoice} ${invoice.number}`, {
-          size: 21,
-          bold: true,
-          color: INK,
-        }),
+        Text(documentTitle(invoice, L), { size: 21, bold: true, color: INK }),
         ...deliverTo(invoice.delivery, L),
         ...notes(invoice),
         lineItemsTable(invoice, c, L, fmt),
@@ -377,7 +373,14 @@ function paymentPanel(invoice: Invoice, L: InvoiceLabels, fmt: Formatters): PDFE
 }
 
 // --- legal footer band: identity + tax ids + register + bank ---
-function legalFooter(seller: Seller, L: InvoiceLabels): PDFElement {
+/** "Rechnung RE-2026-118" / "Gutschrift …" - BT-3 decides the word (§14 Abs. 4 Nr. 10 UStG).
+ *  Exported because the heading and the page footer must never drift apart. */
+export function documentTitle(invoice: Invoice, L: InvoiceLabels): string {
+  return `${invoice.type === 381 ? L.creditNote : L.invoice} ${invoice.number}`;
+}
+
+function legalFooter(invoice: Invoice, L: InvoiceLabels): PDFElement {
+  const { seller } = invoice;
   const col = (items: (string | false | undefined)[]) =>
     Expanded(
       { flex: 1 },
@@ -406,7 +409,7 @@ function legalFooter(seller: Seller, L: InvoiceLabels): PDFElement {
       ]),
     ]),
     PageBuilder(({ pageNumber, pageCount }) =>
-      Text(`${L.page} ${pageNumber} ${L.pageOf} ${pageCount}`, {
+      Text(`${documentTitle(invoice, L)} · ${L.page} ${pageNumber} ${L.pageOf} ${pageCount}`, {
         size: 7.5,
         color: MUTED,
         align: "right",

--- a/packages/e-invoice/tests/completeness.test.ts
+++ b/packages/e-invoice/tests/completeness.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from "vitest";
+import { defaultInvoiceTemplate } from "../src/template";
+import { computeInvoice } from "../src/compute";
+import { resolveLabels, makeFormatters } from "../src/i18n";
+import { Invoice } from "../src/invoice";
+import { printedText } from "./support/printed";
+import { en16931Problems } from "../src/profile-check";
+import { renderZugferd } from "../src/render";
+
+/**
+ * Every field that reaches the XML must reach the PAPER.
+ *
+ * The defect this exists to prevent is a whole class, not one bug: data enters the model, the CII
+ * generator writes it, and the template quietly never shows it. A ZUGFeRD file whose two halves say
+ * different things is exactly what got four real invoices rejected - and NO validator catches it,
+ * because neither EN 16931 nor PDF/A has an opinion about what the picture contains.
+ *
+ * The invoice below sets EVERY optional field to a distinctive marker. Anything deliberately left
+ * off the page belongs in `NOT_PRINTED` with a reason - never silently.
+ */
+
+const maximal: Invoice = {
+  number: "RE-MARK-NUMBER",
+  issueDate: "2026-08-25",
+  type: 380,
+  currency: "EUR",
+  dueDate: "2026-09-08",
+  buyerReference: "MARK-BUYERREF",
+  purchaseOrderRef: "MARK-ORDERREF",
+  contractRef: "MARK-CONTRACTREF",
+  notes: ["MARK-DOCNOTE"],
+  seller: {
+    name: "MARK-SELLERNAME",
+    tradingName: "MARK-SELLERTRADING",
+    vatId: "MARK-SELLERVAT",
+    taxNumber: "MARK-SELLERTAXNO",
+    legalRegistrationId: "MARK-SELLERREG",
+    additionalLegalInfo: "MARK-SELLERLEGAL",
+    electronicAddress: "MARK-SELLEREADDR",
+    address: {
+      line1: "MARK-SELLERLINE1",
+      line2: "MARK-SELLERLINE2",
+      line3: "MARK-SELLERLINE3",
+      city: "MARK-SELLERCITY",
+      postCode: "11111",
+      subdivision: "MARK-SELLERSUB",
+      country: "DE",
+    },
+    contact: { name: "MARK-SELLERCONTACT", phone: "MARK-SELLERPHONE", email: "MARK-SELLERMAIL" },
+  },
+  buyer: {
+    name: "MARK-BUYERNAME",
+    tradingName: "MARK-BUYERTRADING",
+    vatId: "MARK-BUYERVAT",
+    legalRegistrationId: "MARK-BUYERREG",
+    electronicAddress: "MARK-BUYEREADDR",
+    address: {
+      line1: "MARK-BUYERLINE1",
+      line2: "MARK-BUYERLINE2",
+      line3: "MARK-BUYERLINE3",
+      city: "MARK-BUYERCITY",
+      postCode: "22222",
+      subdivision: "MARK-BUYERSUB",
+      country: "DE",
+    },
+    contact: { name: "MARK-BUYERCONTACT", phone: "MARK-BUYERPHONE", email: "MARK-BUYERMAIL" },
+  },
+  delivery: {
+    date: "2026-08-20",
+    recipientName: "MARK-DELIVERYTO",
+    address: {
+      line1: "MARK-DELIVERYLINE1",
+      city: "MARK-DELIVERYCITY",
+      postCode: "33333",
+      country: "DE",
+    },
+  },
+  period: { start: "2026-07-02", end: "2026-07-20" },
+  payeeName: "MARK-PAYEE",
+  lines: [
+    {
+      id: "MARK-LINEID",
+      name: "MARK-ITEMNAME",
+      description: "MARK-ITEMDESCR",
+      sellerItemId: "MARK-SELLERITEM",
+      buyerItemId: "MARK-BUYERITEM",
+      standardItemId: "MARK-GTIN",
+      quantity: 3,
+      unit: "C62",
+      netUnitPrice: 250,
+      priceBaseQuantity: 10,
+      vat: { category: "S", ratePercent: 19 },
+      period: { start: "2026-07-02", end: "2026-07-20" },
+      note: "MARK-LINENOTE",
+      allowancesCharges: [
+        {
+          isCharge: false,
+          amount: 5,
+          vat: { category: "S", ratePercent: 19 },
+          reason: "MARK-LINEALLOWANCE",
+        },
+      ],
+    },
+    {
+      name: "MARK-REVERSECHARGE",
+      quantity: 1,
+      unit: "C62",
+      netUnitPrice: 400,
+      vat: { category: "AE" },
+    },
+  ],
+  allowancesCharges: [
+    {
+      isCharge: false,
+      amount: 20,
+      vat: { category: "S", ratePercent: 19 },
+      reason: "MARK-DOCALLOWANCE",
+    },
+    {
+      isCharge: true,
+      amount: 15,
+      vat: { category: "S", ratePercent: 19 },
+      reason: "MARK-DOCCHARGE",
+    },
+  ],
+  vatExemptionReasons: { AE: { text: "MARK-EXEMPTTEXT", code: "MARK-EXEMPTCODE" } },
+  payment: {
+    meansCode: "58",
+    meansText: "MARK-MEANSTEXT",
+    reference: "MARK-PAYREF",
+    iban: "MARK-IBAN",
+    accountName: "MARK-ACCOUNTNAME",
+    bic: "MARK-BIC",
+    terms: "MARK-TERMS",
+  },
+  paidAmount: 100,
+};
+
+/** Deliberately absent from the page - each needs a reason, or it is a bug, not a decision. */
+const NOT_PRINTED: Record<string, string> = {
+  "MARK-EXEMPTCODE":
+    "BT-121 is a code-list id (VATEX-EU-AE) for machines; the human text BT-120 is printed",
+  "MARK-SELLEREADDR":
+    "BT-34 is a Peppol routing address, not correspondence - the contact email is printed",
+  "MARK-BUYEREADDR": "BT-49, same reason as BT-34",
+};
+
+describe("every field that reaches the XML reaches the paper", () => {
+  const text = printedText(
+    defaultInvoiceTemplate(
+      maximal,
+      computeInvoice(maximal),
+      resolveLabels("de"),
+      makeFormatters("de", "EUR"),
+    ),
+  ).join("\n");
+
+  const markers = JSON.stringify(maximal).match(/MARK-[A-Z0-9]+/g) ?? [];
+  const expected = [...new Set(markers)].filter((m) => !(m in NOT_PRINTED));
+
+  it("sets enough markers to be a real check", () => {
+    expect(expected.length).toBeGreaterThan(30);
+  });
+
+  it.each(expected)("prints %s", (marker) => {
+    expect(text).toContain(marker);
+  });
+
+  it("prints the price base quantity, or the arithmetic reads as wrong", () => {
+    // 3 x 250 per 10 units = 75, not 750. Without the base quantity the line looks miscalculated.
+    expect(text).toMatch(/10/);
+  });
+
+  it("keeps the deliberate omissions deliberate", () => {
+    for (const [marker, reason] of Object.entries(NOT_PRINTED)) {
+      expect(reason.length, `${marker} needs a reason`).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe("reverse charge without both VAT ids", () => {
+  // EN 16931 BR-AE-3 and §14a Abs. 1 UStG both want them. The official validator rejects such a
+  // file, so failing early with the field name beats handing the user a rule id.
+  const reverseCharge: Invoice = {
+    ...maximal,
+    lines: [
+      { name: "Beratung", quantity: 1, unit: "C62", netUnitPrice: 100, vat: { category: "AE" } },
+    ],
+  };
+
+  it("is accepted when both are set", () => {
+    expect(en16931Problems(reverseCharge)).toEqual([]);
+  });
+
+  it("names the BUYER id when it is missing", () => {
+    const missing = { ...reverseCharge, buyer: { ...reverseCharge.buyer, vatId: undefined } };
+    expect(en16931Problems(missing).join(" ")).toMatch(/buyer VAT ID.*BT-48/);
+  });
+
+  it("names the SELLER id when it is missing", () => {
+    const missing = { ...reverseCharge, seller: { ...reverseCharge.seller, vatId: undefined } };
+    expect(en16931Problems(missing).join(" ")).toMatch(/seller VAT ID.*BT-31/);
+  });
+
+  it("says nothing for an ordinary taxed invoice", () => {
+    const plain = {
+      ...reverseCharge,
+      lines: [{ ...reverseCharge.lines[0], vat: { category: "S" as const, ratePercent: 19 } }],
+    };
+    expect(en16931Problems({ ...plain, buyer: { ...plain.buyer, vatId: undefined } })).toEqual([]);
+  });
+
+  it("refuses to render one, rather than emitting a file that will be rejected", async () => {
+    const missing = { ...reverseCharge, buyer: { ...reverseCharge.buyer, vatId: undefined } };
+    await expect(renderZugferd(missing)).rejects.toThrow(/BT-48/);
+  });
+});

--- a/packages/e-invoice/tests/completeness.test.ts
+++ b/packages/e-invoice/tests/completeness.test.ts
@@ -215,3 +215,73 @@ describe("reverse charge without both VAT ids", () => {
     await expect(renderZugferd(missing)).rejects.toThrow(/BT-48/);
   });
 });
+
+describe("a credit note must not call itself an invoice", () => {
+  // BT-3 reaches the XML either way; the PAPER used to say "Rechnung" regardless. A document that
+  // names itself wrong is not a cosmetic problem - §14 Abs. 4 Nr. 10 UStG is about what it is called.
+  const titleOf = (invoice: Invoice, locale: "de" | "en" = "de") =>
+    printedText(
+      defaultInvoiceTemplate(
+        invoice,
+        computeInvoice(invoice),
+        resolveLabels(locale),
+        makeFormatters(locale, invoice.currency),
+      ),
+      // the bare number also appears in the information block - the TITLE is the one that prefixes it
+    ).find((t) => t !== invoice.number && t.endsWith(invoice.number));
+
+  it("says Gutschrift for type 381", () => {
+    expect(titleOf({ ...maximal, type: 381 })).toMatch(/^Gutschrift /);
+  });
+
+  it("still says Rechnung for type 380 and for no type at all", () => {
+    expect(titleOf({ ...maximal, type: 380 })).toMatch(/^Rechnung /);
+    expect(titleOf({ ...maximal, type: undefined })).toMatch(/^Rechnung /);
+  });
+
+  it("follows the locale", () => {
+    expect(titleOf({ ...maximal, type: 381 }, "en")).toMatch(/^Credit note /);
+  });
+});
+
+describe("a category that charges no VAT has to say why", () => {
+  // Without this we emitted a file the official validator rejects (BR-AE-10 and its siblings), with
+  // no warning at all. Verified against the vendored KoSIT/EN 16931 schematron.
+  const withCategory = (category: "E" | "AE" | "K" | "G" | "O" | "S" | "Z"): Invoice => ({
+    ...maximal,
+    vatExemptionReasons: undefined,
+    lines: [
+      {
+        name: "Leistung",
+        quantity: 1,
+        unit: "C62",
+        netUnitPrice: 100,
+        vat: category === "S" ? { category, ratePercent: 19 } : { category },
+      },
+    ],
+  });
+
+  it.each(["E", "AE", "K", "G", "O"] as const)("demands a reason for %s", (category) => {
+    expect(en16931Problems(withCategory(category)).join(" ")).toMatch(
+      new RegExp(`Category ${category} needs an exemption reason`),
+    );
+  });
+
+  it.each(["S", "Z"] as const)("demands nothing for %s, which is taxed", (category) => {
+    expect(en16931Problems(withCategory(category))).toEqual([]);
+  });
+
+  it("is satisfied by the text alone", () => {
+    const ok = { ...withCategory("E"), vatExemptionReasons: { E: { text: "§4 Nr. 21 UStG" } } };
+    expect(en16931Problems(ok)).toEqual([]);
+  });
+
+  it("is satisfied by the code alone", () => {
+    const ok = { ...withCategory("E"), vatExemptionReasons: { E: { code: "VATEX-EU-132" } } };
+    expect(en16931Problems(ok)).toEqual([]);
+  });
+
+  it("refuses to render one, rather than emitting a file the validator rejects", async () => {
+    await expect(renderZugferd(withCategory("AE"))).rejects.toThrow(/BT-120/);
+  });
+});

--- a/packages/e-invoice/tests/completeness.test.ts
+++ b/packages/e-invoice/tests/completeness.test.ts
@@ -178,41 +178,133 @@ describe("every field that reaches the XML reaches the paper", () => {
   });
 });
 
-describe("reverse charge without both VAT ids", () => {
-  // EN 16931 BR-AE-3 and §14a Abs. 1 UStG both want them. The official validator rejects such a
-  // file, so failing early with the field name beats handing the user a rule id.
-  const reverseCharge: Invoice = {
-    ...maximal,
-    lines: [
-      { name: "Beratung", quantity: 1, unit: "C62", netUnitPrice: 100, vat: { category: "AE" } },
-    ],
-  };
+describe("the identifiers a zero-VAT category demands", () => {
+  // The wording comes from the vendored schematron, not from memory - and the ALTERNATIVES matter.
+  // BR-AE-02/03/04 accept the seller's tax number and the buyer's legal registration id; BR-IC-02
+  // does not. Getting that wrong in a check that THROWS would reject perfectly valid invoices.
+  const bare = (category: "AE" | "K") =>
+    ({
+      ...maximal,
+      seller: { ...maximal.seller, vatId: undefined, taxNumber: undefined },
+      buyer: { ...maximal.buyer, vatId: undefined, legalRegistrationId: undefined },
+      allowancesCharges: undefined,
+      vatExemptionReasons: { [category]: { text: "Grund" } },
+      lines: [{ name: "Leistung", quantity: 1, unit: "C62", netUnitPrice: 100, vat: { category } }],
+    }) as Invoice;
 
-  it("is accepted when both are set", () => {
-    expect(en16931Problems(reverseCharge)).toEqual([]);
+  describe("reverse charge (AE)", () => {
+    it("names both sides when neither has any identifier", () => {
+      const problems = en16931Problems(bare("AE")).join(" ");
+      expect(problems).toMatch(/seller identifier.*BT-31.*BT-32/);
+      expect(problems).toMatch(/buyer identifier.*BT-48.*BT-47/);
+    });
+
+    it("accepts the seller's TAX NUMBER instead of a VAT id", () => {
+      const invoice = bare("AE");
+      const ok = {
+        ...invoice,
+        seller: { ...invoice.seller, taxNumber: "147/815/12345" },
+        buyer: { ...invoice.buyer, vatId: "ATU12345678" },
+      };
+      expect(en16931Problems(ok)).toEqual([]);
+    });
+
+    it("accepts the buyer's LEGAL REGISTRATION ID instead of a VAT id", () => {
+      const invoice = bare("AE");
+      const ok = {
+        ...invoice,
+        seller: { ...invoice.seller, vatId: "DE123456789" },
+        buyer: { ...invoice.buyer, legalRegistrationId: "FN 123456a" },
+      };
+      expect(en16931Problems(ok)).toEqual([]);
+    });
   });
 
-  it("names the BUYER id when it is missing", () => {
-    const missing = { ...reverseCharge, buyer: { ...reverseCharge.buyer, vatId: undefined } };
-    expect(en16931Problems(missing).join(" ")).toMatch(/buyer VAT ID.*BT-48/);
+  describe("intra-community supply (K) is stricter", () => {
+    it("will not take a legal registration id for the buyer", () => {
+      const invoice = bare("K");
+      const notEnough = {
+        ...invoice,
+        seller: { ...invoice.seller, vatId: "DE123456789" },
+        buyer: { ...invoice.buyer, legalRegistrationId: "FN 123456a" },
+      };
+      expect(en16931Problems(notEnough).join(" ")).toMatch(/buyer VAT ID.*BT-48/);
+    });
+
+    it("will not take a tax number for the seller", () => {
+      const invoice = bare("K");
+      const notEnough = {
+        ...invoice,
+        seller: { ...invoice.seller, taxNumber: "147/815/12345" },
+        buyer: { ...invoice.buyer, vatId: "ATU12345678" },
+      };
+      expect(en16931Problems(notEnough).join(" ")).toMatch(/seller VAT ID.*BT-31/);
+    });
+
+    it("is satisfied by both VAT ids", () => {
+      const invoice = bare("K");
+      const ok = {
+        ...invoice,
+        seller: { ...invoice.seller, vatId: "DE123456789" },
+        buyer: { ...invoice.buyer, vatId: "ATU12345678" },
+      };
+      expect(en16931Problems(ok)).toEqual([]);
+    });
   });
 
-  it("names the SELLER id when it is missing", () => {
-    const missing = { ...reverseCharge, seller: { ...reverseCharge.seller, vatId: undefined } };
-    expect(en16931Problems(missing).join(" ")).toMatch(/seller VAT ID.*BT-31/);
+  describe("a category that appears ONLY on a document allowance or charge", () => {
+    // BR-AE-03 / BR-AE-04 exist precisely for this: the category never touches a line, but it forms
+    // its own BG-23 group and the rule applies to it. Reading `invoice.lines` alone would miss it.
+    const onlyOnAdjustment = (isCharge: boolean): Invoice => ({
+      ...maximal,
+      seller: { ...maximal.seller, vatId: undefined, taxNumber: undefined },
+      buyer: { ...maximal.buyer, vatId: undefined, legalRegistrationId: undefined },
+      vatExemptionReasons: { AE: { text: "Reverse charge" } },
+      lines: [
+        {
+          name: "Leistung",
+          quantity: 1,
+          unit: "C62",
+          netUnitPrice: 100,
+          vat: { category: "S", ratePercent: 19 },
+        },
+      ],
+      allowancesCharges: [{ isCharge, amount: 10, vat: { category: "AE" }, reason: "Grund" }],
+    });
+
+    it.each([false, true])("is caught (isCharge=%s)", (isCharge) => {
+      expect(en16931Problems(onlyOnAdjustment(isCharge)).join(" ")).toMatch(
+        /Reverse charge \(AE\)/,
+      );
+    });
+
+    it("also demands its exemption reason", () => {
+      const noReason = { ...onlyOnAdjustment(false), vatExemptionReasons: undefined };
+      expect(en16931Problems(noReason).join(" ")).toMatch(/Category AE needs an exemption reason/);
+    });
   });
 
   it("says nothing for an ordinary taxed invoice", () => {
-    const plain = {
-      ...reverseCharge,
-      lines: [{ ...reverseCharge.lines[0], vat: { category: "S" as const, ratePercent: 19 } }],
+    const plain: Invoice = {
+      ...maximal,
+      allowancesCharges: undefined,
+      vatExemptionReasons: undefined,
+      buyer: { ...maximal.buyer, vatId: undefined, legalRegistrationId: undefined },
+      lines: [
+        {
+          name: "L",
+          quantity: 1,
+          unit: "C62",
+          netUnitPrice: 100,
+          vat: { category: "S", ratePercent: 19 },
+        },
+      ],
     };
-    expect(en16931Problems({ ...plain, buyer: { ...plain.buyer, vatId: undefined } })).toEqual([]);
+    expect(en16931Problems(plain)).toEqual([]);
   });
 
-  it("refuses to render one, rather than emitting a file that will be rejected", async () => {
-    const missing = { ...reverseCharge, buyer: { ...reverseCharge.buyer, vatId: undefined } };
-    await expect(renderZugferd(missing)).rejects.toThrow(/BT-48/);
+  it("refuses to render, rather than emitting a file that will be rejected", async () => {
+    await expect(renderZugferd(bare("AE"))).rejects.toThrow(/BT-48/);
   });
 });
 

--- a/packages/e-invoice/tests/completeness.test.ts
+++ b/packages/e-invoice/tests/completeness.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { defaultInvoiceTemplate } from "../src/template";
+import { defaultInvoiceTemplate, documentTitle } from "../src/template";
 import { computeInvoice } from "../src/compute";
 import { resolveLabels, makeFormatters } from "../src/i18n";
 import { Invoice } from "../src/invoice";
@@ -375,5 +375,32 @@ describe("a category that charges no VAT has to say why", () => {
 
   it("refuses to render one, rather than emitting a file the validator rejects", async () => {
     await expect(renderZugferd(withCategory("AE"))).rejects.toThrow(/BT-120/);
+  });
+});
+
+describe("every sheet names its own invoice", () => {
+  // Separate the pages - scanning, filing - and page two carries the totals, the VAT breakdown and
+  // the bank details with nothing to attach them to. The footer is a page band, so the title repeats
+  // on every physical page; that it is DRAWN there is measured on the rendered PDF, since a footer
+  // built by a PageBuilder does not exist until layout runs.
+  //
+  // What is pinned here is the string itself, which the heading and the footer share by construction.
+  it("names the document by its type", () => {
+    expect(documentTitle(maximal, resolveLabels("de"))).toBe(`Rechnung ${maximal.number}`);
+    expect(documentTitle({ ...maximal, type: 381 }, resolveLabels("de"))).toBe(
+      `Gutschrift ${maximal.number}`,
+    );
+    expect(documentTitle({ ...maximal, type: undefined }, resolveLabels("de"))).toBe(
+      `Rechnung ${maximal.number}`,
+    );
+  });
+
+  it("follows the locale", () => {
+    expect(documentTitle({ ...maximal, type: 381 }, resolveLabels("en"))).toBe(
+      `Credit note ${maximal.number}`,
+    );
+    expect(documentTitle({ ...maximal, type: 381 }, resolveLabels("fr"))).toBe(
+      `Avoir ${maximal.number}`,
+    );
   });
 });

--- a/packages/e-invoice/tests/support/printed.ts
+++ b/packages/e-invoice/tests/support/printed.ts
@@ -1,0 +1,43 @@
+import type { PDFElement } from "@jasy/pdf";
+
+/**
+ * Every string the template puts into the layout, in tree order.
+ *
+ * This reads the ELEMENT TREE, not the finished PDF: the drawn text uses a subsetted Identity-H
+ * font, so the content stream holds glyph ids, not readable characters. What is really drawn where
+ * is the job of `template-overflow.test.ts`; this answers the other half - does the value reach the
+ * page at all.
+ */
+export function printedText(root: PDFElement): string[] {
+  const out: string[] = [];
+  const seen = new Set<unknown>();
+
+  const walk = (node: unknown): void => {
+    if (!node || typeof node !== "object" || seen.has(node)) return;
+    seen.add(node);
+
+    const props = (node as { getProps?: () => { content?: unknown } }).getProps?.();
+    const content = props?.content;
+    if (typeof content === "string") out.push(content);
+    // A Text built from segments carries them instead of a plain string.
+    else if (Array.isArray(content)) {
+      for (const seg of content) {
+        if (
+          seg &&
+          typeof seg === "object" &&
+          typeof (seg as { text?: unknown }).text === "string"
+        ) {
+          out.push((seg as { text: string }).text);
+        }
+      }
+    }
+
+    for (const value of Object.values(node)) {
+      if (Array.isArray(value)) value.forEach(walk);
+      else walk(value);
+    }
+  };
+
+  walk(root);
+  return out;
+}

--- a/packages/e-invoice/tests/template-overflow.test.ts
+++ b/packages/e-invoice/tests/template-overflow.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { renderZugferd } from "../src/render";
+import { Invoice } from "../src/invoice";
+
+// Nothing may be DRAWN outside the page. A real invoice broke exactly here: a long company name took
+// its natural single-line width, pushed the contact block past the right edge, and the viewer clipped
+// the seller's own address mid-word. The document still validated - PDF/A says nothing about content
+// sitting off the MediaBox - so no validator would ever have caught it.
+//
+// The check reads the text-positioning operators out of an UNCOMPRESSED content stream, which is why
+// it sees what is really drawn rather than what the element tree intended.
+
+const A4_WIDTH = 595.28;
+const A4_HEIGHT = 841.89;
+
+const base: Invoice = {
+  number: "RE-1",
+  issueDate: "2026-08-25",
+  currency: "EUR",
+  dueDate: "2026-09-08",
+  seller: {
+    name: "Muster GmbH",
+    vatId: "DE123456789",
+    electronicAddress: "re@muster.de",
+    address: { line1: "Hauptstr. 1", city: "Berlin", postCode: "10115", country: "DE" },
+    contact: { name: "Erika Muster", phone: "+49 30 1234567", email: "kontakt@muster.de" },
+  },
+  buyer: {
+    name: "Kunde AG",
+    electronicAddress: "re@kunde.de",
+    address: { city: "München", postCode: "80331", country: "DE" },
+  },
+  lines: [
+    {
+      name: "Wartung",
+      quantity: 1,
+      unit: "C62",
+      netUnitPrice: 500,
+      vat: { category: "S", ratePercent: 19 },
+    },
+  ],
+  payment: { iban: "DE02120300000000202051" },
+};
+
+/** Where every text run starts, read from the raw (uncompressed) content stream. */
+async function drawnAt(invoice: Invoice): Promise<{ x: number; y: number }[]> {
+  const { bytes } = await renderZugferd(invoice, { compress: false });
+  const stream = Buffer.from(bytes).toString("latin1");
+  return [...stream.matchAll(/(-?[\d.]+) (-?[\d.]+) Td/g)].map((m) => ({
+    x: parseFloat(m[1]),
+    y: parseFloat(m[2]),
+  }));
+}
+
+const LONG_NAME = "Heuberger Softwareentwicklung und Digitale Medien GmbH & Co. KG";
+const LONG_STREET = "Bahnhofstrasse 145a, Gebaeude C, 3. Obergeschoss";
+
+describe("nothing is drawn outside the page", () => {
+  const cases: [string, Invoice][] = [
+    ["a plain invoice", base],
+    ["a long seller name", { ...base, seller: { ...base.seller, name: LONG_NAME } }],
+    [
+      "a long seller street",
+      {
+        ...base,
+        seller: { ...base.seller, address: { ...base.seller.address, line1: LONG_STREET } },
+      },
+    ],
+    ["a long buyer name", { ...base, buyer: { ...base.buyer, name: LONG_NAME } }],
+    [
+      "everything long at once",
+      {
+        ...base,
+        seller: {
+          ...base.seller,
+          name: LONG_NAME,
+          address: { ...base.seller.address, line1: LONG_STREET },
+        },
+        buyer: {
+          ...base.buyer,
+          name: LONG_NAME,
+          address: { ...base.buyer.address, line1: LONG_STREET },
+        },
+      },
+    ],
+  ];
+
+  it.each(cases)("keeps every text run inside the page: %s", async (_label, invoice) => {
+    const positions = await drawnAt(invoice);
+    expect(positions.length).toBeGreaterThan(10); // the stream really was read
+
+    const offPage = positions.filter(
+      (p) => p.x < 0 || p.x > A4_WIDTH || p.y < 0 || p.y > A4_HEIGHT,
+    );
+    expect(offPage).toEqual([]);
+  });
+});

--- a/packages/e-invoice/tests/template-overflow.test.ts
+++ b/packages/e-invoice/tests/template-overflow.test.ts
@@ -67,6 +67,8 @@ describe("nothing is drawn outside the page", () => {
       },
     ],
     ["a long buyer name", { ...base, buyer: { ...base.buyer, name: LONG_NAME } }],
+    // A real one, from a real invoice: no space anywhere, so no line breaker can help it.
+    ["an unbreakable invoice number", { ...base, number: "INV-MRHG2EXG-2026/012-SD" }],
     [
       "everything long at once",
       {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,6 +11,15 @@ set -e
 # Release order matters (dependency chain): release pdf first, then its dependents - e-invoice -> cli, vue,
 # and nuxt (which needs pdf AND vue) - so their `workspace:*` deps resolve to the versions just released.
 
+# After the release just run in the console (!!! change the versions !!!):
+# OTP=<6-digit OTP code
+
+# npm dist-tag add @jasy/pdf@1.0.0-alpha.9       latest --otp=$OTP
+# npm dist-tag add @jasy/e-invoice@1.0.0-alpha.8 latest --otp=$OTP
+# npm dist-tag add @jasy/cli@1.0.0-alpha.8       latest --otp=$OTP
+# npm dist-tag add @jasy/vue@1.0.0-alpha.9       latest --otp=$OTP
+# npm dist-tag add @jasy/nuxt@1.0.0-alpha.8      latest --otp=$OTP
+
 usage() {
   echo "Usage: ./scripts/release.sh <package> <version>"
   echo "  package: pdf | e-invoice | cli | vue | nuxt"


### PR DESCRIPTION
## Summary

Add missing fields, correct the address part, page numbers, layout issues in the ZUGFeRD template.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [ ] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added credit-note titles and improved invoice headings, footers, page numbering, and currency display.
  * Added detailed VAT breakdowns, taxable bases, tax amounts, and localized currency names in German, English, and French.
  * Added publicly available EN 16931 validation results.
* **Bug Fixes**
  * Strengthened validation for VAT categories, exemptions, reverse-charge details, and document-level adjustments.
  * Prevented incomplete invoices and long content from overflowing page boundaries.
* **Chores**
  * Enhanced post-release package publishing automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->