### PR TITLE
feat: break a word that does not fit, instead of drawing over its neighbour

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -139,15 +139,18 @@ clockwise) and resolved against the box by the renderer.
 
 ### Content
 
-| Factory                            | Purpose                              | Key options                                                              | Maps to                   |
-| ---------------------------------- | ------------------------------------ | ------------------------------------------------------------------------ | ------------------------- |
-| `Text(content, opts)`              | `content` = string OR `Span[]`       | `size`, `font`, `bold`, `italic`, `color`, `align`, `orphans`, `widows`‡ | `TextElement`             |
-| `span(text, opts)`                 | inline run for mixed `Text`          | `size`, `font`, `bold`, `italic`, `color`                                | `TextSegment`             |
-| `Paragraph(content, opts)`         | `Text` with body defaults            | as `Text` (the same `TextOptions`, forwarded verbatim)                   | `TextElement`             |
-| `DefaultTextStyle(opts, children)` | cascaded text defaults for a subtree | `size`, `font`, `bold`, `italic`, `color`, `align`, `lineHeight`         | `DefaultTextStyleElement` |
-| `Image(src, opts)`                 | image                                | `fit`, **`radius`**, sizing†                                             | `ImageElement`            |
-| `Divider(opts?)`                   | horizontal rule                      | `color`, `thickness`, `margin`                                           | `LineElement`             |
-| `Line(opts)`                       | explicit line                        | `from`, `to`, `color`, `thickness`                                       | `LineElement`             |
+| Factory                            | Purpose                              | Key options                                                                                         | Maps to                   |
+| ---------------------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------- |
+| `Text(content, opts)`              | `content` = string OR `Span[]`       | `size`, `font`, `bold`, `italic`, `color`, `align`, `orphans`, `widows`‡, `breakWord`, `hyphenate`§ | `TextElement`             |
+| `span(text, opts)`                 | inline run for mixed `Text`          | `size`, `font`, `bold`, `italic`, `color`                                                           | `TextSegment`             |
+| `Paragraph(content, opts)`         | `Text` with body defaults            | as `Text` (the same `TextOptions`, forwarded verbatim)                                              | `TextElement`             |
+| `DefaultTextStyle(opts, children)` | cascaded text defaults for a subtree | `size`, `font`, `bold`, `italic`, `color`, `align`, `lineHeight`, `breakWord`, `hyphenate`§         | `DefaultTextStyleElement` |
+| `Image(src, opts)`                 | image                                | `fit`, **`radius`**, sizing†                                                                        | `ImageElement`            |
+| `Divider(opts?)`                   | horizontal rule                      | `color`, `thickness`, `margin`                                                                      | `LineElement`             |
+| `Line(opts)`                       | explicit line                        | `from`, `to`, `color`, `thickness`                                                                  | `LineElement`             |
+
+§ **A word that does not fit** - `breakWord` and `hyphenate`, both off by default. See 6c. They are
+read per `Text`, not per `span`, which is why `span` does not list them.
 
 ‡ **Page-break behaviour of a paragraph.**
 

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -215,6 +215,7 @@ Shipping the full model in v1 (foundation work) so we never re-touch alignment.
 | 2026-07-08 → 07-11 | `Rotated` / `RotatedBox`, navigation, page numbers, `letterSpacing`, text decoration, page-break control                 |
 | 2026-07            | AcroForm fields; `@jasy/pdf/edit` for reading and filling an existing form                                               |
 | 2026-08-01         | the sizing set (`aspectRatio`, `min`/`max`), `%` insets, `alignSelf`, per-corner `radius`, gradients, `orphans`/`widows` |
+| 2026-08-30         | hard line breaks (`\n`), `breakWord`, `hyphenate`                                                                        |
 
 The component set HAS grown - `Positioned`, `Rotated`, `RotatedBox`, `Link`, `Anchor`, `Bookmark`,
 `PageBuilder`, `PageBreak`, `keepTogether`, the seven form fields and the gradient constructors are all
@@ -222,6 +223,44 @@ new factories beside the original ones. What is unchanged is what the lock was a
 **shape** of the API (a factory taking one options object plus children), the alignment model below, and
 the meaning of every option that was already there. Nothing in the list above reopened a decision - it
 added next to one.
