### PR TITLE
feat: canvas - the imperative escape hatch, typed and scoped

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,7 @@ shared state.
 | `KeepTogetherElement`   | `elements/layout/keep-together-element.ts`   | `KeepTogetherRenderer` | transparent wrapper; vetoes a page-split (break-inside: avoid), degrades if > 1 page      |
 | form fields (6 classes) | `elements/forms/*.ts`                        | `FormFieldRenderer`    | AcroForm widgets; reserve a rect, emit a widget annotation. Shared spec: `forms/field.ts` |
 | `SvgElement`            | `elements/svg-element.ts`                    | `SvgRenderer`          | an SVG drawing; parsed at construction, `svg/` turns it into `Path` IR                    |
+| `CanvasElement`         | `elements/canvas-element.ts`                 | `CanvasRenderer`       | a box drawn by a callback; `canvas/painter.ts` records into `Path` IR                     |
 
 Every renderer's `render()` returns `Promise<IRNode[]>` (since roadmap Phase 1). Adding an element =
 new element + renderer that returns IR + (if it draws something new) a primitive in `ir/display-list.ts`
@@ -808,6 +809,20 @@ wordWidth > maxWidth` and forgot the SPACE that would join the word. It went uns
     the root `<svg>` is a VIEWPORT and clips to itself, and **its own presentation attributes were
     never read** - `fill="none"` sits there in 778 of the 10,819 files (the Figma export default), so
     every shape without its own fill came out BLACK and covered what was underneath.
+
+- ✅ **Canvas** (2026-09-05) - `Canvas({ width, height }, (c, size) => …)`, the imperative escape hatch.
+  The SECOND producer of the vector layer, so it needed no new IR and no backend change: everything it
+  draws is a `Path` node, which means it tags, paginates and runs in the browser like anything else.
+  Surface is react-pdf's painter feature for feature (`move line curve quad close rect circle ellipse
+polygon path fill stroke fillAndStroke group clipped`), with three deliberate differences that are
+  the whole reason to have our own: **typed to the value** (theirs is `painter: any`), **no hidden
+  state** (no `lineWidth(2)` a later `stroke()` picks up, no `save`/`restore` to forget - a transform
+  or clip is a SCOPE that closes itself), and **one coordinate system** (top-left, like every element
+  and like SVG). `c.path(d)` reuses the SVG path reader, and a gradient resolves against the shape's
+  own bounding box exactly as `objectBoundingBox` does. It is a block IN the layout, never a way around
+  it - no text layout, no pagination inside. What is beyond it but still expressible in PDF (text
+  render modes, blend modes, tiling patterns, CMYK/spot, soft masks, optional content) is in `todo.md`
+  under Roadmap to 1.1.
 
 Genuine remaining gaps / deferred:
 

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -147,11 +147,15 @@ clockwise) and resolved against the box by the renderer.
 | `DefaultTextStyle(opts, children)` | cascaded text defaults for a subtree | `size`, `font`, `bold`, `italic`, `color`, `align`, `lineHeight`, `breakWord`, `hyphenate`§         | `DefaultTextStyleElement` |
 | `Image(src, opts)`                 | image; an SVG source routes to `Svg` | `fit`, **`radius`**, sizing†                                                                        | `ImageElement`            |
 | `Svg(source, opts)`                | vector drawing from SVG¶             | sizing†, `alt`                                                                                      | `SvgElement`              |
+| `Canvas(opts?, paint)`             | a box you draw into yourself‖        | sizing†, `alt`                                                                                      | `CanvasElement`           |
 | `Divider(opts?)`                   | horizontal rule                      | `color`, `thickness`, `margin`                                                                      | `LineElement`             |
 | `Line(opts)`                       | explicit line                        | `from`, `to`, `color`, `thickness`                                                                  | `LineElement`             |
 
 § **A word that does not fit** - `breakWord` and `hyphenate`, both off by default. See 6c. They are
 read per `Text`, not per `span`, which is why `span` does not list them.
+
+‖ **Canvas** - see 6e. The escape hatch for what no component covers; it is a block IN the layout,
+not a way around it.
 
 ¶ **SVG** - see 6d. `Image` recognises an SVG source itself, so `Image("logo.svg")` keeps a logo a
 VECTOR instead of turning it into a bitmap.
@@ -303,6 +307,47 @@ already worked. Going the other way would change existing output.
 **Measured against 10,819 real SVG files** from a working machine: 96.4% render. Correctness is
 checked against headless Chrome, not against our own reasoning - which is how the viewport clip, the
 `<svg fill="none">` inheritance and `svg-parser`'s id corruption were all found.
+
+---
+
+## 6e. Canvas - the imperative escape hatch (2026-09-05)
+
+```ts
+Canvas({ width: 300, height: 46 }, (c, { width, height }) => {
+  c.move(0, height)
+    .line(20, 12)
+    .line(60, 22)
+    .line(width, 4)
+    .stroke("#1450aa", { width: 1.5, cap: "round" });
+
+  c.circle(width - 4, 4, 2.5).fill(linearGradient({ angle: 180, stops: ["#1450aa", "#7aa5e8"] }));
+});
+```
+
+The surface is react-pdf's painter, feature for feature: `move line curve quad close rect circle
+ellipse polygon path fill stroke fillAndStroke group clipped`. Three things are deliberately
+different, and they are the whole argument for having our own:
+
+1. **Typed to the value.** `cap: "round"` autocompletes and a wrong one is a compile error.
+   react-pdf's callback receives `painter: any` - no help on the one thing you use.
+2. **No hidden state.** No `lineWidth(2)` that a later `stroke()` happens to pick up, and no
+   `save()`/`restore()` pair to forget: a transform or a clip is a SCOPE that closes itself
+   (`group({ rotate }, c => …)`, `clipped(build, draw)`).
+3. **One coordinate system.** Top-left, y down, points - the same as every element and the same as
+   SVG. `0,0` is the canvas box's own corner.
+
+With no size it FILLS the box it is offered (there is no intrinsic size to derive), and the callback
+is handed that resolved size, so a drawing written against `size.width` works at any width. It is
+clipped to its own box, tags as a `Figure` with `alt`, and paginates as one unbreakable block.
+
+**It is a block IN the layout, never a way around it.** Text belongs in `Text` - a canvas has no line
+breaking, no pagination inside it, and no structure tree of its own. That line is what keeps a
+document that uses one still reflow-able and still accessible.
+
+`Canvas` and `Svg` are the two producers of the same vector layer, so anything one can draw the other
+can. What is beyond both but still expressible in PDF - text render modes, blend modes, tiling
+patterns, CMYK and spot colours, soft masks, optional-content layers - is listed in `todo.md` under
+Roadmap to 1.1, each one independently shippable.
 
 ---
 

--- a/src/lib/api/content.ts
+++ b/src/lib/api/content.ts
@@ -19,6 +19,7 @@ import {
   toRadius,
 } from "./dimension.ts";
 import { SvgElement, type SvgSource } from "../elements/svg-element.ts";
+import { CanvasElement, type CanvasPaint } from "../elements/canvas-element.ts";
 
 /** A horizontal rule (locked §4). */
 export interface DividerOptions {
@@ -87,6 +88,44 @@ export interface ImageOptions extends BoundsInput {
   /** Alternate text for accessibility (tagged PDF): describes the image for screen readers. With `alt`
    *  the image is a `Figure`; without it (and when rendered `accessible`) it counts as decoration. */
   alt?: string;
+}
+
+/** Options for `Canvas`. Sizing only - what is drawn is entirely the callback's business. */
+export interface CanvasOptions extends BoundsInput {
+  width?: SizeInput;
+  height?: SizeInput;
+  /** Alternate text (tagged PDF). With it the drawing is a `Figure`; without it, decoration. */
+  alt?: string;
+}
+
+/**
+ * A box you draw into yourself - the escape hatch for what the declarative layer has no component
+ * for: a sparkline, a seal, a chart, a signature flourish.
+ *
+ * With no size it FILLS the box it is offered, because there is nothing to derive an intrinsic size
+ * from. The callback is handed that resolved size, so a drawing written against `size.width` works
+ * at any width. It is clipped to its own box: a canvas is a block IN the layout, never a way around
+ * it - text still belongs in `Text`, and this still paginates as one unbreakable block.
+ */
+export function Canvas(opts: CanvasOptions, paint: CanvasPaint): CanvasElement;
+export function Canvas(paint: CanvasPaint): CanvasElement;
+export function Canvas(a: CanvasOptions | CanvasPaint, b?: CanvasPaint): CanvasElement {
+  const opts = typeof a === "function" ? {} : a;
+  const paint = typeof a === "function" ? a : b!;
+  const w = opts.width !== undefined ? toDimension(opts.width) : undefined;
+  const h = opts.height !== undefined ? toDimension(opts.height) : undefined;
+  return new CanvasElement({
+    paint,
+    width: w?.points,
+    height: h?.points,
+    widthFactor: w?.factor,
+    heightFactor: h?.factor,
+    ...toBounds(opts),
+    alt: opts.alt,
+  })
+    .withAlignSelf(opts.alignSelf)
+    .withOrder(opts.order)
+    .withFlexShrink(opts.flexShrink) as CanvasElement;
 }
 
 /**

--- a/src/lib/api/descriptor.ts
+++ b/src/lib/api/descriptor.ts
@@ -19,7 +19,7 @@ import {
   Rotated,
   RotatedBox,
 } from "./layout.ts";
-import { Divider, Image, Svg } from "./content.ts";
+import { Canvas, Divider, Image, Svg } from "./content.ts";
 import { Page, Document, DefaultTextStyle } from "./structure.ts";
 import { PageNumber, PageCount } from "./page-builder.ts";
 import { Table, Cell } from "./table.ts";
@@ -139,6 +139,8 @@ const REGISTRY: Record<string, ElementFactory> = {
   image: (props) => Image(props.src, props),
   // `src` is markup, a path or bytes - the same three the factory takes.
   svg: (props) => Svg(props.src, props),
+  // `paint` is a closure, so this type only reaches a code-built tree, never a template.
+  canvas: (props) => Canvas(props, props.paint),
   text: (props, children) => Text(textContent(children), props),
   paragraph: (props, children) => Paragraph(textContent(children), props),
   // `<Table>` reads its `<TableRow>`/`<TableCell>` structure raw; one row may be marked `header`.

--- a/src/lib/api/descriptor.ts
+++ b/src/lib/api/descriptor.ts
@@ -139,7 +139,8 @@ const REGISTRY: Record<string, ElementFactory> = {
   image: (props) => Image(props.src, props),
   // `src` is markup, a path or bytes - the same three the factory takes.
   svg: (props) => Svg(props.src, props),
-  // `paint` is a closure, so this type only reaches a code-built tree, never a template.
+  // `paint` is a function PROP - `<Canvas :paint="drawChart" />` in a template passes one like any
+  // other value. (Unlike `PageBuilder`, whose closure is the CHILD and has no template form.)
   canvas: (props) => Canvas(props, props.paint),
   text: (props, children) => Text(textContent(children), props),
   paragraph: (props, children) => Paragraph(textContent(children), props),

--- a/src/lib/canvas/painter.ts
+++ b/src/lib/canvas/painter.ts
@@ -1,0 +1,281 @@
+import { Color } from "../common/color.ts";
+import { toColor, type ColorInput } from "../api/color.ts";
+import { isGradientInput, resolveGradient, type GradientInput } from "../api/gradient.ts";
+import type { Gradient, IRNode, PathCommand, StrokeStyle } from "../ir/display-list.ts";
+import { pathData } from "../svg/shapes.ts";
+import { boundsOf, quadToCubic } from "../vector/path.ts";
+
+/**
+ * The imperative escape hatch: a box in the layout that you draw into yourself.
+ *
+ * It is the SECOND producer of the vector layer (SVG is the first), so it needs no new IR and no
+ * backend change - everything it draws is a `Path` node like any other, which means it tags, it
+ * paginates, and it works in the browser.
+ *
+ * Three deliberate departures from the PDFKit-shaped painters (react-pdf's included):
+ *
+ * 1. **Typed to the value.** `cap: "round"` autocompletes and a wrong one is a compile error, where
+ *    react-pdf's `paint` callback receives `painter: any` - no help on the one thing you use.
+ * 2. **No hidden state.** There is no `lineWidth(2)` that a later `stroke()` happens to pick up, and
+ *    no `save()`/`restore()` pair to forget: a transform or a clip is a SCOPE (`group`, `clipped`)
+ *    that closes itself.
+ * 3. **One coordinate system.** Top-left, y down, points - the same as every other element in jasy
+ *    and the same as SVG. The origin is the canvas box, so `0,0` is its own corner.
+ */
+
+/** Where a shape ends up. A gradient resolves against the shape's own bounding box, as in SVG. */
+export type PaintInput = ColorInput | GradientInput;
+
+export interface StrokeOptions {
+  /** Line width in points. Default 1. */
+  width?: number;
+  cap?: StrokeStyle["cap"];
+  join?: StrokeStyle["join"];
+  miterLimit?: number;
+  /** Dash lengths in points, plus the phase to start at. */
+  dash?: number[];
+  dashOffset?: number;
+}
+
+export interface FillOptions {
+  /** `evenodd` cuts a hole where subpaths overlap an odd number of times. Default `nonzero`. */
+  rule?: "nonzero" | "evenodd";
+}
+
+/** A transform applied for the duration of a `group`. Composed in this order: translate, rotate, scale. */
+export interface TransformOptions {
+  translate?: [number, number];
+  /** Degrees, clockwise on the page. */
+  rotate?: number;
+  /** One number scales both axes. */
+  scale?: number | [number, number];
+  /** The point `rotate` and `scale` happen around. Default `[0, 0]`. */
+  origin?: [number, number];
+}
+
+/** The size the callback was given, so a drawing can be written relative to its box. */
+export interface CanvasSize {
+  width: number;
+  height: number;
+}
+
+const DEGREES = Math.PI / 180;
+
+export class CanvasPainter {
+  /** The nodes drawn so far, in order. */
+  private readonly nodes: IRNode[] = [];
+  /** The path being built. Emptied by every painting call, so a shape cannot leak into the next. */
+  private current: PathCommand[] = [];
+  private cursor: [number, number] = [0, 0];
+  private start: [number, number] = [0, 0];
+
+  constructor(readonly size: CanvasSize) {}
+
+  /** Everything drawn, for the renderer. */
+  drawn(): IRNode[] {
+    return this.nodes;
+  }
+
+  // --- building a path ---------------------------------------------------------------------------
+
+  move(x: number, y: number): this {
+    this.current.push({ op: "m", x, y });
+    this.cursor = [x, y];
+    this.start = [x, y];
+    return this;
+  }
+
+  line(x: number, y: number): this {
+    this.current.push({ op: "l", x, y });
+    this.cursor = [x, y];
+    return this;
+  }
+
+  /** A cubic Bézier - the curve PDF draws natively. */
+  curve(x1: number, y1: number, x2: number, y2: number, x: number, y: number): this {
+    this.current.push({ op: "c", x1, y1, x2, y2, x, y });
+    this.cursor = [x, y];
+    return this;
+  }
+
+  /** A quadratic Bézier. PDF has no operator for one, so it is raised to a cubic exactly. */
+  quad(cx: number, cy: number, x: number, y: number): this {
+    this.current.push(quadToCubic(this.cursor[0], this.cursor[1], cx, cy, x, y));
+    this.cursor = [x, y];
+    return this;
+  }
+
+  close(): this {
+    this.current.push({ op: "z" });
+    this.cursor = [...this.start];
+    return this;
+  }
+
+  rect(x: number, y: number, width: number, height: number): this {
+    return this.move(x, y)
+      .line(x + width, y)
+      .line(x + width, y + height)
+      .line(x, y + height)
+      .close();
+  }
+
+  circle(cx: number, cy: number, r: number): this {
+    return this.ellipse(cx, cy, r, r);
+  }
+
+  /** Four cubics; the constant is the standard circle-to-Bézier one. */
+  ellipse(cx: number, cy: number, rx: number, ry: number): this {
+    const k = 0.5522847498307936;
+    const [ox, oy] = [rx * k, ry * k];
+    return this.move(cx - rx, cy)
+      .curve(cx - rx, cy - oy, cx - ox, cy - ry, cx, cy - ry)
+      .curve(cx + ox, cy - ry, cx + rx, cy - oy, cx + rx, cy)
+      .curve(cx + rx, cy + oy, cx + ox, cy + ry, cx, cy + ry)
+      .curve(cx - ox, cy + ry, cx - rx, cy + oy, cx - rx, cy)
+      .close();
+  }
+
+  polygon(points: readonly (readonly [number, number])[]): this {
+    if (points.length === 0) return this;
+    this.move(points[0]![0], points[0]![1]);
+    for (const [x, y] of points.slice(1)) this.line(x, y);
+    return this.close();
+  }
+
+  /** SVG path data, through the same reader `Svg()` uses - arcs and shorthands included. */
+  path(d: string): this {
+    const parsed = pathData(d);
+    this.current.push(...parsed);
+    // Where the pen ends up: after a `z` it is back at that subpath's `m`, not at the last point.
+    for (const cmd of parsed) {
+      if (cmd.op === "m") this.start = [cmd.x, cmd.y];
+      this.cursor = cmd.op === "z" ? [...this.start] : [cmd.x, cmd.y];
+    }
+    return this;
+  }
+
+  // --- painting it -------------------------------------------------------------------------------
+
+  /** Fills the path built so far and starts a new one. Default black, as in SVG and PDF. */
+  fill(paint: PaintInput = "black", options: FillOptions = {}): this {
+    return this.paint(this.resolve(paint), undefined, options.rule);
+  }
+
+  /** Strokes the path built so far and starts a new one. */
+  stroke(color: ColorInput = "black", options: StrokeOptions = {}): this {
+    return this.paint(undefined, this.strokeStyle(color, options));
+  }
+
+  fillAndStroke(
+    paint: PaintInput,
+    color: ColorInput,
+    options: StrokeOptions & FillOptions = {},
+  ): this {
+    return this.paint(this.resolve(paint), this.strokeStyle(color, options), options.rule);
+  }
+
+  // --- scopes, instead of save/restore -----------------------------------------------------------
+
+  /**
+   * Draws inside a transform. It closes itself, so there is no `restore()` to forget - and a nested
+   * `group` composes, exactly like a `<g transform>` in SVG.
+   */
+  group(transform: TransformOptions, draw: (c: CanvasPainter) => void): this {
+    this.assertNoPendingPath("group");
+    const matrix = this.matrixOf(transform);
+    this.nodes.push({ type: "transform-push", matrix });
+    draw(this);
+    this.assertNoPendingPath("group");
+    this.nodes.push({ type: "transform-pop" });
+    return this;
+  }
+
+  /**
+   * Draws clipped to a path. `build` draws the clip shape (nothing is painted from it), `draw` draws
+   * what the clip applies to.
+   */
+  clipped(
+    build: (c: CanvasPainter) => void,
+    draw: (c: CanvasPainter) => void,
+    options: FillOptions = {},
+  ): this {
+    this.assertNoPendingPath("clipped");
+    build(this);
+    const commands = this.current;
+    this.current = [];
+    this.nodes.push({ type: "clip-path-push", commands, fillRule: options.rule });
+    draw(this);
+    this.assertNoPendingPath("clipped");
+    this.nodes.push({ type: "clip-pop" });
+    return this;
+  }
+
+  // --- internals ---------------------------------------------------------------------------------
+
+  private paint(
+    fill: Color | Gradient | undefined,
+    stroke: StrokeStyle | undefined,
+    rule?: FillOptions["rule"],
+  ): this {
+    const commands = this.current;
+    this.current = [];
+    if (commands.length === 0) return this;
+    this.nodes.push({ type: "path", commands, fill, fillRule: rule, stroke });
+    return this;
+  }
+
+  /**
+   * A path may not cross the edge of a scope. It would be built in one coordinate space and painted
+   * in another, and the version that just dropped it made a shape vanish without a word - exactly
+   * the silence this codebase refuses everywhere else.
+   */
+  private assertNoPendingPath(scope: string): void {
+    if (this.current.length === 0) return;
+    this.current = [];
+    throw new Error(
+      `@jasy/pdf: a Canvas path was built but never filled or stroked around \`${scope}()\`. ` +
+        `Paint it before the scope opens, or move the drawing inside it.`,
+    );
+  }
+
+  private resolve(paint: PaintInput): Color | Gradient {
+    if (isGradientInput(paint)) {
+      const box = boundsOf(this.current);
+      return resolveGradient(paint, box.x, box.y, box.width, box.height);
+    }
+    return toColor(paint);
+  }
+
+  private strokeStyle(color: ColorInput, options: StrokeOptions): StrokeStyle {
+    return {
+      color: toColor(color),
+      width: options.width ?? 1,
+      cap: options.cap,
+      join: options.join,
+      miterLimit: options.miterLimit,
+      dash: options.dash,
+      dashOffset: options.dashOffset,
+    };
+  }
+
+  private matrixOf(t: TransformOptions): [number, number, number, number, number, number] {
+    const [ox, oy] = t.origin ?? [0, 0];
+    const [sx, sy] = Array.isArray(t.scale) ? t.scale : [t.scale ?? 1, t.scale ?? 1];
+    const theta = (t.rotate ?? 0) * DEGREES;
+    const [cos, sin] = [Math.cos(theta), Math.sin(theta)];
+    // T(translate) · T(origin) · R · S · T(-origin), written out as a PDF `cm` operand.
+    const [a, b, c, d] = [cos * sx, sin * sx, -sin * sy, cos * sy];
+    const [tx, ty] = t.translate ?? [0, 0];
+    // `-sin(0)` is -0, which is a surprising value to read back out of a matrix. It writes as
+    // "0.000" either way, so normalising costs nothing and keeps the number predictable.
+    const zero = (n: number): number => (n === 0 ? 0 : n);
+    return [a, b, c, d, tx + ox - (a * ox + c * oy), ty + oy - (b * ox + d * oy)].map(zero) as [
+      number,
+      number,
+      number,
+      number,
+      number,
+      number,
+    ];
+  }
+}

