### PR TITLE
feat: `Latin` ligatures, and kerning for shaped runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,9 +151,13 @@ constant** — that is exactly how `BASELINE_RATIO = 683/1000` happened. `letter
 element's constructor**. Everything else in jasy survives two copies of the library being loaded -
 building elements, layout, font metrics, byte writing. This one does not.
 
-And it fails **silently**: seventeen call sites read `const renderer = getRenderer(el); if (renderer)
-{ … }` with no `else`. Two instances → every element is skipped → a valid PDF with embedded fonts and
-a one-byte content stream. It is the same hazard as "two copies of React", minus the error message.
+It used to fail **silently**: seventeen call sites read `const renderer = getRenderer(el); if
+(renderer) { … }` with no `else`. Two instances → every element skipped → a valid PDF with embedded
+fonts and an empty content stream. Same hazard as "two copies of React", minus the error message.
+**Since 2026-08-26 it THROWS** (`MissingRendererError`), and the message names both causes - an
+unregistered element, or two copies of `@jasy/pdf`. The dead guards are gone. Note the corollary: the
+registry keys on the EXACT constructor, so a SUBCLASS of a registered element is not registered either
+and now throws - deliberate, because silently borrowing the parent's renderer would draw the parent.
 
 **This bit us for real** (2026-08-26, ISSUE-11): `@jasy/nuxt` injects auto-imports into the
 CONSUMER's code (`addServerImports({ from: "@jasy/pdf" })`), so under pnpm the consumer's route and
@@ -163,6 +167,13 @@ and the monorepo playground both hid it.
 **The rule that follows:** a package whose names you inject into someone else's code must be a
 **peer dependency**, or the injector must resolve the path itself and inject that. Exact version pins
 answer a different question - they fix VERSIONS, not module IDENTITY.
+
+**Fixed 2026-08-26**, and the mechanism was NOT what it looked like: there was one physical copy on
+disk. Nitro resolves the CONSUMER's server code and the module's own runtime separately, so one server
+build held two module records. `nitro.alias` on the resolved path pins them together; `@jasy/pdf` and
+`@jasy/vue` became peer dependencies of `@jasy/nuxt` so a consumer cannot install a second copy either.
+Two things measured along the way that are worth NOT re-testing: `nitro.externals.inline` does not fix
+it, and the `browser` field is not involved (the main entry has no browser condition).
 
 ### State threading — explicit, no singleton (since roadmap Phase 2)
 
@@ -249,7 +260,7 @@ rendering. This is the standing visual check; prefer it over one-off `scripts/ru
 - `pnpm test` — Vitest (watch). `pnpm exec vitest run` for a one-shot CI-style run.
   `pnpm run test:coverage` for coverage. Unit tests live in **`tests/unit/`**, mirroring the `src/lib/`
   structure (`tests/unit/{common,elements,renderer,utils}/…`). `src/` is pure production code — the
-  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **1066 tests, green** —
+  build (`tsconfig.json` includes only `src/**`) therefore keeps `dist/` test-free. **1407 tests, green** —
   what the root run covers: core 908, `@jasy/cli` 37, `@jasy/vue` 33, `@jasy/e-invoice` 38. `@jasy/nuxt`
   is excluded from it (`vitest.config.ts`) and runs on its own.
 - `pnpm run build` — `tsc` → `dist/`.