+
+## 6c. Text that does not fit — `breakWord` and `hyphenate` (2026-08-30)
+
+A `\n` in a string is a **hard line break**, in a plain `Text` and inside a `span`. It breaks even where
+there is room, because it is an instruction and not wrapping. `\r\n`, a lone `\r` and U+2028/U+2029 fold
+into it; a tab becomes a space. (CSS would collapse `\n` to a space; a text COMPONENT breaks on it, as
+Flutter's `Text` and react-pdf do.)
+
+A word **wider than its box** used to stay on its line and draw over whatever was beside it. Two layers
+handle it now, stacked the way CSS stacks them, and **both are off by default** - without them a too-wide
+word still overflows, exactly as in CSS.
+
+```ts
+// The floor: split where the box ends, no hyphen. This is what an e-mail address, an IBAN or an
+// invoice number needs - they have no valid hyphenation point anywhere.
+Text(customer.email, { breakWord: true });
+```
+
+```ts
+// Language-aware splitting, with a hyphen drawn at the break. Bring your own patterns:
+import { hyphenateSync } from "hyphen/de";
+
+const german = (word: string) => hyphenateSync(word).split("\u00AD");
+
+Text(bodyCopy, { hyphenate: german }); // or on Document / DefaultTextStyle, it inherits
+```
+
+That adapter is the whole integration - `hyphen` (ISC, no dependencies) returns the word with soft
+hyphens and we split on them. It is executed by `tests/unit/text/hyphenation-integration.test.ts`, so it
+cannot quietly stop working.
+
+**Why no patterns ship with jasy.** German alone is 732 KB, which is against the character of a library
+that sells on "no headless browser, no JVM". And hyphenating without being told the language is worse
+than not hyphenating: react-pdf does it with the patterns it bundles, which means German split by
+English rules. The default is a position, not a gap - _we do not hyphenate until you name the language._
+
+With both set, hyphenation is tried first and `breakWord` catches what it cannot split. Known deviation
+from CSS: both are read per `Text`, not per `span` (todo.md, ISSUE-13).
 
 ## 7. Decisions — LOCKED (2026-06-11)
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@jimp/types": "^1.6.0",
     "@types/node": "^25.9.3",
     "@vitest/coverage-v8": "^2.1.1",
+    "hyphen": "^1.14.1",
     "ncp": "^2.0.0",
     "oxfmt": "^0.55.0",
     "oxlint": "^1.70.0",

--- a/packages/e-invoice/src/template.ts
+++ b/packages/e-invoice/src/template.ts
@@ -131,20 +131,32 @@ function deliverTo(delivery: Delivery | undefined, L: InvoiceLabels): PDFElement
 /**
  * One label/value line of the information block.
  *
- * A long value gets its OWN line. Side by side it would take its natural single-line width and run
- * back over the label - and a real invoice number like "INV-MRHG2EXG-2026/012-SD" carries no space,
- * so no line breaker can help: there is nowhere to break. Stacking gives it the full panel width.
+ * These are §14 UStG mandatory particulars - an invoice number or a VAT ID that is cut off is not
+ * untidy, it is MISSING, and the recipient can lose the input-tax deduction over it. So the rule here
+ * is absolute: never truncate. A value that does not fit beside its label takes the next line and
+ * stays whole.
+ *
+ * It used to decide by counting characters (`value.length > 18`), which measures the wrong thing:
+ * eighteen narrow digits fit easily and eighteen capitals do not, so a wide value slipped past the
+ * threshold and drew straight over its label.
+ *
+ * The value is `Expanded` because a bare `Text` takes its natural SINGLE-LINE width - there is no
+ * maxWidth to break against, so it would run over the label however the row is configured. Given the
+ * leftover width it wraps at its spaces, both lines stay right-aligned on the same edge, and no
+ * threshold is needed at all.
+ *
+ * `breakWord` covers the rest: a value with no space at all - an e-mail address, an IBAN, an invoice
+ * number - has nowhere to break, and would otherwise draw straight over its label. Here completeness
+ * outranks typography: a §14 field split mid-word is readable, a field painted over its neighbour is
+ * not. Hyphenation is deliberately NOT switched on for these - one does not hyphenate an e-mail.
  */
 function metaRow(label: string, value: string): PDFElement {
-  if (value.length > 18) {
-    return Column({ gap: 0 }, [
-      Text(label, { size: 9, color: MUTED }),
-      Text(value, { size: 9, color: INK, bold: true, align: "right" }),
-    ]);
-  }
   return Row({ gap: 6, align: "start" }, [
-    Expanded({ flex: 1 }, Text(label, { size: 9, color: MUTED })),
-    Text(value, { size: 9, color: INK, bold: true, align: "right" }),
+    Text(label, { size: 9, color: MUTED }),
+    Expanded(
+      { flex: 1 },
+      Text(value, { size: 9, color: INK, bold: true, align: "right", breakWord: true }),
+    ),
   ]);
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^2.1.1
         version: 2.1.9(vitest@2.1.9(@types/node@25.9.3)(terser@5.48.0))
+      hyphen:
+        specifier: ^1.14.1
+        version: 1.14.1
       ncp:
         specifier: ^2.0.0
         version: 2.0.0
@@ -3417,6 +3420,9 @@ packages:
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
+
+  hyphen@1.14.1:
+    resolution: {integrity: sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -8674,6 +8680,8 @@ snapshots:
   httpxy@0.5.3: {}
 
   human-signals@5.0.0: {}
+
+  hyphen@1.14.1: {}
 
   ieee754@1.2.1: {}
 

--- a/src/lib/api/text.ts
+++ b/src/lib/api/text.ts
@@ -10,6 +10,7 @@ import { TextOverflow } from "../text/line-breaker.ts";
 import type { Direction } from "../text/bidi.ts";
 import { ResolvedTextStyle, type TextTransform } from "../text/text-style.ts";
 import { ColorInput, toColor } from "./color.ts";
+import type { Hyphenator } from "../text/word-splitting.ts";
 
 export type { TextOverflow };
 
@@ -44,6 +45,13 @@ export interface TextStyle {
   wordSpacing?: number;
   /** CSS `text-indent`, in points: how far the FIRST line of a paragraph starts in. */
   textIndent?: number;
+  /** Split a word that is wider than its box, anywhere, no hyphen (CSS `overflow-wrap:
+   *  break-word`). The floor under `hyphenate`: an e-mail, an IBAN or an invoice number has no
+   *  valid hyphenation point anywhere. Off by default - a too-wide word overflows, as in CSS. */
+  breakWord?: boolean;
+  /** Language-aware splitting: given a word, return its parts. A hyphen is drawn at the break.
+   *  Pluggable, so no pattern data ships here: pass `hyphen`, `hyphenopoly`, or your own. */
+  hyphenate?: Hyphenator;
   /** CSS `vertical-align` for a SPAN: raises a footnote marker or lowers an index. It shifts the
    *  baseline only - pass a smaller `size` too if you want the browser's `<sup>` look. */
   verticalAlign?: VerticalTextAlign;
@@ -185,6 +193,8 @@ export function Text(content: string | TextSegment[], opts: TextOptions = {}): T
     textTransform: opts.textTransform,
     wordSpacing: opts.wordSpacing,
     textIndent: opts.textIndent,
+    breakWord: opts.breakWord,
+    hyphenate: opts.hyphenate,
     role: opts.role,
   });
 }
@@ -220,6 +230,13 @@ export interface TextDefaults {
   wordSpacing?: number;
   /** CSS `text-indent`, in points: how far the FIRST line of a paragraph starts in. */
   textIndent?: number;
+  /** Split a word that is wider than its box, anywhere, no hyphen (CSS `overflow-wrap:
+   *  break-word`). The floor under `hyphenate`: an e-mail, an IBAN or an invoice number has no
+   *  valid hyphenation point anywhere. Off by default - a too-wide word overflows, as in CSS. */
+  breakWord?: boolean;
+  /** Language-aware splitting: given a word, return its parts. A hyphen is drawn at the break.
+   *  Pluggable, so no pattern data ships here: pass `hyphen`, `hyphenopoly`, or your own. */
+  hyphenate?: Hyphenator;
 }
 
 /** Maps the `Text`-style option names onto a partial engine `ResolvedTextStyle` (only the set
@@ -245,5 +262,7 @@ export function toTextStyleOverride(opts: TextDefaults): Partial<ResolvedTextSty
   if (opts.textTransform !== undefined) style.textTransform = opts.textTransform;
   if (opts.wordSpacing !== undefined) style.wordSpacing = opts.wordSpacing;
   if (opts.textIndent !== undefined) style.textIndent = opts.textIndent;
+  if (opts.breakWord !== undefined) style.breakWord = opts.breakWord;
+  if (opts.hyphenate !== undefined) style.hyphenate = opts.hyphenate;
   return style;
 }

--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -31,6 +31,7 @@ import { lineBoxForSegmentLine, lineBoxForString } from "../text/line-metrics.ts
 import { HorizontalAlignment, LayoutContext, SizedPDFElement } from "./pdf-element.ts";
 import { normalizeContent } from "../text/whitespace.ts";
 import { coverText } from "../text/glyph-coverage.ts";
+import type { Hyphenator } from "../text/word-splitting.ts";
 export interface TextSegment {
   content: string;
   fontStyle?: FontStyle;
@@ -107,6 +108,10 @@ interface TextElementParams {
   wordSpacing?: number;
   /** CSS `text-indent`, in points: how far the first line starts in. */
   textIndent?: number;
+  /** CSS `overflow-wrap: break-word` - split a word wider than its box, anywhere. */
+  breakWord?: boolean;
+  /** Language-aware splitting; a hyphen is drawn at the break. See text/word-splitting.ts. */
+  hyphenate?: Hyphenator;
   /** Accessibility role for the tagged structure tree (heading level or paragraph; default `"p"`). */
   role?: TextRole;
 }