--- a/src/lib/elements/canvas-element.ts
+++ b/src/lib/elements/canvas-element.ts
@@ -1,0 +1,78 @@
+import {
+  BoxConstraints,
+  Offset,
+  Size,
+  SizingParams,
+  extentSpecs,
+  resolveSize,
+} from "../layout/box-constraints.ts";
+import type { CanvasPainter, CanvasSize } from "../canvas/painter.ts";
+import { LayoutContext, SizedPDFElement } from "./pdf-element.ts";
+
+/** What the user draws. Runs at RENDER time, once the box is known. */
+export type CanvasPaint = (painter: CanvasPainter, size: CanvasSize) => void;
+
+interface CanvasElementParams extends SizingParams {
+  paint: CanvasPaint;
+  widthFactor?: number;
+  heightFactor?: number;
+  /** Alternate text (tagged PDF): with it the drawing is a Figure, without it decoration. */
+  alt?: string;
+}
+
+/**
+ * A box in the layout that the caller draws into.
+ *
+ * It has no children and no intrinsic size, so unlike an image it FILLS what it is offered when no
+ * size is given - there is nothing to derive one from. That is also why the callback is handed the
+ * resolved size: a drawing written against `size.width` works at any box.
+ */
+export class CanvasElement extends SizedPDFElement {
+  private paintFn: CanvasPaint;
+  private alt?: string;
+  private requested: { width?: number; height?: number };
+  private sizing: SizingParams;
+  private widthFactor?: number;
+  private heightFactor?: number;
+
+  constructor(params: CanvasElementParams) {
+    super({ x: 0, y: 0, width: params.width, height: params.height });
+    const { paint, alt, widthFactor, heightFactor, ...sizing } = params;
+    this.paintFn = paint;
+    this.alt = alt;
+    this.widthFactor = widthFactor;
+    this.heightFactor = heightFactor;
+    this.sizing = sizing;
+    this.requested = { width: params.width, height: params.height };
+  }
+
+  override getProps() {
+    return {
+      x: this.x,
+      y: this.y,
+      width: this.width,
+      height: this.height,
+      paint: this.paintFn,
+      alt: this.alt,
+    };
+  }
+
+  calculateLayout(constraints: BoxConstraints, offset: Offset, _ctx: LayoutContext): Size {
+    this.x = offset.x;
+    this.y = offset.y;
+
+    const specs = extentSpecs({
+      ...this.sizing,
+      width: this.requested.width,
+      height: this.requested.height,
+      widthFactor: this.widthFactor,
+      heightFactor: this.heightFactor,
+    });
+    const resolved = resolveSize(specs.width, specs.height, this.sizing.aspectRatio, constraints);
+    const bounds = resolved.constraints;
+
+    this.width = resolved.width ?? (bounds.hasBoundedWidth ? bounds.maxWidth : 0);
+    this.height = resolved.height ?? (bounds.hasBoundedHeight ? bounds.maxHeight : 0);
+    return { width: this.width, height: this.height };
+  }
+}

