### PR TITLE
feat(vue): expose the text styles the engine already has

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -869,7 +869,11 @@ prefixed components; custom fonts + images load as `Uint8Array` (`<JasyDocument 
 components; **`@jasy/vue@1.0.0-alpha.2`** — the `jasyVue` GLOBAL plugin was **REMOVED** (global registration
 never resolves in `renderToPdf`'s fresh app; plain Vue = explicit imports, prefix is Nuxt-only). The
 **`@jasy/nuxt` Nuxt module shipped** (`@1.0.0-alpha.1` — client OR server, zero-config; see Repo facts +
-`packages/nuxt`). A `style`-object CSS layer + `@media` are **won't-do** (props + `DefaultTextStyle` cover styling;
+`packages/nuxt`). **Its typed props are held to the engine by a test** (2026-09-04): the components forward
+`{ ...attrs, ...props }`, so an undeclared prop still WORKS - which is why eight text options drifted
+in unnoticed over four features. `packages/vue/tests/text-props.test.ts` reads the option names out of
+`src/lib/api/text.ts` (following `extends` and `Omit`) and fails per component, so a new text style
+cannot ship without its prop. A `style`-object CSS layer + `@media` are **won't-do** (props + `DefaultTextStyle` cover styling;
 media queries are meaningless for a fixed-size PDF). **✅ Relative/percentage sizing DONE (2026-07-05)**:
 `width`/`height` as `"50%"`/pt on Box/Column/Row/Image, image aspect auto-size, and `%` children in flex
 containers resolved against `line − gaps` (so N columns at (100/N)%+gaps fit exactly - better than

--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -2,21 +2,31 @@ import { defineComponent, h, type PropType } from "vue";
 import type {
   ButtonActionInput,
   ColorInput,
+  Direction,
+  Hyphenator,
   Insets,
   ImageSource,
   FontSource,
   PageSizeInput,
   ColumnWidth,
+  TextOverflow,
+  TextRole,
+  TextTransform,
+  VerticalTextAlign,
 } from "@jasy/pdf";
 
 const colorProp = [String, Number, Object] as PropType<ColorInput>;
 const insetsProp = [Number, Object, Array] as PropType<Insets>;
+// A family name, or a STACK: each code point is drawn by the first family that has a glyph for it.
+const fontProp = [String, Array] as PropType<string | string[]>;
+// Text-internal alignment. Shared, because it is spread into four prop bags and drifted apart once.
+const alignProp = String as PropType<"left" | "center" | "right" | "justify">;
 
 // `bold`/`italic` use `default: undefined` so an unset flag stays undefined (and inherits the
 // DefaultTextStyle) while `<Text bold>` still coerces to true.
 const textStyleProps = {
   size: Number,
-  font: String,
+  font: fontProp,
   bold: { type: Boolean, default: undefined },
   italic: { type: Boolean, default: undefined },
   color: colorProp,
@@ -25,6 +35,20 @@ const textStyleProps = {
   /** Step the underline around descenders. Needs an embedded font. */
   skipInk: { type: Boolean, default: undefined },
   letterSpacing: Number,
+  /** Base writing direction (CSS `direction`): `"rtl"` starts the line on the right. */
+  direction: String as PropType<Direction>,
+  /** CSS `text-transform`: recase the text. */
+  textTransform: String as PropType<TextTransform>,
+  /** CSS `word-spacing`, in points: extra advance at every space. */
+  wordSpacing: Number,
+  /** CSS `text-indent`, in points: how far the FIRST line starts in. */
+  textIndent: Number,
+  /** Split a word wider than its box, anywhere, no hyphen (CSS `overflow-wrap: break-word`). */
+  breakWord: { type: Boolean, default: undefined },
+  /** The ligatures the font's designer drew (`fi`, `fl`, `ffi`). On by default; `false` opts out. */
+  ligatures: { type: Boolean, default: undefined },
+  /** Language-aware splitting: given a word, return its parts. Bring your own (`hyphen`, ...). */
+  hyphenate: Function as PropType<Hyphenator>,
 };
 // A link target. Shared by `<Text>`/`<Paragraph>` (links the whole run) and `<Span>` (links just that
 // run). NOT part of `textStyleProps`: `<Document>` and `<DefaultTextStyle>` set defaults, they cannot link.
@@ -35,13 +59,24 @@ const linkTargetProps = {
   /** The `name` of an `<Anchor>` elsewhere in the document. */
   to: String,
 };
+// `vertical-align` belongs to ONE run, not to a document's defaults - same reason as linkTargetProps.
+const spanOnlyProps = {
+  /** CSS `vertical-align`: raises a footnote marker or lowers an index. Shifts the baseline only -
+   *  pass a smaller `size` too for the browser's `<sup>` look. */
+  verticalAlign: String as PropType<VerticalTextAlign>,
+};
 const textProps = {
   ...textStyleProps,
   ...linkTargetProps,
-  align: String as PropType<"left" | "center" | "right">,
+  align: alignProp,
   lineHeight: Number,
   maxLines: Number,
-  overflow: String as PropType<"clip" | "ellipsis">,
+  overflow: String as PropType<TextOverflow>,
+  /** Minimum lines left behind at / carried over a page break (CSS `orphans`/`widows`, both 2). */
+  orphans: Number,
+  widows: Number,
+  /** Accessibility role for the tagged structure tree: `"h1"`..`"h6"` or `"p"`. Semantic only. */
+  role: String as PropType<TextRole>,
 };
 const stackProps = {
   gap: Number,
@@ -88,7 +123,7 @@ const pageProps = {
 };
 const documentProps = {
   ...textStyleProps,
-  align: String as PropType<"left" | "center" | "right">,
+  align: alignProp,
   lineHeight: Number,
   meta: Object as PropType<{ title?: string; author?: string }>,
   fonts: Object as PropType<Record<string, FontSource>>,
@@ -106,7 +141,7 @@ const positionedProps = {
 };
 const defaultTextStyleProps = {
   ...textStyleProps,
-  align: String as PropType<"left" | "center" | "right">,
+  align: alignProp,
   lineHeight: Number,
 };
 
@@ -225,7 +260,7 @@ export const Paragraph = defineComponent({
 export const Span = defineComponent({
   name: "JasySpan",
   inheritAttrs: false,
-  props: { ...textStyleProps, ...linkTargetProps },
+  props: { ...textStyleProps, ...linkTargetProps, ...spanOnlyProps },
   setup: fwd("span"),
 });
 // `<Table :columns>` holds `<TableRow>`s (mark one `header` to repeat it per page) of `<TableCell>`s.
@@ -307,7 +342,7 @@ export const RotatedBox = defineComponent({
 // The current page / the document total, as text. Usable anywhere, not just in a `#footer`. `offset` is
 // added to the number - use `-1` when a cover page should not count.
 // (`PageBuilder` from the core is not exposed: it takes a closure, which a template cannot express.)
-const pageNumberProps = { ...textStyleProps, align: String, lineHeight: Number, offset: Number };
+const pageNumberProps = { ...textStyleProps, align: alignProp, lineHeight: Number, offset: Number };
 export const PageNumber = defineComponent({
   name: "JasyPageNumber",
   inheritAttrs: false,

--- a/packages/vue/tests/text-props.test.ts
+++ b/packages/vue/tests/text-props.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { Document, DefaultTextStyle, Text, Paragraph, Span } from "../src/index.ts";
+
+// The components forward `{ ...attrs, ...props }`, so an UNDECLARED prop still reaches the engine -
+// which is why this drifted through four features without anything failing. Undeclared means no type,
+// no autocomplete, no template check: the user has to already know the prop exists.
+//
+// The guard is therefore on the DECLARATION, not on behaviour: every option the public text interfaces
+// offer must be a declared prop. Read out of the engine's own source, because the types are erased at
+// runtime and this test tree is not type-checked (todo.md ISSUE-6).
+
+const source = readFileSync(
+  fileURLToPath(new URL("../../../src/lib/api/text.ts", import.meta.url)),
+  "utf8",
+);
+
+/**
+ * The options one `export interface X { ... }` offers: its own properties plus those of the interface
+ * it extends, minus anything an `extends Omit<..., "a" | "b">` takes back off (that is how
+ * `TextOptions` drops the span-only `verticalAlign`). Doc comments are ignored.
+ */
+function optionsOf(name: string): string[] {
+  const decl = new RegExp(`export interface ${name}([^{]*)\\{([\\s\\S]*?)\\n\\}`).exec(source);
+  if (!decl) throw new Error(`interface ${name} not found - did api/text.ts move?`);
+  const base = /extends\s+(?:Omit<\s*)?(\w+)/.exec(decl[1]!)?.[1];
+  const omitted = [...decl[1]!.matchAll(/"(\w+)"/g)].map((m) => m[1]!);
+  const own = [...decl[2]!.matchAll(/^ {2}(\w+)\??:/gm)].map((m) => m[1]!);
+  return [...(base ? optionsOf(base) : []), ...own].filter((key) => !omitted.includes(key));
+}
+
+const declared = (component: { props?: object }) => Object.keys(component.props ?? {});
+
+const cases: [string, { props?: object }, string[]][] = [
+  ["Text", Text, optionsOf("TextOptions")],
+  ["Paragraph", Paragraph, optionsOf("TextOptions")],
+  ["Span", Span, optionsOf("TextStyle")],
+  ["Document", Document, optionsOf("TextDefaults")],
+  ["DefaultTextStyle", DefaultTextStyle, optionsOf("TextDefaults")],
+];
+
+describe("every public text option is a declared prop", () => {
+  it("really reads the interfaces, inheritance and omissions included", () => {
+    // Guards the parser itself: a rename that emptied it would make every case below vacuously green.
+    expect(optionsOf("TextStyle")).toContain("ligatures");
+    expect(optionsOf("TextDefaults")).toContain("hyphenate");
+    expect(optionsOf("TextOptions")).toEqual(expect.arrayContaining(["maxLines", "letterSpacing"]));
+    // Inherited from TextStyle, then omitted again: a span raises one run, a whole Text is a block.
+    expect(optionsOf("TextOptions")).not.toContain("verticalAlign");
+    expect(optionsOf("TextStyle")).toContain("verticalAlign");
+  });
+
+  it.each(cases)("%s", (_name, component, options) => {
+    const props = declared(component);
+    expect(options.filter((option) => !props.includes(option))).toEqual([]);
+  });
+});

--- a/packages/vue/tests/text-props.test.ts
+++ b/packages/vue/tests/text-props.test.ts
@@ -32,12 +32,16 @@ function optionsOf(name: string): string[] {
 
 const declared = (component: { props?: object }) => Object.keys(component.props ?? {});
 
-const cases: [string, { props?: object }, string[]][] = [
-  ["Text", Text, optionsOf("TextOptions")],
-  ["Paragraph", Paragraph, optionsOf("TextOptions")],
-  ["Span", Span, optionsOf("TextStyle")],
-  ["Document", Document, optionsOf("TextDefaults")],
-  ["DefaultTextStyle", DefaultTextStyle, optionsOf("TextDefaults")],
+// [component, the options it must declare, props it may have BESIDE them]. The extras are named one by
+// one on purpose: a prop that is in neither list is a typo (`textIndentation`) or a leftover, and both
+// are invisible otherwise - the forwarding passes anything through.
+const cases: [string, { props?: object }, string[], string[]][] = [
+  ["Text", Text, optionsOf("TextOptions"), []],
+  ["Paragraph", Paragraph, optionsOf("TextOptions"), []],
+  ["Span", Span, optionsOf("TextStyle"), []],
+  // `meta` and `fonts` are document-level, not text options.
+  ["Document", Document, optionsOf("TextDefaults"), ["meta", "fonts"]],
+  ["DefaultTextStyle", DefaultTextStyle, optionsOf("TextDefaults"), []],
 ];
 
 describe("every public text option is a declared prop", () => {
@@ -51,8 +55,21 @@ describe("every public text option is a declared prop", () => {
     expect(optionsOf("TextStyle")).toContain("verticalAlign");
   });
 
-  it.each(cases)("%s", (_name, component, options) => {
-    const props = declared(component);
-    expect(options.filter((option) => !props.includes(option))).toEqual([]);
+  it.each(cases)(
+    "%s declares every option and nothing else",
+    (_name, component, options, extra) => {
+      const props = declared(component);
+      expect(options.filter((option) => !props.includes(option))).toEqual([]);
+      expect(props.filter((prop) => !options.includes(prop) && !extra.includes(prop))).toEqual([]);
+    },
+  );
+
+  // The one place a text style is deliberately NOT uniform: `vertical-align` raises a single run, so it
+  // belongs to a span. `Text` is the block, and CSS ignores it there too - hence the Omit in TextOptions.
+  it("keeps verticalAlign on the span and off the block", () => {
+    expect(declared(Span)).toContain("verticalAlign");
+    for (const block of [Text, Paragraph, Document, DefaultTextStyle]) {
+      expect(declared(block)).not.toContain("verticalAlign");
+    }
   });
 });

--- a/src/lib/api/text.ts
+++ b/src/lib/api/text.ts
@@ -12,7 +12,9 @@ import { ResolvedTextStyle, type TextTransform } from "../text/text-style.ts";
 import { ColorInput, toColor } from "./color.ts";
 import type { Hyphenator } from "../text/word-splitting.ts";
 
-export type { TextOverflow };
+// The types of the public text options, so a consumer (a framework binding, a typed wrapper) can name
+// them. `Hyphenator` in particular IS the contract of `Text({ hyphenate })`.
+export type { TextOverflow, Direction, TextTransform, Hyphenator };
 
 /** Text styling shared by `Text`, `Paragraph` and `span`. `bold`/`italic` are booleans
  *  (locked §7.3) and combine into one engine `FontStyle`. */
@@ -66,7 +68,10 @@ export interface TextStyle {
   to?: string;
 }
 
-export interface TextOptions extends TextStyle {
+// `verticalAlign` is NOT inherited from `TextStyle`: it raises ONE run, and `Text` is the whole block -
+// CSS `vertical-align` is inert on a block for the same reason. It was in the type and silently dropped
+// by the factory below; put it on a `span(...)` instead.
+export interface TextOptions extends Omit<TextStyle, "verticalAlign"> {
   /** Text-internal alignment (left/center/right) - independent of a parent's `cross` (§5). */
   align?: "left" | "center" | "right" | "justify";
   /** Cap the number of wrapped lines (default: unlimited - the text grows down as far as it needs,


### PR DESCRIPTION
## Summary

Implement Latin ligatures into VUE

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added text styling options for direction, transformation, spacing, indentation, word breaking, ligatures, and hyphenation.
  - Added typed overflow, orphan and widow limits, semantic text roles, and vertical alignment support for spans.
  - Expanded public text configuration types, including direction, transformation, and hyphenation options.
- **Improvements**
  - Standardized alignment options across documents, default text styles, page numbers, and text components.
  - Restricted vertical alignment to spans, where it is supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->