@@ -141,6 +146,8 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
   private readonly rawTextTransform?: TextTransform;
   private readonly rawWordSpacing?: number;
   private readonly rawTextIndent?: number;
+  private readonly rawBreakWord?: boolean;
+  private readonly rawHyphenate?: Hyphenator;
 
   // Resolved style (raw -> inherited -> built-in default). Seeded to the built-in default in the
   // constructor so the element is self-sufficient, then refined against the cascade at layout time.
@@ -162,6 +169,8 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
   private textTransform!: TextTransform;
   private wordSpacing!: number;
   private textIndent!: number;
+  private breakWord!: boolean;
+  private hyphenate?: Hyphenator;
 
   private content: string | TextSegment[];
   private maxLines?: number;
@@ -191,6 +200,8 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     textTransform,
     wordSpacing,
     textIndent,
+    breakWord,
+    hyphenate,
     role,
   }: TextElementParams) {
     super({ x: 0, y: 0 });
@@ -211,6 +222,8 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     this.rawTextTransform = textTransform;
     this.rawWordSpacing = finitePoints(wordSpacing, "wordSpacing");
     this.rawTextIndent = finitePoints(textIndent, "textIndent");
+    this.rawBreakWord = breakWord;
+    this.rawHyphenate = hyphenate;
     // Control characters have no glyph and would be DRAWN as .notdef boxes; `\n` survives
     // because the breaker treats it as a hard break. See text/whitespace.ts.
     this.content = normalizeContent(content);
@@ -304,6 +317,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     return {
       wordSpacing: this.wordSpacing,
       indent: this.textIndent,
+      splitting: { breakWord: this.breakWord, hyphenate: this.hyphenate },
       // Justified lines may be squeezed to keep a word; every other alignment gets no slack.
       shrink: this.textAlignment === HorizontalAlignment.justify ? MAX_SPACE_SHRINK : 0,
     };
@@ -325,6 +339,8 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     this.textTransform = this.rawTextTransform ?? ts.textTransform;
     this.wordSpacing = this.rawWordSpacing ?? ts.wordSpacing;
     this.textIndent = this.rawTextIndent ?? ts.textIndent;
+    this.breakWord = this.rawBreakWord ?? ts.breakWord;
+    this.hyphenate = this.rawHyphenate ?? ts.hyphenate;
   }
 
   /**
@@ -567,6 +583,8 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       direction: this.direction,
       wordSpacing: this.wordSpacing,
       textIndent: this.textIndent,
+      breakWord: this.breakWord,
+      hyphenate: this.hyphenate,
       role: this.role,
     };
   }

--- a/src/lib/renderer/text-renderer.ts
+++ b/src/lib/renderer/text-renderer.ts
@@ -67,8 +67,16 @@ export class TextRenderer {
       return lines.length * box.height;
     }
 
-    // Segments: each line's box comes from the fonts actually on it.
-    const defaults = { fontFamily, fontSize, fontStyle, letterSpacing };
+    // Segments: each line's box comes from the fonts actually on it. `splitting` has to travel with
+    // them for the same reason `letterSpacing` does: it changes where a line ENDS, so leaving it out
+    // measures a paragraph at one line count and draws it at another.
+    const defaults = {
+      fontFamily,
+      fontSize,
+      fontStyle,
+      letterSpacing,
+      splitting: lineOptions.splitting,
+    };
     const lines = breakSegmentsIntoLines(
       content,
       defaults,
@@ -741,7 +749,13 @@ export class TextRenderer {
     // The seam flips the whole thing to PDF space. `letterSpacing` MUST be in the defaults so a span
     // that does not override it wraps and aligns with the element's spacing - the same defaults the
     // measure path (calculateTextHeight) uses, or segmented spaced text mis-wraps (measured != drawn).
-    const defaults = { fontFamily, fontSize, fontStyle, letterSpacing };
+    const defaults = {
+      fontFamily,
+      fontSize,
+      fontStyle,
+      letterSpacing,
+      splitting: { breakWord, hyphenate },
+    };
     let top = yPosition;
     // Materialised, because justification has to know which line is the LAST one of the paragraph.
     const segmentLines = [

--- a/src/lib/renderer/text-renderer.ts
+++ b/src/lib/renderer/text-renderer.ts
@@ -31,6 +31,7 @@ import {
   strikethroughStroke,
   underlineStroke,
 } from "../text/text-decoration.ts";
+import type { Hyphenator } from "../text/word-splitting.ts";
 
 export class TextRenderer {
   // Measuring only needs metrics, not the full object manager. (The render pass below
@@ -107,6 +108,8 @@ export class TextRenderer {
       direction,
       wordSpacing,
       textIndent,
+      breakWord,
+      hyphenate,
       role,
     } = textElement.getProps();
 
@@ -134,6 +137,8 @@ export class TextRenderer {
       direction,
       wordSpacing,
       textIndent,
+      breakWord,
+      hyphenate,
     );
 
     // Accessible tagging: this whole text block is one structure element (a paragraph P, or a heading
@@ -378,6 +383,8 @@ export class TextRenderer {
     direction: Direction = "ltr",
     wordSpacing = 0,
     textIndent = 0,
+    breakWord = false,
+    hyphenate?: Hyphenator,
   ): { runs: TextRun[]; links: Link[]; decorations: Line[] } {
     const runs: TextRun[] = [];
     // /Link annotation rects for any `href` spans, collected as we place segments. Empty for the
@@ -598,6 +605,7 @@ export class TextRenderer {
           wordSpacing,
           indent: textIndent,
           shrink: align === HorizontalAlignment.justify ? MAX_SPACE_SHRINK : 0,
+          splitting: { breakWord, hyphenate },
         },
       );
       // yPosition is the top of the text box (top-left). The line box seats its own baseline; lines

--- a/src/lib/text/line-breaker.ts
+++ b/src/lib/text/line-breaker.ts
@@ -142,7 +142,11 @@ export function wrapStringIntoLines(
       // A word too wide for the box, split into pieces that fit (hyphenation first, break-word as the
       // floor). Every piece but the last closes a line; the last carries on as an ordinary word. Off by
       // default, so a document that asks for neither reaches the untouched path below.
-      const split = splitLongWord(word, room, font, metrics, letterSpacing, splitting);
+      // The pieces land on lines that are NOT the first one whenever the current line is closed below,
+      // so they get the full box - `room` only loses the indent while we are genuinely still filling
+      // the indented first line.
+      const splitRoom = lines.length === 0 && currentLine === "" ? room : maxWidth;
+      const split = splitLongWord(word, splitRoom, font, metrics, letterSpacing, splitting);
       if (split) {
         if (currentLine !== "") lines.push(currentLine.trim());
         for (const piece of split.slice(0, -1)) lines.push(piece);

--- a/src/lib/text/line-breaker.ts
+++ b/src/lib/text/line-breaker.ts
@@ -2,6 +2,7 @@ import type { FontStyle } from "../utils/pdf-object-manager.ts";
 import type { FontMetrics } from "../utils/font-metrics.ts";
 import type { TextSegment } from "../elements/text-element.ts";
 import { runAdvance } from "./advance.ts";
+import { splitLongWord, type WordSplitting } from "./word-splitting.ts";
 
 /**
  * How far a JUSTIFIED line's spaces may be squeezed to keep one more word on it.
@@ -25,6 +26,8 @@ export interface LineOptions {
   indent?: number;
   /** How far a justified line's spaces may be squeezed to keep one more word (0 = not justified). */
   shrink?: number;