--- a/src/lib/elements/index.ts
+++ b/src/lib/elements/index.ts
@@ -25,3 +25,4 @@ export * from "./layout/rotated-box-element.ts";
 export * from "./line-element.ts";
 export * from "./row-element.ts";
 export * from "./svg-element.ts";
+export * from "./canvas-element.ts";

--- a/src/lib/renderer/canvas-renderer.ts
+++ b/src/lib/renderer/canvas-renderer.ts
@@ -14,14 +14,18 @@ import type { IRNode } from "../ir/display-list.ts";
 export class CanvasRenderer {
   static async render(element: CanvasElement, objectManager: PDFObjectManager): Promise<IRNode[]> {
     const { x, y, width, height, paint, alt } = element.getProps();
-    const box = { width: width ?? 0, height: height ?? 0 };
+    // The layout bounds are kept as plain numbers, and the painter and the callback each get their
+    // OWN size object. Sharing one meant a callback that wrote to `size.width` moved the clip away
+    // from the box layout had reserved - the drawing would then bleed into what sits beside it.
+    const w = width ?? 0;
+    const h = height ?? 0;
 
-    const painter = new CanvasPainter(box);
-    paint(painter, box);
+    const painter = new CanvasPainter({ width: w, height: h });
+    paint(painter, { width: w, height: h });
     const drawn = painter.drawn();
 
     const nodes: IRNode[] = [
-      { type: "clip-push", x: x ?? 0, y: y ?? 0, width: box.width, height: box.height },
+      { type: "clip-push", x: x ?? 0, y: y ?? 0, width: w, height: h },
       { type: "transform-push", matrix: [1, 0, 0, 1, x ?? 0, y ?? 0] },
       ...drawn,
       { type: "transform-pop" },

--- a/src/lib/renderer/canvas-renderer.ts
+++ b/src/lib/renderer/canvas-renderer.ts
@@ -1,0 +1,38 @@
+import { PDFObjectManager } from "../utils/pdf-object-manager.ts";
+import { CanvasElement } from "../elements/canvas-element.ts";
+import { CanvasPainter } from "../canvas/painter.ts";
+import type { IRNode } from "../ir/display-list.ts";
+
+/**
+ * Runs the caller's paint callback and hands back what it drew.
+ *
+ * The painter works in CANVAS coordinates (0,0 is the box's own corner), so the whole drawing is
+ * wrapped in one translate rather than every point being offset - the same shape `Svg` uses, and it
+ * keeps the callback independent of where the box ended up. The clip is the box: a drawing that runs
+ * past its own edge would otherwise bleed into the layout beside it.
+ */
+export class CanvasRenderer {
+  static async render(element: CanvasElement, objectManager: PDFObjectManager): Promise<IRNode[]> {
+    const { x, y, width, height, paint, alt } = element.getProps();
+    const box = { width: width ?? 0, height: height ?? 0 };
+
+    const painter = new CanvasPainter(box);
+    paint(painter, box);
+    const drawn = painter.drawn();
+
+    const nodes: IRNode[] = [
+      { type: "clip-push", x: x ?? 0, y: y ?? 0, width: box.width, height: box.height },
+      { type: "transform-push", matrix: [1, 0, 0, 1, x ?? 0, y ?? 0] },
+      ...drawn,
+      { type: "transform-pop" },
+      { type: "clip-pop" },
+    ];
+
+    if (!alt || !objectManager.struct.enabled) return nodes;
+    const tag = {
+      role: "Figure",
+      key: objectManager.struct.openElement(element.structId, "Figure", { alt }),
+    };
+    return nodes.map((node) => (node.type === "path" ? { ...node, tag } : node));
+  }
+}

--- a/src/lib/renderer/index.ts
+++ b/src/lib/renderer/index.ts
@@ -9,3 +9,4 @@ export * from "./expanded-renderer.ts";
 export * from "./line-renderer.ts";
 export * from "./row-renderer.ts";
 export * from "./svg-renderer.ts";
+export * from "./canvas-renderer.ts";

--- a/src/lib/renderer/pdf-renderer.ts
+++ b/src/lib/renderer/pdf-renderer.ts
@@ -7,6 +7,7 @@ import {
   ExpandedElement,
   ImageElement,
   LineElement,
+  CanvasElement,
   PaddingElement,
   SvgElement,
   TextElement,
@@ -24,6 +25,7 @@ import { DefaultTextStyleRenderer } from "./default-text-style-renderer.ts";
 import { ImageRenderer } from "./image-renderer.ts";
 import { LineRenderer } from "./line-renderer.ts";
 import { SvgRenderer } from "./svg-renderer.ts";
+import { CanvasRenderer } from "./canvas-renderer.ts";
 import { RepeatingHeaderElement } from "../elements/layout/repeating-header-element.ts";
 import { RepeatingHeaderRenderer } from "./repeating-header-renderer.ts";
 import { DeferredElement } from "../elements/layout/deferred-element.ts";
@@ -84,6 +86,7 @@ export class PDFRenderer {
     RendererRegistry.register(ImageElement, ImageRenderer.render);
     RendererRegistry.register(LineElement, LineRenderer.render);
     RendererRegistry.register(SvgElement, SvgRenderer.render);
+    RendererRegistry.register(CanvasElement, CanvasRenderer.render);
     RendererRegistry.register(RepeatingHeaderElement, RepeatingHeaderRenderer.render);
     RendererRegistry.register(DeferredElement, DeferredRenderer.render);
     RendererRegistry.register(PositionedElement, PositionedRenderer.render);

--- a/src/lib/svg/gradients.ts
+++ b/src/lib/svg/gradients.ts
@@ -5,6 +5,7 @@ import type { Affine } from "../utils/ttf-parser.ts";
 import { SvgUnsupportedError } from "./errors.ts";
 import { IDENTITY, isIdentity, parseTransform } from "./transform.ts";
 import { svgColor, type Attributes } from "./style.ts";
+import { boundsOf } from "../vector/path.ts";
 import { ratio } from "./units.ts";
 import type { XmlElement, XmlNode } from "./xml.ts";
 
@@ -122,40 +123,6 @@ function inherited(
     current = current.href === undefined ? undefined : defs.get(current.href);
   }
   return { attributes, stops, opacities };
-}
-
-/** The bounding box of a shape, for `objectBoundingBox` units. Control points are included, which
- *  overstates a curve slightly - the same approximation every renderer makes here. */
-function boundsOf(commands: readonly PathCommand[]): {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-} {
-  let minX = Infinity,
-    minY = Infinity,
-    maxX = -Infinity,
-    maxY = -Infinity;
-  for (const c of commands) {
-    const points =
-      c.op === "c"
-        ? ([
-            [c.x1, c.y1],
-            [c.x2, c.y2],
-            [c.x, c.y],
-          ] as const)
-        : c.op === "z"
-          ? ([] as const)
-          : ([[c.x, c.y]] as const);
-    for (const [x, y] of points) {
-      minX = Math.min(minX, x);
-      maxX = Math.max(maxX, x);
-      minY = Math.min(minY, y);
-      maxY = Math.max(maxY, y);
-    }
-  }
-  if (!Number.isFinite(minX)) return { x: 0, y: 0, width: 0, height: 0 };
-  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
 }
 
 const SPREAD: Record<string, Gradient["extend"]> = {

--- a/src/lib/vector/path.ts
+++ b/src/lib/vector/path.ts
@@ -62,3 +62,39 @@ export function transformCommands(
     return { op: cmd.op, x: mx(cmd.x, cmd.y), y: my(cmd.x, cmd.y) };
   });
 }
+
+/**
+ * The bounding box of a command list. Control points are included, which overstates a curve slightly -
+ * the approximation every renderer makes for `objectBoundingBox` units and for a canvas gradient.
+ */
+export function boundsOf(commands: readonly PathCommand[]): {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+} {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const c of commands) {
+    const points =
+      c.op === "c"
+        ? [
+            [c.x1, c.y1],
+            [c.x2, c.y2],
+            [c.x, c.y],
+          ]
+        : c.op === "z"
+          ? []
+          : [[c.x, c.y]];
+    for (const [x, y] of points) {
+      minX = Math.min(minX, x!);
+      maxX = Math.max(maxX, x!);
+      minY = Math.min(minY, y!);
+      maxY = Math.max(maxY, y!);
+    }
+  }
+  if (!Number.isFinite(minX)) return { x: 0, y: 0, width: 0, height: 0 };
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+}

--- a/tests/unit/canvas/element.test.ts
+++ b/tests/unit/canvas/element.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { Document, Page, Box, Canvas } from "../../../src/lib/api/index.ts";
+import { renderPdf } from "../../../src/lib/api/structure.ts";
+
+// A canvas is a block IN the layout, never a way around it: it takes the box it is given, it clips
+// to that box, and it paginates as one unbreakable unit.
+
+const render = (element: unknown, options = {}) =>
+  renderPdf(Document([Page([element as never])]), { compress: false, ...options });
+
+describe("the box", () => {
+  it("hands the callback the size it resolved to", async () => {
+    let seen: { width: number; height: number } | undefined;
+    await render(Canvas({ width: 120, height: 40 }, (_c, size) => void (seen = size)));
+    expect(seen).toEqual({ width: 120, height: 40 });
+  });
+
+  it("fills what it is offered when no size is given", async () => {
+    // Unlike an image there is no intrinsic size to fall back on.
+    let seen = 0;
+    await render(Box({ width: 200 }, [Canvas({ height: 30 }, (_c, s) => void (seen = s.width))]));
+    expect(seen).toBe(200);
+  });
+
+  it("clips to its own box, so a drawing cannot bleed into the layout beside it", async () => {
+    const pdf = await render(
+      Canvas({ width: 50, height: 20 }, (c) => void c.rect(0, 0, 5, 5).fill()),
+    );
+    expect(pdf).toContain("W n");
+  });
+});
+
+describe("what it draws reaches the page", () => {
+  it("writes the fill colour into the content stream", async () => {
+    const pdf = await render(
+      Canvas({ width: 40, height: 20 }, (c) => void c.rect(0, 0, 10, 10).fill("#1450aa")),
+    );
+    expect(pdf).toContain("0.078 0.314 0.667 rg");
+  });
+
+  it("is a Figure with alt text, and decoration without it", async () => {
+    const accessible = { accessible: true, title: "t", lang: "en" };
+    const tagged = await render(
+      Canvas({ width: 40, height: 20, alt: "A sparkline" }, (c) => void c.rect(0, 0, 9, 9).fill()),
+      accessible,
+    );
+    expect(tagged).toContain("/Figure");
+    expect(tagged).toContain("A sparkline");
+
+    const plain = await render(
+      Canvas({ width: 40, height: 20 }, (c) => void c.rect(0, 0, 9, 9).fill()),
+      accessible,
+    );
+    expect(plain).not.toContain("/Figure");
+  });
+
+  it("takes the callback alone when the box comes from the layout", async () => {
+    const pdf = await render(
+      Box({ width: 60, height: 20 }, [Canvas((c) => void c.rect(0, 0, 9, 9).fill("#e2483d"))]),
+    );
+    expect(pdf).toContain("0.886 0.282 0.239 rg");
+  });
+});

--- a/tests/unit/canvas/element.test.ts
+++ b/tests/unit/canvas/element.test.ts
@@ -22,6 +22,21 @@ describe("the box", () => {
     expect(seen).toBe(200);
   });
 
+  it("keeps the clip on the LAYOUT box even if the callback writes to its size", async () => {
+    // The painter, the callback and the clip used to share one object, so `size.width = 999` moved
+    // the clip away from the box the layout had reserved.
+    const pdf = await render(
+      Canvas({ width: 50, height: 20 }, (c, size) => {
+        size.width = 999;
+        (c as unknown as { size: { height: number } }).size.height = 999;
+        c.rect(0, 0, 5, 5).fill();
+      }),
+    );
+    // The clip rect the backend writes: "<x> <y> <w> <h> re".
+    const clip = /([-\d.]+) ([-\d.]+) ([-\d.]+) ([-\d.]+) re/.exec(pdf);
+    expect(clip?.slice(3, 5)).toEqual(["50", "20"]);
+  });
+
   it("clips to its own box, so a drawing cannot bleed into the layout beside it", async () => {
     const pdf = await render(
       Canvas({ width: 50, height: 20 }, (c) => void c.rect(0, 0, 5, 5).fill()),

--- a/tests/unit/canvas/painter.test.ts
+++ b/tests/unit/canvas/painter.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import { CanvasPainter } from "../../../src/lib/canvas/painter.ts";
+import { linearGradient } from "../../../src/lib/api/gradient.ts";
+import type { Path } from "../../../src/lib/ir/display-list.ts";
+
+// The painter is the SECOND producer of the vector layer, so it emits the same `Path` nodes an SVG
+// does - no new IR, no backend change. What is tested here is the surface a user actually touches.
+
+const painter = () => new CanvasPainter({ width: 100, height: 50 });
+const paths = (draw: (c: CanvasPainter) => void): Path[] => {
+  const c = painter();
+  draw(c);
+  return c.drawn().filter((n): n is Path => n.type === "path");
+};
+
+describe("a path is finished by painting it", () => {
+  it("emits one node per fill or stroke", () => {
+    const out = paths((c) => {
+      c.rect(0, 0, 10, 10).fill("red");
+      c.rect(20, 0, 10, 10).stroke("blue");
+    });
+    expect(out).toHaveLength(2);
+    expect(out[0]!.fill).toBeDefined();
+    expect(out[0]!.stroke).toBeUndefined();
+    expect(out[1]!.stroke?.color.toPDFColorString()).toBe("0.000 0.000 1.000");
+  });
+
+  it("starts a new path afterwards, so a shape cannot leak into the next", () => {
+    const out = paths((c) => {
+      c.rect(0, 0, 10, 10).fill();
+      c.rect(20, 0, 10, 10).fill();
+    });
+    expect(out[0]!.commands).toHaveLength(5);
+    expect(out[1]!.commands).toHaveLength(5);
+  });
+
+  it("draws nothing for a path nobody painted", () => {
+    expect(paths((c) => void c.rect(0, 0, 10, 10))).toHaveLength(0);
+  });
+
+  it("does both with fillAndStroke", () => {
+    const [p] = paths((c) => void c.circle(5, 5, 4).fillAndStroke("red", "blue", { width: 2 }));
+    expect(p!.fill).toBeDefined();
+    expect(p!.stroke?.width).toBe(2);
+  });
+});
+
+describe("the shapes", () => {
+  it("closes a rect on its four corners", () => {
+    const [p] = paths((c) => void c.rect(1, 2, 10, 20).fill());
+    expect(p!.commands).toEqual([
+      { op: "m", x: 1, y: 2 },
+      { op: "l", x: 11, y: 2 },
+      { op: "l", x: 11, y: 22 },
+      { op: "l", x: 1, y: 22 },
+      { op: "z" },
+    ]);
+  });
+
+  it("draws a circle as four cubics", () => {
+    const [p] = paths((c) => void c.circle(10, 10, 5).fill());
+    expect(p!.commands.filter((s) => s.op === "c")).toHaveLength(4);
+  });
+
+  it("raises a quadratic to the cubic PDF needs", () => {
+    const [p] = paths((c) => void c.move(0, 0).quad(6, 9, 12, 0).stroke());
+    expect(p!.commands[1]).toMatchObject({ op: "c", x1: 4, y1: 6, x2: 8, y2: 6, x: 12, y: 0 });
+  });
+
+  it("reads SVG path data, arcs included", () => {
+    const [p] = paths((c) => void c.path("M0 0 h10 a5 5 0 0 1 0 10 z").fill());
+    expect(p!.commands.every((s) => ["m", "l", "c", "z"].includes(s.op))).toBe(true);
+  });
+
+  it("leaves the pen where SVG leaves it - a `z` returns to the subpath start", () => {
+    // A `quad` after a closed path used the last POINT seen, which is not where the pen is.
+    const [p] = paths((c) => void c.path("M10 10 h10 v10 z").quad(30, 30, 20, 20).stroke());
+    expect(p!.commands.at(-1)).toMatchObject({ x1: 23.333333333333332, y1: 23.333333333333332 });
+  });
+});
+
+describe("scopes close themselves - there is no restore() to forget", () => {
+  it("wraps a group in a transform pair", () => {
+    const c = painter();
+    c.group({ translate: [5, 5] }, (g) => void g.rect(0, 0, 4, 4).fill());
+    const kinds = c.drawn().map((n) => n.type);
+    expect(kinds).toEqual(["transform-push", "path", "transform-pop"]);
+  });
+
+  it("composes translate, rotate and scale around an origin", () => {
+    const c = painter();
+    c.group({ translate: [10, 0], scale: 2 }, () => {});
+    expect(c.drawn()[0]).toMatchObject({ matrix: [2, 0, 0, 2, 10, 0] });
+  });
+
+  it("turns clockwise, like every other rotation in the engine", () => {
+    const c = painter();
+    c.group({ rotate: 90 }, () => {});
+    const m = (c.drawn()[0] as { matrix: number[] }).matrix;
+    expect(m[1]).toBeCloseTo(1, 10);
+    expect(m[2]).toBeCloseTo(-1, 10);
+  });
+
+  it("clips with the shape `build` drew, and paints nothing from it", () => {
+    const c = painter();
+    c.clipped(
+      (clip) => void clip.circle(10, 10, 5),
+      (draw) => void draw.rect(0, 0, 20, 20).fill(),
+    );
+    const kinds = c.drawn().map((n) => n.type);
+    expect(kinds).toEqual(["clip-path-push", "path", "clip-pop"]);
+    // Exactly one path: the clip shape is geometry, never ink.
+    expect(c.drawn().filter((n) => n.type === "path")).toHaveLength(1);
+  });
+});
+
+// Found while reviewing: a path built BEFORE a scope was silently swallowed when the scope closed -
+// the user's shape simply disappeared. It cannot be carried across either, because it would be built
+// in one coordinate space and painted in another.
+describe("a path may not cross the edge of a scope", () => {
+  it("names it instead of dropping the shape", () => {
+    expect(() => {
+      const c = painter();
+      c.rect(0, 0, 10, 10);
+      c.group({ translate: [50, 0] }, (g) => void g.circle(5, 5, 4).fill());
+    }).toThrow(/never filled or stroked/);
+  });
+
+  it("names one left behind INSIDE a scope too", () => {
+    expect(() => {
+      const c = painter();
+      c.group({ translate: [50, 0] }, (g) => void g.rect(0, 0, 4, 4));
+    }).toThrow(/group\(\)/);
+  });
+
+  it("is happy when every path is painted", () => {
+    expect(() => {
+      const c = painter();
+      c.rect(0, 0, 10, 10).fill();
+      c.group({ translate: [50, 0] }, (g) => void g.circle(5, 5, 4).fill());
+    }).not.toThrow();
+  });
+});
+
+describe("paint", () => {
+  it("defaults to black, as SVG and PDF do", () => {
+    const [p] = paths((c) => void c.rect(0, 0, 4, 4).fill());
+    expect(p!.fill && "toPDFColorString" in p.fill && p.fill.toPDFColorString()).toBe(
+      "0.000 0.000 0.000",
+    );
+  });
+
+  it("takes any ColorInput the rest of the API takes", () => {
+    const [p] = paths((c) => void c.rect(0, 0, 4, 4).fill("rgb(20, 90, 170)"));
+    expect(p!.fill && "toPDFColorString" in p.fill && p.fill.toPDFColorString()).toBe(
+      "0.078 0.353 0.667",
+    );
+  });
+
+  it("resolves a gradient against the SHAPE's own box, as SVG does", () => {
+    const [p] = paths(
+      (c) =>
+        void c.rect(10, 20, 40, 10).fill(linearGradient({ angle: 90, stops: ["#000", "#fff"] })),
+    );
+    const fill = p!.fill as { type: string; x0: number; x1: number };
+    expect(fill.type).toBe("linear");
+    expect([fill.x0, fill.x1]).toEqual([10, 50]);
+  });
+
+  it("carries the even-odd rule through", () => {
+    const [p] = paths((c) => void c.rect(0, 0, 9, 9).fill("red", { rule: "evenodd" }));
+    expect(p!.fillRule).toBe("evenodd");
+  });
+});


### PR DESCRIPTION
## Summary

Basic Canvas implementation. 

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Canvas API for imperative vector drawing in generated PDFs.
  - Supports shapes, paths, curves, fills, strokes, gradients, clipping, and scoped transforms.
  - Canvas content respects layout dimensions, top-left coordinates, and clipping boundaries.
  - Optional alternate text enables accessible figure tagging.
  - Supports callback-only usage and configurable sizing, aspect ratios, and dimensions.

- **Documentation**
  - Added API guidance covering drawing capabilities, layout behavior, accessibility, and pagination.

- **Tests**
  - Added coverage for sizing, rendering, geometry, gradients, transforms, clipping, and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->