### PR TITLE
feat: add line period `BG 26`

### DIFF
--- a/packages/e-invoice/src/template.ts
+++ b/packages/e-invoice/src/template.ts
@@ -220,9 +220,18 @@ function lineItemsTable(
     );
     const sub = (t: string) => Text(t, { size: 8, color: MUTED });
 
+    // BG-26: the period THIS line covers, shown only when it says something the document period
+    // does not - repeating an identical span on every row is noise, and the header already has it.
+    const linePeriod =
+      line.period &&
+      (line.period.start !== invoice.period?.start || line.period.end !== invoice.period?.end)
+        ? `${L.servicePeriod} ${fmt.period(line.period.start, line.period.end)}`
+        : undefined;
+
     const descr = Column({ gap: 1 }, [
       Text(line.name, { size: 9.5, color: INK }),
       ...(line.description ? [sub(line.description)] : []),
+      ...(linePeriod ? [sub(linePeriod)] : []),
       ...(itemIds ? [sub(`${L.itemNumber} ${itemIds}`)] : []),
       ...(line.note ? [sub(line.note)] : []), // BT-127
       ...lineAdjustments.map(sub),

--- a/packages/e-invoice/tests/period.test.ts
+++ b/packages/e-invoice/tests/period.test.ts
@@ -177,3 +177,57 @@ describe("the period in the PRINTED invoice", () => {
     expect(text).toContain("May 2026");
   });
 });
+
+describe("the line period on the paper (BG-26)", () => {
+  // The document period was printed since 2026-08-25; a period on a single LINE reached the XML and
+  // stayed invisible. That is the half-a-document defect one level down - the case it matters for is
+  // an invoice whose lines cover DIFFERENT months, where the header period cannot speak for them.
+  const printed = (i: Invoice): string[] => {
+    const doc = defaultInvoiceTemplate(
+      i,
+      computeInvoice(i),
+      resolveLabels("de"),
+      makeFormatters("de", i.currency),
+    );
+    const out: string[] = [];
+    const seen = new Set<unknown>();
+    const walk = (node: unknown): void => {
+      if (!node || typeof node !== "object" || seen.has(node)) return;
+      seen.add(node);
+      const props = (node as { getProps?: () => { content?: unknown } }).getProps?.();
+      if (typeof props?.content === "string") out.push(props.content);
+      for (const value of Object.values(node)) {
+        if (Array.isArray(value)) value.forEach(walk);
+        else walk(value);
+      }
+    };
+    walk(doc);
+    return out;
+  };
+
+  const twoMonths: Invoice = {
+    ...base,
+    lines: [
+      { ...base.lines[0], name: "Mai", period: { start: "2026-05-01", end: "2026-05-31" } },
+      { ...base.lines[0], name: "Juni", period: { start: "2026-06-01", end: "2026-06-30" } },
+    ],
+  };
+
+  it("prints each line's own period", () => {
+    const text = printed(twoMonths).join("\n");
+    expect(text).toContain("Leistungszeitraum Mai 2026");
+    expect(text).toContain("Leistungszeitraum Juni 2026");
+  });
+
+  it("stays silent when the line repeats the document period", () => {
+    // Same span on the header and on every row is noise; the header already said it.
+    const same: Invoice = { ...base, period, lines: [{ ...base.lines[0], period }] };
+    const rows = printed(same).filter((t) => t.startsWith("Leistungszeitraum "));
+    expect(rows).toEqual([]); // the header uses a separate label/value pair, not this string
+  });
+
+  it("still prints a line period when the document has none", () => {
+    const lineOnly: Invoice = { ...base, lines: [{ ...base.lines[0], period }] };
+    expect(printed(lineOnly).join("\n")).toContain("Leistungszeitraum Mai 2026");
+  });
+});


### PR DESCRIPTION
## Summary

Now we can show period time ranges by line

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Line-item descriptions now show their service period when it differs from the invoice’s overall period.
  * Line-level periods are also displayed when no invoice-wide period is provided.
  * Matching periods remain omitted to keep invoices concise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->