+  /** How a word wider than its box is split - hyphenation, break-word, or neither (the default). */
+  splitting?: WordSplitting;
 }
 
 /** Default font for segments that don't override it. */
@@ -34,6 +37,8 @@ export interface SegmentDefaults {
   fontStyle: FontStyle;
   /** Extra space after every glyph, in points; a segment may override it. Default 0. */
   letterSpacing?: number;
+  /** Same knobs as the string path - see `LineOptions.splitting`. */
+  splitting?: WordSplitting;
 }
 
 /** What happens to text beyond `maxLines`: `"clip"` drops it, `"ellipsis"` ends the last kept line
@@ -102,7 +107,7 @@ export function wrapStringIntoLines(
   letterSpacing = 0,
   options: LineOptions = {},
 ): string[] {
-  const { wordSpacing = 0, indent = 0, shrink = 0 } = options;
+  const { wordSpacing = 0, indent = 0, shrink = 0, splitting = {} } = options;
   let currentLine = "";
   let currentWidth = 0;
   let gaps = 0; // spaces on the current line, which is what a justified line can squeeze
@@ -134,6 +139,19 @@ export function wrapStringIntoLines(
       //
       // A single word wider than maxWidth still sits on its (empty) line and overflows, rather than
       // pushing a phantom empty line before it (which would over-count the height by a line).
+      // A word too wide for the box, split into pieces that fit (hyphenation first, break-word as the
+      // floor). Every piece but the last closes a line; the last carries on as an ordinary word. Off by
+      // default, so a document that asks for neither reaches the untouched path below.
+      const split = splitLongWord(word, room, font, metrics, letterSpacing, splitting);
+      if (split) {
+        if (currentLine !== "") lines.push(currentLine.trim());
+        for (const piece of split.slice(0, -1)) lines.push(piece);
+        currentLine = split[split.length - 1]!;
+        currentWidth = runAdvance(metrics, currentLine, font, letterSpacing);
+        gaps = 0;
+        return;
+      }
+
       const candidate = currentWidth + (spaceWidth + wordWidth);
 
       if (currentLine === "") {
@@ -226,6 +244,41 @@ export function breakSegmentsIntoLines(
 
       words.forEach((word, wordIndex) => {
         const wordWidth = runAdvance(metrics, word, font, letterSpacing);
+
+        // Same treatment as the string path: a word too wide for the box is split into pieces that fit.
+        // Each finished piece closes the line it sits on, keeping this segment's style.
+        const split = splitLongWord(
+          word,
+          maxWidth,
+          font,
+          metrics,
+          letterSpacing,
+          defaults.splitting ?? {},
+        );
+        if (split) {
+          // Close whatever is already on the line FIRST. The pieces were measured against the full box,
+          // not against what is left of this line - appending the first one put a line 80 wide into a
+          // 50 box, and reported 50, which is exactly why it went unnoticed. The string path has always
+          // pushed its current line before splitting; this is the same move.
+          if (width > 0) {
+            lines.push({ segments: lineSegments, width });
+            lineSegments = [{ ...segment, fontFamily: family, content: "" }];
+            combined = "";
+          }
+          for (const piece of split.slice(0, -1)) {
+            lineSegments[lineSegments.length - 1]!.content = piece;
+            // The width a line REPORTS is what alignment and line-metrics work from: measure it.
+            lines.push({
+              segments: lineSegments,
+              width: runAdvance(metrics, piece, font, letterSpacing),
+            });
+            lineSegments = [{ ...segment, fontFamily: family, content: "" }];
+          }
+          combined = split[split.length - 1]!;
+          width = runAdvance(metrics, combined, font, letterSpacing);
+          lineSegments[lineSegments.length - 1]!.content = combined;
+          return;
+        }
         // A space joins this word to what precedes it only INSIDE a segment; segments butt together
         // with nothing between them, which is what `span("a") + span("b")` draws.
         const joiner = wordIndex > 0 ? spaceWidth : 0;

--- a/src/lib/text/text-style.ts
+++ b/src/lib/text/text-style.ts
@@ -2,6 +2,7 @@ import { Color } from "../common/color.ts";
 import { FontStyle } from "../utils/pdf-object-manager.ts";
 import { HorizontalAlignment } from "../elements/pdf-element.ts";
 import type { Direction } from "./bidi.ts";
+import type { Hyphenator } from "./word-splitting.ts";
 
 /** CSS `text-transform`. `capitalize` upper-cases the first letter of every word, as CSS does. */
 export type TextTransform = "none" | "uppercase" | "lowercase" | "capitalize";