@@ -699,6 +710,69 @@ wordWidth > maxWidth` and forgot the SPACE that would join the word. It went uns
   the spec twice. Found while auditing four rejected SumUp invoices for Flo: none carried BT-72 or
   BG-14, the period was free text in the item description only.
 
+- ✅ **Text that cannot be drawn - the invisible class** (2026-08-30). A character with no glyph is
+  still ENCODED and DRAWN: it comes out as the font's `.notdef` box, and veraPDF rejects the file for
+  referencing it (ISO 19005-3, 6.2.11.8). Found on a real invoice whose service description carried its
+  own line breaks - the first string that reached jasy from OUTSIDE instead of being composed line by
+  line in our own code. Two separate faults, one symptom:
+  - **`\n` is a HARD line break** now (`text/whitespace.ts` + both breakers). It breaks even where there
+    is room, because it is an instruction, not wrapping. `\r\n`, a lone `\r`, `\n\r` and U+2028/U+2029
+    fold into it; a tab becomes a space; C0/C1, U+200B and U+FEFF are dropped. U+200C/D and U+200E/F are
+    KEPT - they drive Arabic shaping and bidi, and removing them would silently change correct text.
+    Normalised once in the `TextElement` constructor, the one place every text enters.
+  - **A code point no font can draw is removed and REPORTED** (`text/glyph-coverage.ts`). The check is
+    DYNAMIC against the resolved font - which characters are missing is a property of the FONT, not of
+    Unicode (`@jasy/e-invoice` embeds Liberation, whose gaps look arbitrary: "→" draws, "⇒" does not).
+    A plain equivalent is substituted where one means the same, because dropping U+2011 would turn
+    `E-Rechnung` into `ERechnung`. Everything else is dropped and handed back: `renderToBytes` gained
+    `onMissingGlyphs`, `renderZugferd` returns `droppedCharacters`. Deliberately no policy option - a
+    missing tick must never stop an invoice being produced, and a server log is not a report. Colour
+    emoji is exempt (`rendersAsEmoji`): it is missing from the text font by design.
+  - This REVERSED a documented decision: an undrawable code point used to stay and show `.notdef`,
+    "as a browser does". PDF/A forbids it, so completeness now outranks browser parity.
+
+- ✅ **A word that does not fit** (2026-08-30, `text/word-splitting.ts`). It used to stay on its line and
+  draw over its neighbour - on an invoice, a §14 UStG mandatory field painted across its own label.
+  Two layers, stacked as CSS stacks them, **both off by default** (so a too-wide word still overflows,
+  as in CSS, and every existing document is byte-identical):
+  - **`Text({ breakWord })`** splits where the box ends, no hyphen. The floor - it is what an e-mail, an
+    IBAN or an invoice number needs, having no valid hyphenation point anywhere.
+  - **`Text({ hyphenate })`** splits at a valid point and draws the hyphen. **A HOOK, not bundled data**:
+    German patterns alone are 732 KB, against the character of a library that sells on "no headless
+    browser, no JVM". `hyphen` (ISC) returns a word with soft hyphens, so the adapter is one line -
+    documented in `docs/api-design.md` 6c and EXECUTED by
+    `tests/unit/text/hyphenation-integration.test.ts`, because a documented integration nobody runs
+    rots. **No `@jasy/hyphenation` package is planned** (reasoning in `todo.md`).
+  - The default is a POSITION, not a gap: _we do not hyphenate until you name the language._ react-pdf
+    hyphenates with no configuration using the patterns it ships - German split by English rules, in the
+    market we care about.
+  - Both are read per `Text`, not per `span` - known deviation from CSS, `todo.md` ISSUE-13.
+  - The two traps this feature walked into, both caught by tests written afterwards: the SEGMENT breaker
+    appended the first piece to the line it was already filling (a 50pt box got an 80pt line, and
+    REPORTED 50), and the renderer built its `SegmentDefaults` without `splitting`, so spans never split
+    at all. Same shape as the older bugs - one path right, the other wrong; measured ≠ drawn.
+
+- ✅ **Latin ligatures, and kerning for a shaped run** (2026-08-30). `fi`, `fl`, `ffi` become one glyph,
+  read from the font's GSUB. **ON by default**, like kerning - the font's designer drew them, CSS and
+  every other renderer apply them, and nobody should need the word to get text set properly. An
+  inheritable text style, so `ligatures: false` opts out on a `Text`, a `DefaultTextStyle` subtree or the
+  whole `Document`. Embedded fonts only (the standard-14 have no GSUB). Internally the run carries a
+  FEATURE LIST, not a boolean - that is the seam a general `fontFeatures` would use; react-pdf exposes
+  `fontFeatureSettings`, which we do not copy because our GSUB reader only executes lookup types 1, 4
+  and 7 and promising the rest would be a promise we cannot keep.
+  - **It needed kerning for shaped runs first**, which did not exist: `getKernPairs` returned `[]` on
+    sight of a shaped run, because the pairs were keyed by unshaped glyphs and the `TJ` operand was
+    built from TEXT. Shipping `liga` on top of that would have traded every kern for a few ligatures -
+    DejaVu kerns `To` by **-170**. Now `getGlyphKernPairs` kerns the drawn glyphs (`getKerning` is glyph-
+    keyed anyway) and `PdfBackend.kernedArray` is generic over its unit, so ONE chunking serves
+    characters and glyph ids. Arabic gains the same, closing a `todo.md` gap.
+  - **Four bugs on the way, all the same shape - measured ≠ drawn.** The renderer shaped at DRAW time
+    with the default setting; the backend asked `getKernPairs` without the run's setting, so it shaped
+    internally and returned 11 pairs for 13 characters; `kernedArray` walks the GAPS, so a short list
+    silently dropped the last unit ("Verpflichtung" lost its g); and `encodeCustomText` shaped on its
+    own although the renderer had already decided. The unit tests were green through all of it - only
+    the rendered PDF showed it. `kernedArray` now throws on a length mismatch.
+
 Genuine remaining gaps / deferred:
 
 1. **Absolute positioning — Stages 1+2 built** (2026-06-21). CSS-style: `Box({ relative: true })` is a
@@ -769,13 +843,17 @@ starting work. Working agreement: **phase by phase, Flo approves each gate, Clau
 unprompted, comments English + sensible, don't break the font math.**
 
 Status: **LAUNCHED 2026-06-27**, still shipping alpha increments (no beta/rc/stable until the feature set is
-complete — see `todo.md`). All five packages live on npm; **published as of 2026-07-30: `@jasy/pdf`@alpha.7,
-`@jasy/zugferd`@alpha.4 (the OLD name - `@jasy/e-invoice` has not been published yet, see the rename
-below), `@jasy/cli`@alpha.6, `@jasy/vue`@alpha.7, `@jasy/nuxt`@alpha.6** (the alpha.7 cascade =
-page-break control — the termination guard, `PageBreak`, `breakBefore`/`breakAfter`, `keepTogether` — plus
-kerning turned on by default). Repo public + locked, full CI + changelog +
+complete — see `todo.md`). All five packages live on npm; **as of 2026-08-30: `@jasy/pdf`@alpha.12,
+`@jasy/e-invoice`@alpha.13, `@jasy/vue`@alpha.11, `@jasy/cli`@alpha.10, `@jasy/nuxt`@alpha.9**.
+
+**The release cascade is short now** (2026-08-30). `@jasy/vue`, `@jasy/e-invoice` and `@jasy/cli` depend
+on their siblings by RANGE (`workspace:^` → `^1.0.0-alpha.N`, which matches later alphas) instead of the
+exact pin `workspace:*` produced, and `@jasy/pdf` is a **peer** dependency of `@jasy/vue` as it already
+was of `@jasy/nuxt`. So a patch to the engine needs ONE release, not five - the others pull it on the
+user's next install. The peer part is not convenience: it is what stops a consumer ending up with two
+copies of the engine, which is the failure that made a Nuxt route render a blank page (ISSUE-11). Repo public + locked, full CI + changelog +
 bots in place (see Repo facts). The engine is **feature-complete for the alpha** — inheritance, `onOverflow`,
-custom formats, the line-breaker fixes; **1066 tests green** (the root run, i.e. everything but
+custom formats, the line-breaker fixes; **1407 tests green** (the root run, i.e. everything but
 `@jasy/nuxt`). The **landing**
 (`~/projects/jasy-landing` → **jasy.dev**) is built: showroom (12 cards), validator, docs, a home-page
 roadmap section, and a full **SEO + AI-discoverability layer** (OG image, JSON-LD, `robots.txt`,
@@ -812,8 +890,8 @@ more e-invoice profiles, framework bindings). See `todo.md` "⭐ Active" + "🔮
   Content 3). It has its **own CLAUDE.md + HARD RULES: never start/stop its dev server (Flo runs it),
   only Flo commits.** Package links there use **npmx.dev** (Daniel Roe's registry browser), not npmjs.com.
 - License MIT, author Florian Heuberger. **Launched 2026-06-27** (Bluesky + npm; landed with the Vue/Nuxt core
-  crew). npm current (alpha + latest dist-tags): `@jasy/pdf`@alpha.7, `@jasy/e-invoice`@alpha.4, `@jasy/cli`@alpha.6,
-  `@jasy/vue`@alpha.7, `@jasy/nuxt`@alpha.6 (released via `scripts/release.sh <pkg> <version>` → `<pkg>-v*` tag →
+  crew). npm current (alpha + latest dist-tags): `@jasy/pdf`@alpha.12, `@jasy/e-invoice`@alpha.13, `@jasy/cli`@alpha.10,
+  `@jasy/vue`@alpha.11, `@jasy/nuxt`@alpha.9 (released via `scripts/release.sh <pkg> <version>` → `<pkg>-v*` tag →
   CI publish; order matters, deps `workspace:*` pin EXACT so dependents re-release when a dep does; the tag also
   builds the GitHub Release notes via `scripts/gh-release.mjs` — changelogen groups + per-commit contributors,
   idempotent upsert). `latest` dist-tag points at the newest alpha per package.
@@ -823,10 +901,3 @@ more e-invoice profiles, framework bindings). See `todo.md` "⭐ Active" + "🔮
   SECURITY / LICENSE / issue+PR templates / FUNDING) all in. Branch `main`. Runtime deps: `jimp` (images), `fflate`
   (isomorphic deflate), `bidi-js` (UAX #9, behind the `text/bidi.ts` seam and slated to be replaced by
   our own - see `todo.md`); the old `reflect-metadata` DI is gone (decorator removed).
-
-## Open work — NOT pushed yet (ask Flo before pushing)
-
-- **`feat/line-period-bg-26`** — one commit, `010dcc3 feat: add line period (BG 26)`; **no upstream, never
-  pushed**. Contains the `@jasy/e-invoice` per-line invoicing period (BG-26) in `src/template.ts` +
-  `tests/period.test.ts`. Push/PR it only when Flo asks. Afterwards it releases as
-  `@jasy/e-invoice@1.0.0-alpha.11`.

--- a/src/lib/api/text.ts
+++ b/src/lib/api/text.ts
@@ -49,6 +49,9 @@ export interface TextStyle {
    *  break-word`). The floor under `hyphenate`: an e-mail, an IBAN or an invoice number has no
    *  valid hyphenation point anywhere. Off by default - a too-wide word overflows, as in CSS. */
   breakWord?: boolean;