@@ -75,6 +76,14 @@ export interface ResolvedTextStyle {
   wordSpacing: number;
   /** CSS `text-indent`, in points: how far the FIRST line of a paragraph starts in. */
   textIndent: number;
+  /** CSS `overflow-wrap: break-word`: split a word that is wider than its box, anywhere, no hyphen.
+   *  The floor under `hyphenate` - it is what handles an e-mail, an IBAN or an invoice number, which
+   *  have no valid hyphenation point anywhere. Default off: a too-wide word overflows, as in CSS. */
+  breakWord: boolean;
+  /** Language-aware word splitting: given a word, return its parts (`["Rechts", "schutz", ...]`). A
+   *  hyphen is drawn at the break. Pluggable on purpose - no pattern data ships in this package, so
+   *  there is no licence question and nothing is added to a bundle that never asks for it. */
+  hyphenate?: Hyphenator;
 }
 
 /**
@@ -97,6 +106,8 @@ export const DEFAULT_TEXT_STYLE: ResolvedTextStyle = {
   textTransform: "none",
   wordSpacing: 0,
   textIndent: 0,
+  breakWord: false,
+  hyphenate: undefined,
 };
 
 /** Layers a partial override onto a complete style; an unset (undefined) field keeps the base. */
@@ -121,5 +132,7 @@ export function mergeTextStyle(
     textTransform: override.textTransform ?? base.textTransform,
     wordSpacing: override.wordSpacing ?? base.wordSpacing,
     textIndent: override.textIndent ?? base.textIndent,
+    breakWord: override.breakWord ?? base.breakWord,
+    hyphenate: override.hyphenate ?? base.hyphenate,
   };
 }