+  /** The ligatures the font's designer drew (`fi`, `fl`, `ffi`). ON by default, like kerning -
+   *  `false` opts this text out. Embedded fonts only; the standard-14 have no GSUB. */
+  ligatures?: boolean;
   /** Language-aware splitting: given a word, return its parts. A hyphen is drawn at the break.
    *  Pluggable, so no pattern data ships here: pass `hyphen`, `hyphenopoly`, or your own. */
   hyphenate?: Hyphenator;
@@ -194,6 +197,7 @@ export function Text(content: string | TextSegment[], opts: TextOptions = {}): T
     wordSpacing: opts.wordSpacing,
     textIndent: opts.textIndent,
     breakWord: opts.breakWord,
+    ligatures: opts.ligatures,
     hyphenate: opts.hyphenate,
     role: opts.role,
   });
@@ -234,6 +238,9 @@ export interface TextDefaults {
    *  break-word`). The floor under `hyphenate`: an e-mail, an IBAN or an invoice number has no
    *  valid hyphenation point anywhere. Off by default - a too-wide word overflows, as in CSS. */
   breakWord?: boolean;
+  /** The ligatures the font's designer drew (`fi`, `fl`, `ffi`). ON by default, like kerning -
+   *  `false` opts this text out. Embedded fonts only; the standard-14 have no GSUB. */
+  ligatures?: boolean;
   /** Language-aware splitting: given a word, return its parts. A hyphen is drawn at the break.
    *  Pluggable, so no pattern data ships here: pass `hyphen`, `hyphenopoly`, or your own. */
   hyphenate?: Hyphenator;
@@ -263,6 +270,7 @@ export function toTextStyleOverride(opts: TextDefaults): Partial<ResolvedTextSty
   if (opts.wordSpacing !== undefined) style.wordSpacing = opts.wordSpacing;
   if (opts.textIndent !== undefined) style.textIndent = opts.textIndent;
   if (opts.breakWord !== undefined) style.breakWord = opts.breakWord;
+  if (opts.ligatures !== undefined) style.ligatures = opts.ligatures;
   if (opts.hyphenate !== undefined) style.hyphenate = opts.hyphenate;
   return style;
 }

--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -110,6 +110,8 @@ interface TextElementParams {
   textIndent?: number;
   /** CSS `overflow-wrap: break-word` - split a word wider than its box, anywhere. */
   breakWord?: boolean;
+  /** The font's ligatures; on unless switched off. */
+  ligatures?: boolean;
   /** Language-aware splitting; a hyphen is drawn at the break. See text/word-splitting.ts. */
   hyphenate?: Hyphenator;
   /** Accessibility role for the tagged structure tree (heading level or paragraph; default `"p"`). */
@@ -147,6 +149,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
   private readonly rawWordSpacing?: number;
   private readonly rawTextIndent?: number;
   private readonly rawBreakWord?: boolean;
+  private readonly rawLigatures?: boolean;
   private readonly rawHyphenate?: Hyphenator;
 
   // Resolved style (raw -> inherited -> built-in default). Seeded to the built-in default in the
@@ -170,6 +173,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
   private wordSpacing!: number;
   private textIndent!: number;
   private breakWord!: boolean;
+  private ligatures!: boolean;
   private hyphenate?: Hyphenator;
 
   private content: string | TextSegment[];
@@ -202,6 +206,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     textIndent,
     breakWord,
     hyphenate,
+    ligatures,
     role,
   }: TextElementParams) {
     super({ x: 0, y: 0 });
@@ -223,6 +228,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     this.rawWordSpacing = finitePoints(wordSpacing, "wordSpacing");
     this.rawTextIndent = finitePoints(textIndent, "textIndent");
     this.rawBreakWord = breakWord;
+    this.rawLigatures = ligatures;
     this.rawHyphenate = hyphenate;
     // Control characters have no glyph and would be DRAWN as .notdef boxes; `\n` survives
     // because the breaker treats it as a hard break. See text/whitespace.ts.
@@ -318,6 +324,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       wordSpacing: this.wordSpacing,
       indent: this.textIndent,
       splitting: { breakWord: this.breakWord, hyphenate: this.hyphenate },
+      ligatures: this.ligatures,
       // Justified lines may be squeezed to keep a word; every other alignment gets no slack.
       shrink: this.textAlignment === HorizontalAlignment.justify ? MAX_SPACE_SHRINK : 0,
     };
@@ -340,6 +347,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     this.wordSpacing = this.rawWordSpacing ?? ts.wordSpacing;
     this.textIndent = this.rawTextIndent ?? ts.textIndent;
     this.breakWord = this.rawBreakWord ?? ts.breakWord;
+    this.ligatures = this.rawLigatures ?? ts.ligatures;
     this.hyphenate = this.rawHyphenate ?? ts.hyphenate;
   }
 
@@ -584,6 +592,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       wordSpacing: this.wordSpacing,
       textIndent: this.textIndent,
       breakWord: this.breakWord,
+      ligatures: this.ligatures,
       hyphenate: this.hyphenate,
       role: this.role,
     };

--- a/src/lib/renderer/pdf-backend.ts
+++ b/src/lib/renderer/pdf-backend.ts
@@ -180,20 +180,32 @@ export class PdfBackend {
 
   /**
    * Builds the `[ ... ]` operand of a `TJ` from a run and its per-gap kern adjustments (em/1000, the
+   * sign the font declares). Generic over the UNIT so the same chunking serves both paths: characters
+   * for a WinAnsi run, glyph ids for a shaped one - a shaped run cannot be expressed as text.
    * sign the font declares - negative tightens). A `TJ` number moves the pen LEFT, so it is the
    * NEGATED kern. Consecutive un-kerned glyphs stay in one encoded chunk, so `[(T) 40 (otal)]` rather
    * than one chunk per glyph. `kerns[i]` is the adjustment AFTER code point `i`.
    */
-  static kernedArray(text: string, kerns: number[], encode: (chunk: string) => string): string {
-    const chars = [...text];
+  static kernedArray<T>(
+    units: readonly T[],
+    kerns: number[],
+    encode: (chunk: T[]) => string,
+  ): string {
+    if (units.length > 0 && kerns.length !== units.length - 1) {
+      // The loop walks the GAPS, so a short list would drop the units past it - silently, and only the
+      // last glyph, which is exactly the kind of thing nobody notices until a word reads wrong.
+      throw new Error(
+        `@jasy/pdf: ${kerns.length} kern adjustments for ${units.length} units - expected ${units.length - 1}.`,
+      );
+    }
     let out = "";
-    let chunk = chars[0] ?? "";
+    let chunk: T[] = units.length > 0 ? [units[0]!] : [];
     for (let i = 0; i < kerns.length; i++) {
       if (kerns[i] === 0) {
-        chunk += chars[i + 1];
+        chunk.push(units[i + 1]!);
       } else {
         out += encode(chunk) + ` ${-kerns[i]} `;
-        chunk = chars[i + 1];
+        chunk = [units[i + 1]!];
       }
     }
     return `[${out}${encode(chunk)}]`;
@@ -350,7 +362,7 @@ export class PdfBackend {
           : om.registerFont(node.fontFamily, node.fontStyle);
         const encode = (t: string): string =>
           isCustom
-            ? `<${om.encodeCustomText(node.fontFamily, t, node.fontStyle)}>`
+            ? `<${om.encodeCustomText(node.fontFamily, t, node.fontStyle, false)}>`
             : `(${PdfBackend.escapePdfString(t)})`;
         // A shaped run brings its own glyphs, already in drawing order - they cannot be derived from
         // the text here.
@@ -361,14 +373,26 @@ export class PdfBackend {
         // Kerning (if the document has it on): a `TJ` array with the font's per-pair adjustments
         // between glyph chunks, measured into the layout by the SAME numbers (runAdvance). A plain
         // `Tj` when the run has no kerning, byte-identical.
-        const kerns = om.kerningEnabled
-          ? om.getKernPairs(node.text, node.fontFamily, node.fontStyle)
-          : [];
-        const showOp = shapedHex
-          ? `<${shapedHex}> Tj`
-          : kerns.some((k) => k !== 0)
-            ? `${PdfBackend.kernedArray(node.text, kerns, encode)} TJ`
-            : `${encode(node.text)} Tj`;
+        // A shaped run brings its glyphs along, so kern those directly rather than re-deriving them
+        // from the text - which would also have to guess the run's ligature setting.
+        const kerns = !om.kerningEnabled
+          ? []
+          : node.glyphs && isCustom
+            ? om.getGlyphKernPairs(node.glyphs, node.fontFamily, node.fontStyle)
+            : // No glyph list means the run was NOT shaped, whatever the document asks for - so take the
+              // character path explicitly. Letting it default would shape here, and a pair count that
+              // does not match the character count silently drops the last one.
+              om.getKernPairs(node.text, node.fontFamily, node.fontStyle, false);
+        // A shaped run kerns too, over its SHAPED glyphs - `getKernPairs` returns one adjustment per
+        // adjacent drawn pair either way, so both paths use the same numbers `runAdvance` measured.
+        const showOp =
+          node.glyphs && isCustom
+            ? kerns.some((k) => k !== 0)
+              ? `${PdfBackend.kernedArray(node.glyphs, kerns, (chunk) => `<${om.registerGlyphs(node.fontFamily, chunk, node.fontStyle)}>`)} TJ`
+              : `<${shapedHex}> Tj`
+            : kerns.some((k) => k !== 0)
+              ? `${PdfBackend.kernedArray([...node.text], kerns, (chunk) => encode(chunk.join("")))} TJ`
+              : `${encode(node.text)} Tj`;
         // letterSpacing is the `Tc` operator: extra advance after EVERY glyph (an embedded
         // Identity-H font too - that is `Tw`, word spacing, which only touches single-byte code 32).
         const spacing = node.letterSpacing ? `${node.letterSpacing.toFixed(3)} Tc\n` : "";

--- a/src/lib/renderer/pdf-backend.ts
+++ b/src/lib/renderer/pdf-backend.ts
@@ -182,20 +182,22 @@ export class PdfBackend {
    * Builds the `[ ... ]` operand of a `TJ` from a run and its per-gap kern adjustments (em/1000, the
    * sign the font declares). Generic over the UNIT so the same chunking serves both paths: characters
    * for a WinAnsi run, glyph ids for a shaped one - a shaped run cannot be expressed as text.
-   * sign the font declares - negative tightens). A `TJ` number moves the pen LEFT, so it is the
-   * NEGATED kern. Consecutive un-kerned glyphs stay in one encoded chunk, so `[(T) 40 (otal)]` rather
-   * than one chunk per glyph. `kerns[i]` is the adjustment AFTER code point `i`.
+   * A `TJ` number moves the pen LEFT, so it is the NEGATED kern. Consecutive un-kerned glyphs stay in
+   * one encoded chunk, so `[(T) 40 (otal)]` rather than one chunk per glyph. `kerns[i]` is the
+   * adjustment AFTER code point `i`.
    */
   static kernedArray<T>(
     units: readonly T[],
     kerns: number[],
     encode: (chunk: T[]) => string,
   ): string {
-    if (units.length > 0 && kerns.length !== units.length - 1) {
+    const gaps = Math.max(0, units.length - 1);
+    if (kerns.length !== gaps) {
       // The loop walks the GAPS, so a short list would drop the units past it - silently, and only the
-      // last glyph, which is exactly the kind of thing nobody notices until a word reads wrong.
+      // last glyph, which is exactly the kind of thing nobody notices until a word reads wrong. An
+      // empty run has no gaps at all, so any adjustment for one is a disagreement too.
       throw new Error(
-        `@jasy/pdf: ${kerns.length} kern adjustments for ${units.length} units - expected ${units.length - 1}.`,
+        `@jasy/pdf: ${kerns.length} kern adjustments for ${units.length} units - expected ${gaps}.`,
       );
     }
     let out = "";

--- a/src/lib/renderer/text-renderer.ts
+++ b/src/lib/renderer/text-renderer.ts
@@ -76,6 +76,7 @@ export class TextRenderer {
       fontStyle,
       letterSpacing,
       splitting: lineOptions.splitting,
+      ligatures: lineOptions.ligatures,
     };
     const lines = breakSegmentsIntoLines(
       content,
@@ -118,6 +119,7 @@ export class TextRenderer {
       textIndent,
       breakWord,
       hyphenate,
+      ligatures,
       role,
     } = textElement.getProps();
 
@@ -147,6 +149,7 @@ export class TextRenderer {
       textIndent,
       breakWord,
       hyphenate,
+      ligatures,
     );
 
     // Accessible tagging: this whole text block is one structure element (a paragraph P, or a heading
@@ -393,6 +396,7 @@ export class TextRenderer {
     textIndent = 0,
     breakWord = false,
     hyphenate?: Hyphenator,
+    ligatures = true,
   ): { runs: TextRun[]; links: Link[]; decorations: Line[] } {
     const runs: TextRun[] = [];
     // /Link annotation rects for any `href` spans, collected as we place segments. Empty for the
@@ -585,7 +589,14 @@ export class TextRenderer {
       family: string,
       style: FontStyle,
     ): { text: string; glyphs?: number[] } => {
-      const shaped = objectManager.shapeText(part.logical, family, style);
+      // The run's OWN setting, not the default: measuring asked with it (`runAdvance` -> RunFont), and
+      // drawing has to ask the same question or the line is measured one width and drawn another.
+      const shaped = objectManager.shapeText(
+        part.logical,
+        family,
+        style,
+        ligatures ? undefined : [],
+      );
       if (!shaped) return { text: part.text };
       const ordered = part.rtl ? [...shaped].reverse() : shaped;
       return { text: part.logical, glyphs: ordered.map((g) => g.glyph) };
@@ -593,7 +604,7 @@ export class TextRenderer {
 
     // The advance the viewer will use: plain glyph widths (a `Tj` never kerns) plus one
     // `letterSpacing` per code point (the `Tc` operator), from the one shared `advance.ts` primitive.
-    const font = { fontFamily, fontSize, fontStyle };
+    const font = { fontFamily, fontSize, fontStyle, ligatures };
 
     // --- Plain string: one run per wrapped line. ---
     if (typeof content === "string") {
@@ -614,6 +625,7 @@ export class TextRenderer {
           indent: textIndent,
           shrink: align === HorizontalAlignment.justify ? MAX_SPACE_SHRINK : 0,
           splitting: { breakWord, hyphenate },
+          ligatures,
         },
       );
       // yPosition is the top of the text box (top-left). The line box seats its own baseline; lines
@@ -755,6 +767,7 @@ export class TextRenderer {
       fontStyle,
       letterSpacing,
       splitting: { breakWord, hyphenate },
+      ligatures,
     };
     let top = yPosition;
     // Materialised, because justification has to know which line is the LAST one of the paragraph.

--- a/src/lib/text/advance.ts
+++ b/src/lib/text/advance.ts
@@ -27,6 +27,9 @@ export interface RunFont {
   fontFamily: string;
   fontSize: number;
   fontStyle: FontStyle;
+  /** Whether this run gets the font's ligatures. Part of the FONT, because it changes which glyphs are
+   *  drawn and therefore how wide the run is - measuring without it would not match the drawing. */
+  ligatures?: boolean;
 }
 
 /** Number of Unicode code points (not UTF-16 units): an astral char is ONE, so it takes one
@@ -45,16 +48,24 @@ export function runAdvance(
   font: RunFont,
   letterSpacing = 0,
 ): number {
-  let advance = metrics.getStringWidth(text, font.fontFamily, font.fontSize, font.fontStyle);
+  let advance = metrics.getStringWidth(
+    text,
+    font.fontFamily,
+    font.fontSize,
+    font.fontStyle,
+    font.ligatures,
+  );
   if (letterSpacing !== 0) {
     // Per DRAWN glyph, which is what `Tc` applies to; only a ligature makes that differ.
     const glyphs =
-      metrics.shapedGlyphCount?.(text, font.fontFamily, font.fontStyle) ?? codePointCount(text);
+      metrics.shapedGlyphCount?.(text, font.fontFamily, font.fontStyle, font.ligatures) ??
+      codePointCount(text);
     advance += glyphs * letterSpacing;
   }
   if (metrics.kerningEnabled) {
     let units = 0;
-    for (const k of metrics.getKernPairs(text, font.fontFamily, font.fontStyle)) units += k;
+    for (const k of metrics.getKernPairs(text, font.fontFamily, font.fontStyle, font.ligatures))
+      units += k;
     advance += (units / 1000) * font.fontSize; // kern units are em/1000
   }
   return advance;

--- a/src/lib/text/line-breaker.ts
+++ b/src/lib/text/line-breaker.ts
@@ -28,6 +28,8 @@ export interface LineOptions {
   shrink?: number;
   /** How a word wider than its box is split - hyphenation, break-word, or neither (the default). */
   splitting?: WordSplitting;
+  /** Whether the run gets the font's ligatures. Changes which glyphs are drawn, hence the width. */
+  ligatures?: boolean;
 }
 
 /** Default font for segments that don't override it. */
@@ -39,6 +41,7 @@ export interface SegmentDefaults {
   letterSpacing?: number;
   /** Same knobs as the string path - see `LineOptions.splitting`. */
   splitting?: WordSplitting;
+  ligatures?: boolean;
 }
 
 /** What happens to text beyond `maxLines`: `"clip"` drops it, `"ellipsis"` ends the last kept line
@@ -107,13 +110,13 @@ export function wrapStringIntoLines(
   letterSpacing = 0,
   options: LineOptions = {},
 ): string[] {
-  const { wordSpacing = 0, indent = 0, shrink = 0, splitting = {} } = options;
+  const { wordSpacing = 0, indent = 0, shrink = 0, splitting = {}, ligatures } = options;
   let currentLine = "";
   let currentWidth = 0;
   let gaps = 0; // spaces on the current line, which is what a justified line can squeeze
   const lines: string[] = [];
 
-  const font = { fontFamily, fontSize, fontStyle };
+  const font = { fontFamily, fontSize, fontStyle, ligatures };
   // A `\n` is a HARD break: wrap each paragraph on its own, then cut. An EMPTY paragraph still has to
   // produce a line, or a deliberate blank line between two blocks silently disappears.
   text.split("\n").forEach((paragraph, paragraphIndex) => {
@@ -198,6 +201,7 @@ export function wrapStringIntoLines(
       metrics,
       letterSpacing,
       wordSpacing,
+      ligatures,
     );
   }
   return kept;
@@ -227,7 +231,12 @@ export function breakSegmentsIntoLines(
     const size = segment.fontSize || defaults.fontSize;
     const style = segment.fontStyle || defaults.fontStyle;
     const letterSpacing = segment.letterSpacing ?? defaults.letterSpacing ?? 0;
-    const font = { fontFamily: family, fontSize: size, fontStyle: style };
+    const font = {
+      fontFamily: family,
+      fontSize: size,
+      fontStyle: style,
+      ligatures: defaults.ligatures,
+    };
     const spaceWidth = runAdvance(metrics, " ", font, letterSpacing);
 
     // A `\n` inside a span is a HARD break, exactly as in the string path: close the line where it
@@ -356,8 +365,9 @@ function ellipsize(
   metrics: FontMetrics,
   letterSpacing = 0,
   wordSpacing = 0,
+  ligatures?: boolean,
 ): string {
-  const font = { fontFamily, fontSize, fontStyle };
+  const font = { fontFamily, fontSize, fontStyle, ligatures };
   // Measured through `singleLineWidth`, so the ellipsised line is judged by the same sum that decides
   // every other line - word-spacing included.
   const fits = (s: string): boolean =>

--- a/src/lib/text/shape.ts
+++ b/src/lib/text/shape.ts
@@ -36,16 +36,21 @@ const FORM_FEATURES: Record<JoiningForm, string> = {
 /**
  * Shape a run, or `undefined` when there is nothing to do - so untouched documents keep their path.
  *
- * `rlig` (required ligatures - lam-alef, wrong when drawn apart) but not `liga`, which is
- * discretionary and would change how existing Latin text looks.
+ * Arabic always applies `rlig` - lam-alef is wrong when drawn apart. Latin applies whatever `features`
+ * asks for, which is `liga` today; the list is the seam a general `fontFeatures` would use.
  */
 export function shapeRun(
   codePoints: readonly number[],
   font: ShapingFont,
+  features: readonly string[] = [],
 ): ShapedGlyph[] | undefined {
-  if (!needsJoining(codePoints)) return undefined;
   const gsub = font.gsub();
-  if (!gsub || !gsub.hasScript("arab")) return undefined;
+  if (!gsub) return undefined;
+  if (!needsJoining(codePoints)) {
+    // Latin: no joining, only the substitutions the caller asked for.
+    return features.length > 0 ? shapeLatin(codePoints, font, gsub, features) : undefined;
+  }
+  if (!gsub.hasScript("arab")) return undefined;
 
   const forms = joiningForms(codePoints);
   let glyphs: ShapedGlyph[] = codePoints.map((cp, i) => {
@@ -65,13 +70,42 @@ export function shapeRun(
     return { glyph, advance: font.getAdvanceWidth(glyph), codePoints: [cp] };
   });
 
-  glyphs = applyLigatures(glyphs, gsub, font);
+  glyphs = applyLigatures(glyphs, gsub, font, "arab", "rlig");
   return glyphs;
 }
 
-/** Collapse required ligatures, longest match first, carrying every component's code points along. */
-function applyLigatures(glyphs: ShapedGlyph[], gsub: GsubTable, font: ShapingFont): ShapedGlyph[] {
-  const lookups = gsub.lookups("arab", "rlig");
+/**
+ * Latin: no joining, only ligatures. Returns undefined when the font offers none, so a document that
+ * asks for them but uses a font without them keeps the plain path and stays byte-identical.
+ */
+function shapeLatin(
+  codePoints: readonly number[],
+  font: ShapingFont,
+  gsub: GsubTable,
+  features: readonly string[],
+): ShapedGlyph[] | undefined {
+  if (!gsub.hasScript("latn")) return undefined;
+  const wanted = features.filter((f) => gsub.lookups("latn", f).length > 0);
+  if (wanted.length === 0) return undefined;
+  const plain = codePoints.map((cp) => {
+    const glyph = font.getGlyphIndex(cp);
+    return { glyph, advance: font.getAdvanceWidth(glyph), codePoints: [cp] };
+  });
+  let shaped = plain;
+  for (const feature of wanted) shaped = applyLigatures(shaped, gsub, font, "latn", feature);
+  // Nothing merged: hand back undefined so the caller measures and draws the untouched run.
+  return shaped.length === plain.length ? undefined : shaped;
+}
+
+/** Collapse ligatures, longest match first, carrying every component's code points along. */
+function applyLigatures(
+  glyphs: ShapedGlyph[],
+  gsub: GsubTable,
+  font: ShapingFont,
+  script: string,
+  feature: string,
+): ShapedGlyph[] {
+  const lookups = gsub.lookups(script, feature);
   if (lookups.length === 0) return glyphs;
 
   const ids = glyphs.map((g) => g.glyph);

--- a/src/lib/text/text-style.ts
+++ b/src/lib/text/text-style.ts
@@ -76,6 +76,10 @@ export interface ResolvedTextStyle {
   wordSpacing: number;
   /** CSS `text-indent`, in points: how far the FIRST line of a paragraph starts in. */
   textIndent: number;
+  /** The ligatures the font's designer drew (`fi`, `fl`, `ffi`), from its GSUB. ON, like kerning: CSS,
+   *  browsers and every other renderer apply them, and nobody should need the word to get text set
+   *  properly. `false` opts a document, a subtree or one `Text` out. Embedded fonts only. */
+  ligatures: boolean;
   /** CSS `overflow-wrap: break-word`: split a word that is wider than its box, anywhere, no hyphen.
    *  The floor under `hyphenate` - it is what handles an e-mail, an IBAN or an invoice number, which
    *  have no valid hyphenation point anywhere. Default off: a too-wide word overflows, as in CSS. */
@@ -106,6 +110,7 @@ export const DEFAULT_TEXT_STYLE: ResolvedTextStyle = {
   textTransform: "none",
   wordSpacing: 0,
   textIndent: 0,
+  ligatures: true,
   breakWord: false,
   hyphenate: undefined,
 };
@@ -132,6 +137,7 @@ export function mergeTextStyle(
     textTransform: override.textTransform ?? base.textTransform,
     wordSpacing: override.wordSpacing ?? base.wordSpacing,
     textIndent: override.textIndent ?? base.textIndent,
+    ligatures: override.ligatures ?? base.ligatures,
     breakWord: override.breakWord ?? base.breakWord,
     hyphenate: override.hyphenate ?? base.hyphenate,
   };

--- a/src/lib/utils/font-metrics.ts
+++ b/src/lib/utils/font-metrics.ts
@@ -10,7 +10,13 @@ import type { FontDecoration } from "../text/text-decoration.ts";
  * touching layout code.
  */
 export interface FontMetrics {
-  getStringWidth(text: string, fontFamily: string, fontSize: number, fontStyle: FontStyle): number;
+  getStringWidth(
+    text: string,
+    fontFamily: string,
+    fontSize: number,
+    fontStyle: FontStyle,
+    ligatures?: boolean,
+  ): number;
 
   getCharWidth(
     char: string,
@@ -34,7 +40,12 @@ export interface FontMetrics {
 
   /** Per-adjacent-pair kerning of `text`, in em/1000 (negative tightens); length `codePoints - 1`,
    *  zero next to a space. Only meaningful when `kerningEnabled`. */
-  getKernPairs(text: string, fontFamily: string, fontStyle: FontStyle): number[];
+  getKernPairs(
+    text: string,
+    fontFamily: string,
+    fontStyle: FontStyle,
+    ligatures?: boolean,
+  ): number[];
 
   /** Whether this family can draw the code point at all - what picks a face out of a fallback stack. */
   hasGlyph(codePoint: number, fontFamily: string, fontStyle: FontStyle): boolean;
@@ -49,5 +60,10 @@ export interface FontMetrics {
 
   /** How many glyphs the run will DRAW, when a ligature made that differ from its code-point count.
    *  Absent or `undefined` means "the same", which is every Latin run. */
-  shapedGlyphCount?(text: string, fontFamily?: string, fontStyle?: FontStyle): number | undefined;
+  shapedGlyphCount?(
+    text: string,
+    fontFamily?: string,
+    fontStyle?: FontStyle,
+    ligatures?: boolean,
+  ): number | undefined;
 }

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -9,6 +9,14 @@ import { mergeSpans, TTFParser } from "./ttf-parser.ts";
 import { isWoff, woffToSfnt } from "./woff.ts";
 import { subsetTTF } from "./ttf-subsetter.ts";
 import { shapeRun, type ShapedGlyph } from "../text/shape.ts";
+
+/** What Latin text is shaped with unless a run says otherwise: the ligatures a font's designer
+ *  drew for it. On by default like kerning - CSS, browsers and every other renderer do the same,
+ *  and nobody should have to know the word to get text that is set properly. */
+const LATIN_FEATURES = ["liga"] as const;
+
+/** What a run is shaped with. Arabic joining is unconditional; this is only the Latin part. */
+const features = (ligatures: boolean): readonly string[] => (ligatures ? LATIN_FEATURES : []);
 import { getArrayBuffer, isWindows1252 } from "./utf8-to-windows1252-encoder.ts";
 import type { SecurityHandler } from "../crypto/security-handler.ts";
 import type { Gradient, GradientStop } from "../ir/display-list.ts";
@@ -916,8 +924,13 @@ endstream`;
 
   /** How many glyphs a run draws - its code-point count unless a ligature merged some. `letterSpacing`
    *  is per glyph (`Tc`), so this is what it multiplies. */
-  shapedGlyphCount(text: string, fontFamily?: string, fontStyle?: FontStyle): number | undefined {
-    return this.shapeText(text, fontFamily, fontStyle)?.length;
+  shapedGlyphCount(
+    text: string,
+    fontFamily?: string,
+    fontStyle?: FontStyle,
+    ligatures = true,
+  ): number | undefined {
+    return this.shapeText(text, fontFamily, fontStyle, features(ligatures))?.length;
   }
 
   /**
@@ -925,10 +938,15 @@ endstream`;
    * decided, so measuring and drawing cannot disagree. Memoised: a paragraph is measured several
    * times (layout, pagination, drawing).
    */
-  shapeText(text: string, fontFamily?: string, fontStyle: FontStyle = FontStyle.Normal) {
+  shapeText(
+    text: string,
+    fontFamily?: string,
+    fontStyle: FontStyle = FontStyle.Normal,
+    features: readonly string[] = LATIN_FEATURES,
+  ) {
     const resolved = this.resolveCustomStyle(fontFamily, fontStyle);
     if (!resolved) return undefined;
-    const key = `${this.customKey(fontFamily!, resolved)}\u0000${text}`;
+    const key = `${this.customKey(fontFamily!, resolved)}\u0000${features.join(",")}\u0000${text}`;
     const cached = this.shapeCache.get(key);
     if (cached !== undefined) return cached ?? undefined;
     const ttf = this.customFonts.get(fontFamily!)!.get(resolved)!;
@@ -936,6 +954,7 @@ endstream`;
       shapeRun(
         [...text].map((c) => c.codePointAt(0)!),
         ttf,
+        features,
       ) ?? null;
     this.shapeCache.set(key, shaped);
     if (shaped) {
@@ -969,7 +988,12 @@ endstream`;
 
   // Encodes text as a hex Identity-H string for an embedded font's Tj operator: each codepoint
   // becomes its 2-byte glyph id (CID == GID under /CIDToGIDMap /Identity).
-  encodeCustomText(name: string, text: string, style: FontStyle = FontStyle.Normal): string {
+  encodeCustomText(
+    name: string,
+    text: string,
+    style: FontStyle = FontStyle.Normal,
+    shape = true,
+  ): string {
     const resolved = this.resolveCustomStyle(name, style);
     if (!resolved) return "";
     this.ensureEmitted(name, resolved);
@@ -979,7 +1003,9 @@ endstream`;
     const hex4 = (gid: number) => gid.toString(16).padStart(4, "0").toUpperCase();
 
     // The SAME shaped run the measuring path used, so the glyphs drawn are the glyphs measured.
-    const shaped = this.shapeText(text, name, style);
+    // `shape: false` is for a caller that has ALREADY decided the run is unshaped - the renderer puts
+    // shaped glyphs in the IR node, so the backend's text path is the unshaped one by definition.
+    const shaped = shape ? this.shapeText(text, name, style) : undefined;
     if (shaped) {
       let out = "";
       for (const g of shaped) {
@@ -1149,13 +1175,33 @@ endstream`;
    * Standard-14 answers from the AFM `KPX` pairs. An embedded font has no kerning yet (its `kern` /
    * `GPOS` tables are unparsed), so it returns zeros - never a wrong value, just no adjustment.
    */
-  getKernPairs(text: string, fontFamily: string, fontStyle: FontStyle): number[] {
+  /** Kerning between adjacent GLYPHS - what a shaped run needs, and what the backend already holds.
+   *  Same lookup as the character path; `getKerning` is keyed by glyph id either way. */
+  getGlyphKernPairs(glyphs: readonly number[], fontFamily: string, fontStyle: FontStyle): number[] {
+    const ttf = this.getCustomFont(fontFamily, fontStyle);
+    if (!ttf) return [];
+    const pairs: number[] = [];
+    for (let i = 0; i < glyphs.length - 1; i++) {
+      pairs.push(ttf.getKerning(glyphs[i]!, glyphs[i + 1]!));
+    }
+    return pairs;
+  }
+
+  getKernPairs(text: string, fontFamily: string, fontStyle: FontStyle, ligatures = true): number[] {
     const chars = [...text];
     if (chars.length < 2) return [];
-    // A shaped run does not kern here: these pairs are keyed by the UNSHAPED glyphs, and the `TJ`
-    // path would re-shape each chunk on its own, turning every letter isolated. Arabic kerning is in
-    // GPOS, applied during shaping - not built (`todo.md`).
-    if (this.shapeText(text, fontFamily, fontStyle)) return [];
+    // A shaped run kerns over its SHAPED glyphs, not its characters: after shaping there may be fewer
+    // glyphs than code points (a ligature), and the pairs that matter are the ones actually drawn.
+    // `getKerning` is keyed by glyph id anyway, so this is the same lookup - and the backend now emits
+    // a `TJ` over glyph chunks, which is what used to be missing. One adjustment per adjacent DRAWN
+    // pair, either path, so `runAdvance` measures exactly what is drawn.
+    const shaped = this.shapeText(text, fontFamily, fontStyle, features(ligatures));
+    if (shaped)
+      return this.getGlyphKernPairs(
+        shaped.map((g) => g.glyph),
+        fontFamily,
+        fontStyle,
+      );
     const out: number[] = [];
     // An embedded font kerns by GLYPH id (kern table / GPOS); a standard-14 one by character (AFM).
     const ttf = this.getCustomFont(fontFamily, fontStyle);
@@ -1223,10 +1269,11 @@ endstream`;
     fontFamily: string,
     fontSize: number,
     fontStyle: FontStyle,
+    ligatures = true,
   ): number {
     // Shaping first: a joined run is narrower than the same letters apart, so measuring the unshaped
     // form while drawing the shaped one would break every line. Both sides ask `shapeText`.
-    const shaped = this.shapeText(text, fontFamily, fontStyle);
+    const shaped = this.shapeText(text, fontFamily, fontStyle, features(ligatures));
     if (shaped) {
       const ttf = this.getCustomFont(fontFamily, fontStyle)!;
       return shaped.reduce((w, g) => w + ttf.unitsToPoints(g.advance, fontSize), 0);

--- a/tests/unit/support/gsub-builder.ts
+++ b/tests/unit/support/gsub-builder.ts
@@ -88,6 +88,7 @@ export function buildGsub(
   features: { tag: string; lookups: number[] }[],
   lookups: LookupSpec[],
   named = false,
+  scriptTag = "arab",
 ): Uint8Array {
   // --- LookupList
   const lookupBlobs = lookups.map((l) => {
@@ -149,7 +150,7 @@ export function buildGsub(
   const script = named
     ? [...be16(0), ...be16(1), ...tag("ARA "), ...be16(4 + 6), ...langSys]
     : [...be16(4), ...be16(0), ...langSys];
-  const scriptList = [...be16(1), ...tag("arab"), ...be16(2 + 6), ...script];
+  const scriptList = [...be16(1), ...tag(scriptTag), ...be16(2 + 6), ...script];
 
   const headerSize = 10;
   return Uint8Array.from([

--- a/tests/unit/text/ligatures.test.ts
+++ b/tests/unit/text/ligatures.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { PDFObjectManager, FontStyle } from "../../../src/lib/utils/pdf-object-manager.ts";
+import { runAdvance } from "../../../src/lib/text/advance.ts";
+import { buildLigatureTtf } from "../utils/ttf-fixture.ts";
+
+// Latin ligatures are ON, like kerning: the font's designer drew them, every other renderer applies
+// them, and nobody should need the word to get text set properly. `ligatures: false` opts out - on a
+// Document, a DefaultTextStyle subtree or one Text, since it is an inheritable text style.
+//
+// The fixture font merges A+B into glyph 4 and kerns that ligature against the space by -80.
+
+const FONT = { fontFamily: "Lig", fontSize: 10, fontStyle: FontStyle.Normal };
+
+const om = (kerning = false) => {
+  const m = new PDFObjectManager();
+  m.registerCustomFont("Lig", new Uint8Array(buildLigatureTtf()));
+  m.setKerning(kerning);
+  return m;
+};
+
+describe("on by default", () => {
+  it("merges the pair into one glyph", () => {
+    expect(
+      om()
+        .shapeText("AB ", "Lig", FontStyle.Normal)!
+        .map((g) => g.glyph),
+    ).toEqual([4, 3]);
+  });
+
+  it("keeps the code points the ligature stands for, so copied text is still AB", () => {
+    expect(
+      om()
+        .shapeText("AB ", "Lig", FontStyle.Normal)!
+        .map((g) => g.codePoints),
+    ).toEqual([[0x41, 0x42], [0x20]]);
+  });
+
+  it("measures the ligature's own advance, not the sum of its parts", () => {
+    // glyph 4 (600) + space (250) at 10pt/1000upem - narrower than A(500) + B(700) + space(250).
+    expect(runAdvance(om(), "AB ", FONT, 0)).toBeCloseTo(8.5, 5);
+  });
+
+  it("still kerns, over the SHAPED glyphs", () => {
+    // Why shaped-run kerning had to come first: this run would otherwise lose -80.
+    expect(om(true).getKernPairs("AB ", "Lig", FontStyle.Normal)).toEqual([-80]);
+    expect(runAdvance(om(true), "AB ", FONT, 0)).toBeCloseTo(7.7, 5);
+  });
+});
+
+describe("switched off", () => {
+  const off = { ...FONT, ligatures: false };
+
+  it("does not shape, so the run keeps its plain path", () => {
+    expect(om().shapeText("AB ", "Lig", FontStyle.Normal, [])).toBeUndefined();
+  });
+
+  it("measures the letters apart", () => {
+    expect(runAdvance(om(), "AB ", off, 0)).toBeCloseTo(14.5, 5);
+  });
+
+  it("measures what it draws either way - the two settings must not agree by accident", () => {
+    expect(runAdvance(om(), "AB ", FONT, 0)).not.toBeCloseTo(runAdvance(om(), "AB ", off, 0), 5);
+  });
+});
+
+describe("a font with no such feature", () => {
+  it("is left alone, so its documents stay byte-identical", () => {
+    // No lookup covers this pair, so nothing merges and the plain path is kept.
+    expect(om().shapeText("BA ", "Lig", FontStyle.Normal)).toBeUndefined();
+  });
+});

--- a/tests/unit/text/shaped-kerning.test.ts
+++ b/tests/unit/text/shaped-kerning.test.ts
@@ -32,4 +32,12 @@ describe("the TJ operand", () => {
   it("handles a single unit, which has no gaps at all", () => {
     expect(PdfBackend.kernedArray([7], [], glyphs)).toBe("[<0007>]");
   });
+
+  it("refuses a kern count that does not match the gaps", () => {
+    // The guard is the whole point: the loop walks the gaps, so a short list drops the last unit
+    // silently. An empty run has no gaps either, and used to slip past the check entirely.
+    expect(() => PdfBackend.kernedArray([1, 2, 3], [0], glyphs)).toThrow(/expected 2/);
+    expect(() => PdfBackend.kernedArray([], [-10], glyphs)).toThrow(/expected 0/);
+    expect(PdfBackend.kernedArray([], [], glyphs)).toBe("[<>]");
+  });
 });

--- a/tests/unit/text/shaped-kerning.test.ts
+++ b/tests/unit/text/shaped-kerning.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { PdfBackend } from "../../../src/lib/renderer/pdf-backend.ts";
+
+// A shaped run used to return `[]` from `getKernPairs` - no kerning at all - because the `TJ` operand was
+// built from TEXT, which a shaped run cannot be expressed as. Both paths now share one chunking, over
+// characters or over glyph ids.
+
+const chars = (chunk: string[]) => `(${chunk.join("")})`;
+const glyphs = (chunk: number[]) =>
+  `<${chunk.map((g) => g.toString(16).padStart(4, "0").toUpperCase()).join("")}>`;
+
+describe("the TJ operand", () => {
+  it("splits a character run only where a pair kerns", () => {
+    // The sign flips: a TJ number moves the pen LEFT, so it is the negated kern.
+    expect(PdfBackend.kernedArray([..."Total"], [-170, 0, 0, 0], chars)).toBe("[(T) 170 (otal)]");
+  });
+
+  it("splits a glyph run the same way", () => {
+    expect(PdfBackend.kernedArray([1, 2, 3], [-40, 0], glyphs)).toBe("[<0001> 40 <00020003>]");
+  });
+
+  it("keeps one chunk when nothing kerns", () => {
+    expect(PdfBackend.kernedArray([1, 2, 3], [0, 0], glyphs)).toBe("[<000100020003>]");
+  });
+
+  it("kerns every gap", () => {
+    expect(PdfBackend.kernedArray([1, 2, 3], [-10, -20], glyphs)).toBe(
+      "[<0001> 10 <0002> 20 <0003>]",
+    );
+  });
+
+  it("handles a single unit, which has no gaps at all", () => {
+    expect(PdfBackend.kernedArray([7], [], glyphs)).toBe("[<0007>]");
+  });
+});

--- a/tests/unit/utils/ttf-fixture.ts
+++ b/tests/unit/utils/ttf-fixture.ts
@@ -1,3 +1,4 @@
+import { buildGsub, coverage1, ligature } from "../support/gsub-builder.ts";
 // A minimal but valid TTF with the 5 metric tables and 4 glyphs (.notdef, 'A', 'B', ' ')
 // and known advance widths, so tests can assert exact metrics without an MB-sized font.
 // Pass `advances` to mint a distinct variant (e.g. a wider "bold") - default is A=500, B=700.
@@ -513,4 +514,32 @@ function assembleTtf(tables: [string, Buffer][]): Buffer {
   });
 
   return Buffer.concat([offsetTable, dir, ...body]);
+}
+
+// A font that SHAPES and KERNS: GSUB `latn`/`liga` merges A(1)+B(2) into glyph 4, and a `kern` table
+// kerns that ligature against the space (3). Both halves together, because kerning a shaped run reads
+// the pairs off the glyphs shaping produced, not off the characters.
+export function buildLigatureTtf(kernValue = -80): Buffer {
+  const gsub = Buffer.from(
+    buildGsub(
+      [{ tag: "liga", lookups: [0] }],
+      [{ type: 4, subtables: [ligature(coverage1([1]), [[[4, 2]]])] }],
+      false,
+      "latn",
+    ),
+  );
+
+  // kern: one pair, the ligature (4) before the space (3).
+  const kern = Buffer.alloc(24);
+  kern.writeUInt16BE(0, 0);
+  kern.writeUInt16BE(1, 2);
+  kern.writeUInt16BE(0, 4);
+  kern.writeUInt16BE(20, 6);
+  kern.writeUInt16BE(0x0001, 8);
+  kern.writeUInt16BE(1, 10);
+  kern.writeUInt16BE(4, 18);
+  kern.writeUInt16BE(3, 20);
+  kern.writeInt16BE(kernValue, 22);
+
+  return assembleTtf([...baseTables([0, 500, 700, 250, 600]), ["GSUB", gsub], ["kern", kern]]);
 }


### PR DESCRIPTION
## Summary

Latin ligatures (kerning)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional control over Latin ligatures in text styling, enabled by default.
  * Ligature settings apply consistently to text measurement, wrapping, rendering, and ellipsis calculations.
* **Improvements**
  * Improved kerning for text containing ligatures and shaped glyphs.
  * Enhanced fallback behavior when fonts lack applicable ligature features.
* **Documentation**
  * Updated documentation with text-rendering behavior, configuration details, renderer error handling, and current release information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->