--- a/src/lib/text/word-splitting.ts
+++ b/src/lib/text/word-splitting.ts
@@ -1,0 +1,120 @@
+import type { FontStyle } from "../utils/pdf-object-manager.ts";
+import type { FontMetrics } from "../utils/font-metrics.ts";
+import { runAdvance } from "./advance.ts";
+
+/**
+ * What to do with a word that is wider than the box it has to fit in.
+ *
+ * Until now: nothing. It stayed on its line and drew straight over whatever was beside it - which on an
+ * invoice means a mandatory field (§14 UStG) painted across its own label. CSS overflows too, so this
+ * was never a bug; it was a missing feature, and it is the one that bites in German.
+ *
+ * Two layers, and they are NOT alternatives - CSS stacks them the same way:
+ *
+ *   1. HYPHENATION splits a word at a linguistically valid point and marks it with a hyphen:
+ *      `Rechtsschutzver-` / `sicherungsgesellschaften`. It needs language knowledge, which is why it is
+ *      PLUGGABLE rather than bundled - no pattern data in this package, no licence question, nothing
+ *      added to a bundle that never asks for it.
+ *   2. BREAK-WORD is the floor: split wherever the box ends, no hyphen. It is what handles the things
+ *      hyphenation cannot touch - an e-mail address, an IBAN, an invoice number. Those are single
+ *      "words" with no valid point anywhere, and they are exactly what an invoice is full of.
+ *
+ * With both on, hyphenation is tried first and break-word catches what it cannot split.
+ */
+
+/** Splits one word into its hyphenation points, e.g. `["Rechts", "schutz", "ver", "siche", ...]`. */
+export type Hyphenator = (word: string) => string[];
+
+export interface WordSplitting {
+  /** Language-aware splitting, with a hyphen at the break. Supply `hyphen`, `hyphenopoly`, your own. */
+  hyphenate?: Hyphenator;
+  /** Split anywhere as a last resort, without a hyphen. CSS `overflow-wrap: break-word`. */
+  breakWord?: boolean;
+}
+
+/** The hyphen actually drawn at a hyphenation break. U+002D, in every font we can encode. */
+const HYPHEN = "-";
+
+/**
+ * Splits `word` into pieces that each fit within `room`. Returns null when nothing applies - no
+ * splitting configured, or the word fits anyway - and the caller keeps its current behaviour, so a
+ * document that asks for neither is untouched.
+ *
+ * Every piece but the last is a finished line. The last is what carries on, so the caller keeps
+ * filling it as usual.
+ */
+export function splitLongWord(
+  word: string,
+  room: number,
+  font: { fontFamily: string; fontSize: number; fontStyle: FontStyle },
+  metrics: FontMetrics,
+  letterSpacing: number,
+  options: WordSplitting,
+): string[] | null {
+  const { hyphenate, breakWord } = options;
+  if (!hyphenate && !breakWord) return null;
+  if (room <= 0) return null;
+  if (runAdvance(metrics, word, font, letterSpacing) <= room) return null;
+
+  const width = (s: string) => runAdvance(metrics, s, font, letterSpacing);
+  const pieces: string[] = [];
+  let rest = word;
+
+  // Bounded by construction: every pass either emits a piece and shortens `rest`, or gives up.
+  while (width(rest) > room) {
+    // The layering: a linguistically valid split if one is offered and reaches far enough, otherwise
+    // the blunt one - which is what an e-mail address or an IBAN needs, having no valid point at all.
+    const head =
+      (hyphenate ? longestHyphenatedPrefix(rest, room, width, hyphenate) : null) ??
+      (breakWord ? longestPrefix(rest, room, width) : null);
+    // Nothing fits - not even one character, or hyphenation found nothing and break-word is off.
+    // Leave the remainder whole and let it overflow, exactly as before.
+    if (head === null) break;
+    pieces.push(head.text);
+    rest = head.rest;
+  }
+
+  if (pieces.length === 0) return null;
+  return [...pieces, rest];
+}
+
+/** The longest prefix that fits, plus a hyphen - split only where the hyphenator allows. */
+function longestHyphenatedPrefix(
+  word: string,
+  room: number,
+  width: (s: string) => number,
+  hyphenate: Hyphenator,
+): { text: string; rest: string } | null {
+  const parts = hyphenate(word);
+  if (parts.length < 2) return null;
+
+  let taken = "";
+  let best: { text: string; rest: string } | null = null;
+  for (let i = 0; i < parts.length - 1; i++) {
+    taken += parts[i];
+    // The hyphen has to fit too, or the line it lands on overflows by exactly that hyphen.
+    if (width(taken + HYPHEN) > room) break;
+    best = { text: taken + HYPHEN, rest: parts.slice(i + 1).join("") };
+  }
+  return best;
+}
+
+/** The longest prefix that fits, split anywhere. Code points, so an astral character stays whole. */
+function longestPrefix(
+  word: string,
+  room: number,
+  width: (s: string) => number,
+): { text: string; rest: string } | null {
+  const chars = [...word];
+  let taken = "";
+  let count = 0;
+  for (const char of chars) {
+    if (width(taken + char) > room) break;
+    taken += char;
+    count += 1;
+  }
+  // Not even one character fits: the box is narrower than a single glyph. Splitting cannot help, and
+  // looping on it would never terminate.
+  if (count === 0 || count === chars.length) return null;
+  return { text: taken, rest: chars.slice(count).join("") };
+}

--- a/tests/unit/text/hyphenation-integration.test.ts
+++ b/tests/unit/text/hyphenation-integration.test.ts
@@ -1,0 +1,73 @@
+import { createRequire } from "node:module";
+import { describe, it, expect } from "vitest";
+import { wrapStringIntoLines } from "../../../src/lib/text/line-breaker.ts";
+import { FontStyle } from "../../../src/lib/utils/pdf-object-manager.ts";
+import { testMetrics } from "../support/metrics.ts";
+
+// `hyphenate` is a HOOK: no pattern data ships in @jasy/pdf, because 732 KB for German alone is against
+// the character of a library whose selling point is "no headless browser, no JVM". The docs therefore
+// tell people to bring their own, and show one line to do it.
+//
+// This test runs THAT line, against the real package. A documented integration nobody executes is one
+// that rots: two minor versions later the README still shows it and it no longer works. `hyphen` is a
+// devDependency for exactly this - it reaches no user's bundle.
+//
+// Deliberately NOT what react-pdf does. It hyphenates with no configuration at all, using the patterns
+// it bundles - which means German split by English rules, and German is the market. The honest default
+// is not "hyphenate with whatever patterns are lying around" but "do not hyphenate until you name the
+// language".
+
+const require = createRequire(import.meta.url);
+const { hyphenateSync } = require("hyphen/de") as { hyphenateSync: (w: string) => string };
+
+/** The line that belongs in the docs, verbatim. `hyphen` marks its points with U+00AD. */
+const german = (word: string): string[] => hyphenateSync(word).split("\u00AD");
+
+const metrics = testMetrics();
+const FONT = { fontFamily: "Helvetica", fontSize: 12, fontStyle: FontStyle.Normal };
+
+describe("the documented one-line hyphenator adapter", () => {
+  it("produces exactly the shape `Hyphenator` expects", () => {
+    // The word from the roadmap card that started this.
+    expect(german("Rechtsschutzversicherungsgesellschaften")).toEqual([
+      "Rechts",
+      "schutz",
+      "ver",
+      "si",
+      "che",
+      "rungs",
+      "ge",
+      "sell",
+      "schaf",
+      "ten",
+    ]);
+  });
+
+  it("returns the word unsplit when there is nothing to split", () => {
+    // A one-syllable word has no point; the hook must cope, and `splitLongWord` treats it as "no help".
+    expect(german("Haus")).toEqual(["Haus"]);
+  });
+
+  it("actually breaks a line when passed to Text/the breaker", () => {
+    const lines = wrapStringIntoLines(
+      "Rechtsschutzversicherungsgesellschaften",
+      FONT.fontFamily,
+      FONT.fontSize,
+      FONT.fontStyle,
+      150,
+      metrics,
+      undefined,
+      undefined,
+      0,
+      { splitting: { hyphenate: german } },
+    );
+
+    expect(lines.length).toBeGreaterThan(1);
+    // Every line but the last ends with the hyphen that was drawn at the break.
+    for (const line of lines.slice(0, -1)) expect(line.endsWith("-")).toBe(true);
+    // And the text is intact: the pieces, minus those hyphens, spell the word again.
+    expect(lines.map((l) => l.replace(/-$/, "")).join("")).toBe(
+      "Rechtsschutzversicherungsgesellschaften",
+    );
+  });
+});

--- a/tests/unit/text/word-splitting.test.ts
+++ b/tests/unit/text/word-splitting.test.ts
@@ -4,6 +4,9 @@ import { wrapStringIntoLines, breakSegmentsIntoLines } from "../../../src/lib/te
 import { runAdvance } from "../../../src/lib/text/advance.ts";
 import { FontStyle } from "../../../src/lib/utils/pdf-object-manager.ts";
 import { testMetrics } from "../support/metrics.ts";
+import { Document, Page, Box, Text, Paragraph, span } from "../../../src/lib/api/index.ts";
+import { renderPdf } from "../../../src/lib/api/structure.ts";
+import type { PDFElement } from "../../../src/lib/elements/pdf-element.ts";
 
 // A word wider than its box used to stay on its line and draw over its neighbour. On an invoice that
 // means a §14 UStG mandatory field painted across its own label - not untidy, missing. Two layers now,
@@ -119,5 +122,48 @@ describe("both breakers agree, and report honest widths", () => {
     // ...and the width each line reports is the width it actually has.
     for (const line of spans)
       expect(line.width).toBeCloseTo(width(line.segments.map((s) => s.content).join("")), 5);
+  });
+});
+
+// The breakers were right and the RENDERER still did not split: `breakSegmentsIntoLines` is called from
+// three places, and two of them - the measure path and the draw path for styled spans - built their
+// `SegmentDefaults` without `splitting`. Same trap the comment beside `letterSpacing` already warns
+// about: an option that changes where a line ENDS has to travel with the defaults, or a paragraph is
+// measured at one line count and drawn at another. These go through the public API, which is the only
+// level that would have caught it.
+describe("through the public API", () => {
+  const lines = async (el: PDFElement) => {
+    const pdf = await renderPdf(Document([Page([el])]), { compress: false } as never);
+    const streams = (pdf.match(/stream\n([\s\S]*?)\nendstream/g) ?? []).join("");
+    return streams.match(/Td [^\n]*/g) ?? [];
+  };
+
+  it("splits inside a styled span, not only in a plain string", async () => {
+    const out = await lines(
+      Box({ width: 150 }, [
+        Paragraph([span("m.schellenberg@berghof-maschinenbau.example")], { breakWord: true }),
+      ]),
+    );
+    expect(out.length).toBeGreaterThan(1);
+  });
+
+  it("gives the pieces the full box, not the indented first-line width", async () => {
+    // The current line is closed before the pieces are emitted, so they land on lines that never had
+    // the indent taken out of them. Measuring against the reduced room made them needlessly short.
+    const indented = await lines(
+      Box({ width: 150 }, [
+        Text("kurz m.schellenberg@berghof-maschinenbau.example", {
+          breakWord: true,
+          textIndent: 40,
+        }),
+      ]),
+    );
+    const plain = await lines(
+      Box({ width: 150 }, [
+        Text("kurz m.schellenberg@berghof-maschinenbau.example", { breakWord: true }),
+      ]),
+    );
+    // Same number of lines either way: the indent shortens the FIRST line, not the split pieces.
+    expect(indented.length).toBe(plain.length);
   });
 });

--- a/tests/unit/text/word-splitting.test.ts
+++ b/tests/unit/text/word-splitting.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { splitLongWord } from "../../../src/lib/text/word-splitting.ts";
+import { wrapStringIntoLines, breakSegmentsIntoLines } from "../../../src/lib/text/line-breaker.ts";
+import { runAdvance } from "../../../src/lib/text/advance.ts";
+import { FontStyle } from "../../../src/lib/utils/pdf-object-manager.ts";
+import { testMetrics } from "../support/metrics.ts";
+
+// A word wider than its box used to stay on its line and draw over its neighbour. On an invoice that
+// means a §14 UStG mandatory field painted across its own label - not untidy, missing. Two layers now,
+// stacked as CSS stacks them: hyphenation first (a valid point, with a hyphen), break-word as the floor
+// (anywhere, no hyphen) for the things that have no valid point at all - an e-mail, an IBAN, an
+// invoice number.
+
+const metrics = testMetrics();
+const FONT = { fontFamily: "Helvetica", fontSize: 12, fontStyle: FontStyle.Normal };
+const width = (s: string) => runAdvance(metrics, s, FONT, 0);
+
+/** Stands in for a real pattern-based hyphenator: fixed chunks, so the split points are predictable. */
+const chunks = (size: number) => (word: string) =>
+  word.match(new RegExp(`.{1,${size}}`, "g")) ?? [word];
+
+const split = (word: string, room: number, options: object) =>
+  splitLongWord(word, room, FONT, metrics, 0, options);
+
+describe("when nothing applies", () => {
+  it("returns null with neither layer on - the old behaviour, untouched", () => {
+    expect(split("abcdefghijkl", 50, {})).toBeNull();
+  });
+
+  it("returns null for a word that already fits", () => {
+    expect(split("ab", 50, { breakWord: true })).toBeNull();
+  });
+
+  it("returns null when not even one character fits, instead of looping forever", () => {
+    // A box narrower than a single glyph: splitting cannot help, and taking zero characters per pass
+    // would never terminate.
+    expect(split("Wort", 1, { breakWord: true })).toBeNull();
+  });
+});
+
+describe("break-word", () => {
+  it("splits into pieces that each fit", () => {
+    const pieces = split("abcdefghijkl", 50, { breakWord: true })!;
+    expect(pieces).toEqual(["abcd", "efgh", "ijkl"]);
+    for (const piece of pieces) expect(width(piece)).toBeLessThanOrEqual(50);
+  });
+
+  it("keeps an astral character whole - it iterates code points, not code units", () => {
+    const pieces = split("a\u{1F600}\u{1F600}\u{1F600}b", 30, { breakWord: true });
+    // Whatever the split, no piece may contain half a surrogate pair.
+    for (const piece of pieces ?? []) expect(piece).toBe([...piece].join(""));
+  });
+});
+
+describe("hyphenation", () => {
+  it("splits only at offered points, and draws the hyphen", () => {
+    expect(split("aaaabbbbcccc", 60, { hyphenate: chunks(4) })).toEqual(["aaaa-", "bbbb-", "cccc"]);
+  });
+
+  it("counts the hyphen against the box, or the line overflows by exactly that hyphen", () => {
+    const pieces = split("aaaabbbbcccc", 60, { hyphenate: chunks(4) })!;
+    for (const piece of pieces) expect(width(piece)).toBeLessThanOrEqual(60);
+  });
+
+  it("gives up when the hyphenator offers nothing, leaving the word whole", () => {
+    expect(split("abcdefghijkl", 50, { hyphenate: (w: string) => [w] })).toBeNull();
+  });
+});
+
+describe("the two layers together", () => {
+  it("falls back to break-word for what hyphenation cannot split", () => {
+    // An e-mail has no valid hyphenation point anywhere - this is the case the invoice hits.
+    const pieces = split("abcdefghijkl", 50, {
+      hyphenate: (w: string) => [w],
+      breakWord: true,
+    })!;
+    expect(pieces).toEqual(["abcd", "efgh", "ijkl"]);
+  });
+
+  it("prefers a valid point over a blunt one when both could apply", () => {
+    const pieces = split("aaaabbbbcccc", 60, { hyphenate: chunks(4), breakWord: true })!;
+    expect(pieces[0]).toBe("aaaa-");
+  });
+});
+
+// The string breaker and the segment breaker have to agree. They did not: the segment path appended the
+// first piece to the line it was already filling, although the pieces were measured against the FULL
+// box - so a 50pt box got a line 80pt wide, and the line REPORTED 50, which is why nothing complained.
+describe("both breakers agree, and report honest widths", () => {
+  const MAX = 50;
+  const viaString = (text: string) =>
+    wrapStringIntoLines(
+      text,
+      FONT.fontFamily,
+      FONT.fontSize,
+      FONT.fontStyle,
+      MAX,
+      metrics,
+      undefined,
+      undefined,
+      0,
+      { splitting: { breakWord: true } },
+    );
+  const viaSpans = (text: string) =>
+    breakSegmentsIntoLines(
+      [{ content: text }],
+      { ...FONT, splitting: { breakWord: true } },
+      MAX,
+      metrics,
+    );
+
+  it.each(["ab abcdefghijkl", "abcdefghijkl", "ab cd", "aaaa bbbbbbbbbbbb cc"])("%j", (text) => {
+    const spans = viaSpans(text);
+    const lines = spans.map((l) => l.segments.map((s) => s.content).join(""));
+
+    expect(lines).toEqual(viaString(text));
+    // No line wider than the box it was broken against...
+    for (const line of lines) expect(width(line)).toBeLessThanOrEqual(MAX + 0.01);
+    // ...and the width each line reports is the width it actually has.
+    for (const line of spans)
+      expect(line.width).toBeCloseTo(width(line.segments.map((s) => s.content).join("")), 5);
+  });
+});


### PR DESCRIPTION
## Summary

Splitting, break a word... all this stuff

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional long-word breaking and hyphenation for text.
  * Supports hard line breaks, newline normalization, and tab-to-space conversion.
  * Preserves styling while splitting long words to fit available space.
  * Keeps text wrapping disabled by default unless configured.
  * Improved invoice layouts by preventing long values from overlapping labels.

* **Documentation**
  * Documented text wrapping, breaking, and hyphenation behavior.
  * Added the changes to the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->