### PR TITLE
fix: an overflowing row pulls its children back in - `flexShrink` is 1, as in `CSS`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -546,9 +546,9 @@ agree: true })` → declarative values, not object mutation. Save is an **increm
   `order`, `reverse` on `Row`/`Column`. This closes the last react-pdf parity gap in layout (Yoga gives
   them that set for free). `FlexLayoutHelper.layout()` now dispatches: the untouched single-line engine
   is `layoutLine()`, and `layoutWrapped()` splits into lines, measures each, then places the BLOCK of
-  lines by `alignContent`. Two defaults deviate from CSS ON PURPOSE — `flexShrink` is **0** (CSS says 1)
-  so no existing layout moves, and `alignContent` is `start`. All of it is off by default, which is why
-  the 30 gallery cases before it stayed byte-identical.
+  lines by `alignContent`. `flexShrink` shipped as **0** so no existing layout would move, and
+  `alignContent` as `start`; the 30 gallery cases before it stayed byte-identical. **`flexShrink` became
+  1 (the CSS default) on 2026-09-05** — see the entry below.
   **The trap that cost a real bug:** a line's `%` children resolve against **the line minus its gaps**
   (our documented relative-sizing rule, so N columns at (100/N)% fit exactly). The wrap pass has to use
   the SAME base — it first measured against the full line, making each child a few points too wide, and
@@ -823,6 +823,31 @@ polygon path fill stroke fillAndStroke group clipped`), with three deliberate di
   it - no text layout, no pagination inside. What is beyond it but still expressible in PDF (text
   render modes, blend modes, tiling patterns, CMYK/spot, soft masks, optional content) is in `todo.md`
   under Roadmap to 1.1.
+
+- ✅ **`flexShrink` is 1, and has a floor** (2026-09-05) — the CSS default, flipped while still in alpha
+  so it costs nobody a major. An overflowing flex line now pulls its children back inside instead of
+  letting them run past the edge; `flexShrink: 0` opts out. **The measurement is the argument**: four of
+  the 36 gallery cases were overflowing their page margin without anyone noticing (`26-corner-radius` and
+  `27-gradients` by 70px, `08-colors` by 50, `24-percentage-insets` by 26, against a content box ending
+  at 728px). Nothing ever pulled them back, so nothing ever complained. The fifth changed case is
+  `31-flexbox` itself, whose whole point was the contrast — it now demonstrates opting OUT.
+  **No pagination case moved**, which was the real worry: a Column's main axis is vertical, and squeezing
+  children there instead of paginating them would have been catastrophic. It does not happen.
+  - **The floor is the other half, and without it the flip would be half a rule.** `PDFElement.minIntrinsicMain(horizontal, ctx)`
+    is CSS's `min-content` (`layout/min-intrinsic.ts`), built like `needsBoundedMain`: default 0, `TextElement`
+    answers its longest word (a single CHARACTER when `breakWord`/`hyphenate` is on, as CSS does for
+    `word-break: break-all`), and the containers recurse — along their own axis the floors ADD UP plus the
+    gaps, across it the widest wins, and a wrapping stack adds up nothing since it may put every child on
+    its own line. An element's declared extent folds in as CSS's "specified size suggestion": the SMALLER
+    of the two, so a `Box({ width: 400 })` around 50pt of content may still be squeezed to 50.
+    Without it a badly overflowing line grinds a paragraph down to one word per line — measured before it
+    was built: a text capped at 12pt came back 60pt tall, trading a wide box for a tall one and gaining
+    nothing.
+  - **Distribution is iterative** (CSS Flexbox 9.7): a child that lands on its floor is FROZEN there and
+    the share it could not absorb is handed to the rest. One pass would leave that share unspent, so a
+    single unsqueezable child would keep the whole line overflowing while its neighbours still had room.
+  - The floor changed **no** gallery output — it only binds in extreme overflow. That is the point: it is
+    a safety net, not a second behaviour change.
 
 Genuine remaining gaps / deferred:
 

--- a/README.md
+++ b/README.md
@@ -116,9 +116,11 @@ const pdf = await renderToBytes(
 );
 ```
 
-Real text layout (Adobe AFM metrics, kerning, word-wrap), flexbox-style `gap` / `justify` / `align`,
-boxes with radius and alpha, images, custom TrueType fonts, **AES-256 password encryption**, and **real
-pagination** - content that overflows flows onto the next page, headers and footers repeat.
+Real text layout (real font metrics, kerning, ligatures, word-wrap), full flexbox (`gap` / `justify` /
+`align`, wrap, `flexBasis`, `flexShrink`, `order`), boxes with per-corner radius, gradients and alpha, images and
+**SVG**, a `Canvas` to draw into, custom fonts from a file, bytes or a URL, AcroForm fields,
+**AES-256 password encryption**, tagged PDFs for screen readers, and **real pagination** - content that
+overflows flows onto the next page, headers and footers repeat, and a block can refuse to be split.
 
 ---
 
@@ -140,9 +142,19 @@ verify all of it:
 - **PDF/A-3, matched not approximated.** The conformance graph is hand-built and **passes veraPDF**, the
   official ISO 19005 validator.
 - **Byte-exact round-trips.** Generate and parse are inverses: `generate → parse → regenerate` reproduces
-  the identical XML. Over 900 tests hold the line across the workspace.
+  the identical XML. Over 1,600 tests hold the line across the workspace.
 - **Schematron, local.** The official EN-16931 + XRechnung rules run via saxon-js (the real XSLT, in pure
   JS) - no Java, no upload.
+- **Vectors, not bitmaps.** `Image("logo.svg")` keeps a logo a VECTOR - our own SVG reader and our own
+  XML parser, checked against 10,819 real files and compared pixel for pixel with headless Chrome. Need
+  a chart instead? `Canvas` hands you a typed pen for the same vector layer.
+- **Fonts, whatever the container.** `.ttf`, `.woff` and `.woff2` are the same thing at the call site.
+  The WOFF2 container and its `glyf` transform are ours; only Brotli is a dependency, and it is loaded
+  only if a WOFF2 actually turns up.
+- **Byte-stable output.** The same document rendered twice is byte-identical, PDF/A and ZUGFeRD
+  included, across separate processes. An archived invoice stays re-derivable and hashable years later.
+- **Accessible if you ask.** `renderToBytes(doc, { accessible })` emits a full tagged structure tree,
+  verified `isCompliant` by veraPDF against PDF/UA-1.
 
 ---
 
@@ -153,12 +165,14 @@ verify all of it:
 | **[@jasy/e-invoice](https://npmx.dev/@jasy/e-invoice)** | ZUGFeRD / XRechnung: your data → PDF/A-3 + EN-16931 XML, with local validation. **The prize.** |
 | **[@jasy/cli](https://npmx.dev/@jasy/cli)**             | the `jasy` terminal: read · validate · export, headless **and** interactive                    |
 | **[@jasy/pdf](https://npmx.dev/@jasy/pdf)**             | the declarative, Flutter-style PDF layout engine that powers them                              |
+| **[@jasy/vue](https://npmx.dev/@jasy/vue)**             | author PDFs as Vue components - and render them in the browser                                 |
+| **[@jasy/nuxt](https://npmx.dev/@jasy/nuxt)**           | the Nuxt module: zero-config PDFs, client **or** server                                        |
 
 ---
 
 ## Why you can trust it
 
-- **Over 900 tests, green** across the workspace (850 in the engine alone). The generator and the parser
+- **Over 1,600 tests, green** across the workspace (1,190 in the engine alone). The generator and the parser
   are **byte-exact inverses**: `generate → parse → regenerate` reproduces the identical XML. Nothing is
   silently lost.
 - **The same rules the authorities use** - the official KoSIT EN-16931 + XRechnung Schematron, and the
@@ -170,10 +184,14 @@ verify all of it:
 
 ## Honest scope
 
-jasy targets the documents that matter here: invoices, reports, quotes, datasheets. It is **not** a
-LaTeX / WeasyPrint replacement - no microtypography, hyphenation or bidi, and arbitrary multi-page flow
-of _any_ content is still maturing. For e-invoices (a table, totals, a footer) it is complete - they
-even paginate. We would rather under-promise and over-deliver in the demo above.
+jasy targets the documents that matter here: invoices, reports, quotes, datasheets - and it now sets
+text properly: kerning and Latin ligatures from the font's own tables, justification, pluggable
+hyphenation, right-to-left and Arabic shaping, underlines that step around descenders. Pagination is
+real: text splits at line boxes, `keepTogether` moves a card whole, orphans and widows are honoured.
+
+It is still **not** a LaTeX or WeasyPrint replacement, and does not try to be: no automatic
+microtypography, no floats, no CSS engine. What it will not draw, it **names** - an SVG filter, a font
+without the glyph, a word that cannot be split - rather than quietly drawing something else.
 
 > **Status:** young and pre-1.0. The API can still shift between minor versions. Everything shown here
 > works and is tested.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ verify all of it:
 - **Byte-stable output.** The same document rendered twice is byte-identical, PDF/A and ZUGFeRD
   included, across separate processes. An archived invoice stays re-derivable and hashable years later.
 - **Accessible if you ask.** `renderToBytes(doc, { accessible })` emits a full tagged structure tree,
-  verified `isCompliant` by veraPDF against PDF/UA-1.
+  and the output passes veraPDF's machine-verifiable PDF/UA-1 checks.
 
 ---
 

--- a/src/lib/api/dimension.ts
+++ b/src/lib/api/dimension.ts
@@ -50,8 +50,9 @@ export interface BoundsInput {
   order?: number;
   /**
    * How willingly this child gives up main-axis space when the line overflows (CSS `flex-shrink`),
-   * weighted by its own size. **Default 0, deliberately unlike CSS's 1** - shrinking changes what a
-   * document looks like, so it is opted into per child rather than applied to everything at once.
+   * weighted by its own size. Default 1, as in CSS: an overflowing line pulls its children back inside
+   * instead of letting them run past the edge. Set `0` to keep a child at its natural size and let it
+   * overflow. A child is never squeezed below what it can hold - a text stops at its longest word.
    */
   flexShrink?: number;
   minWidth?: SizeInput;

--- a/src/lib/elements/container-element.ts
+++ b/src/lib/elements/container-element.ts
@@ -1,4 +1,5 @@
 import { FlexLayoutHelper, VERTICAL_AXIS, MainAlign, CrossAlign } from "../utils/flex-layout.ts";
+import { stackMinIntrinsic, withDeclaredExtent } from "../layout/min-intrinsic.ts";
 import {
   BoxConstraints,
   Offset,
@@ -186,6 +187,19 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
     if (requested.some((v) => v !== undefined)) return false;
     const ownFlexChild = !horizontal && this.children.some((c) => c instanceof FlexiblePDFElement);
     return ownFlexChild || this.children.some((c) => c.needsBoundedMain(horizontal));
+  }
+
+  /** A Column stacks vertically, so widths overlap and heights add up. */
+  override minIntrinsicMain(horizontal: boolean, ctx: LayoutContext): number {
+    const content = stackMinIntrinsic(
+      this.children,
+      this.gap,
+      !horizontal,
+      horizontal,
+      ctx,
+      this.wrap,
+    );
+    return withDeclaredExtent(content, horizontal ? this.requested.width : this.requested.height);
   }
 
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {

--- a/src/lib/elements/container-element.ts
+++ b/src/lib/elements/container-element.ts
@@ -199,7 +199,11 @@ export class ContainerElement extends SizedPDFElement implements Fragmentable {
       ctx,
       this.wrap,
     );
-    return withDeclaredExtent(content, horizontal ? this.requested.width : this.requested.height);
+    return withDeclaredExtent(
+      content,
+      horizontal ? this.requested.width : this.requested.height,
+      horizontal ? this.requested.minWidth : this.requested.minHeight,
+    );
   }
 
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {

--- a/src/lib/elements/layout/expanded-element.ts
+++ b/src/lib/elements/layout/expanded-element.ts
@@ -24,6 +24,11 @@ export class ExpandedElement extends FlexiblePDFElement implements Fragmentable 
     this.child = child;
   }
 
+  /** Layout-transparent: the floor is whatever the wrapped child needs. */
+  override minIntrinsicMain(horizontal: boolean, ctx: LayoutContext): number {
+    return this.child.minIntrinsicMain(horizontal, ctx);
+  }
+
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
     if (constraints.hasBoundedWidth) this.width = constraints.maxWidth;
     // Absolute placement from the parent; assignment (not +=) so re-layout is idempotent.

--- a/src/lib/elements/layout/keep-together-element.ts
+++ b/src/lib/elements/layout/keep-together-element.ts
@@ -30,6 +30,11 @@ export class KeepTogetherElement extends PDFElement implements Fragmentable {
     this.child = child;
   }
 
+  /** Layout-transparent: the floor is whatever the wrapped child needs. */
+  override minIntrinsicMain(horizontal: boolean, ctx: LayoutContext): number {
+    return this.child.minIntrinsicMain(horizontal, ctx);
+  }
+
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
     return this.child.calculateLayout(constraints, offset, ctx);
   }

--- a/src/lib/elements/layout/padding-element.ts
+++ b/src/lib/elements/layout/padding-element.ts
@@ -62,6 +62,17 @@ export class PaddingElement extends SizedPDFElement implements Fragmentable {
     return new PaddingElement({ margin: this.margin, child });
   }
 
+  /**
+   * The child plus our own insets. A PERCENTAGE inset counts as zero here: it resolves against a width
+   * that is not decided yet, which is exactly how CSS treats a percentage when sizing intrinsically.
+   */
+  override minIntrinsicMain(horizontal: boolean, ctx: LayoutContext): number {
+    const [top, right, bottom, left] = resolveEdges(this.margin, 0);
+    return (
+      this.child.minIntrinsicMain(horizontal, ctx) + (horizontal ? left + right : top + bottom)
+    );
+  }
+
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
     // Padding takes the width it is offered; its height shrink-wraps the child.
     if (constraints.hasBoundedWidth) this.width = constraints.maxWidth;

--- a/src/lib/elements/layout/struct-group.ts
+++ b/src/lib/elements/layout/struct-group.ts
@@ -20,6 +20,11 @@ export class StructGroup extends PDFElement implements Fragmentable {
     this.child = child;
   }
 
+  /** Layout-transparent: the floor is whatever the wrapped child needs. */
+  override minIntrinsicMain(horizontal: boolean, ctx: LayoutContext): number {
+    return this.child.minIntrinsicMain(horizontal, ctx);
+  }
+
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {
     return this.child.calculateLayout(constraints, offset, ctx);
   }

--- a/src/lib/elements/pdf-element.ts
+++ b/src/lib/elements/pdf-element.ts
@@ -115,6 +115,20 @@ export abstract class PDFElement {
   }
 
   /**
+   * The smallest main-axis extent this element can be squeezed into and still hold its content - CSS's
+   * `min-content` size, which is what an automatic `min-width` resolves to on a flex item. The shrink
+   * pass floors every child at this value, so a line that overflows badly stops squeezing rather than
+   * grinding a paragraph down to one word per line (which would only trade a wide box for a tall one).
+   *
+   * `horizontal` = the width. Default 0: an element with no opinion may be squeezed to nothing, which
+   * is what an empty box or a plain drawing can do without harm. Text and the layout containers
+   * override it; containers recurse, since a Row is only as unsqueezable as its children.
+   */
+  minIntrinsicMain(_horizontal: boolean, _ctx: LayoutContext): number {
+    return 0;
+  }
+
+  /**
    * Whether this element IS a forced page break (a `PageBreak`). The pagination packer cuts the flow
    * at such a marker: everything before it stays, everything after starts a new page. Default: no.
    */
@@ -172,11 +186,16 @@ export abstract class PDFElement {
 
   /**
    * How willingly this child gives up main-axis space when the line overflows (CSS `flex-shrink`),
-   * weighted by its own size as CSS does. **Default 0, deliberately unlike CSS's 1**: shrinking is a
-   * change of what a document LOOKS like, and every document written before this existed must keep
-   * laying out exactly as it did. Opt in per child.
+   * weighted by its own size as CSS does. Default 1, as in CSS: an overflowing line squeezes its
+   * children back inside instead of letting them run past the edge of the box. `0` opts out and keeps
+   * a child at its natural size.
+   *
+   * This was 0 until the alpha, so that adding flexShrink could not move an existing layout. That
+   * caution outlived its use: four of the gallery cases turned out to be overflowing their page
+   * margin without anyone noticing, because nothing ever pulled them back. Shrinking is bounded from
+   * below by `minIntrinsicMain`, so a child is never squeezed past what it can actually hold.
    */
-  flexShrink = 0;
+  flexShrink = 1;
 
   /** Sets `flexShrink` and returns the element. */
   withFlexShrink(shrink: number | undefined): this {

--- a/src/lib/elements/rectangle-element.ts
+++ b/src/lib/elements/rectangle-element.ts
@@ -227,7 +227,11 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
   override minIntrinsicMain(horizontal: boolean, ctx: LayoutContext): number {
     const content =
       stackMinIntrinsic(this.children, 0, !horizontal, horizontal, ctx) + 2 * this.borderWidth;
-    return withDeclaredExtent(content, horizontal ? this.sizeMemory.width : this.sizeMemory.height);
+    return withDeclaredExtent(
+      content,
+      horizontal ? this.sizeMemory.width : this.sizeMemory.height,
+      horizontal ? this.sizeMemory.minWidth : this.sizeMemory.minHeight,
+    );
   }
 
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {

--- a/src/lib/elements/rectangle-element.ts
+++ b/src/lib/elements/rectangle-element.ts
@@ -9,6 +9,7 @@ import {
   extentSpecs,
   resolveSize,
 } from "../layout/box-constraints.ts";
+import { stackMinIntrinsic, withDeclaredExtent } from "../layout/min-intrinsic.ts";
 import {
   Fragmentable,
   FragmentResult,
@@ -220,6 +221,13 @@ export class RectangleElement extends SizedPDFElement implements Fragmentable {
       : [this.sizeMemory.height, this.sizeMemory.heightFactor];
     if (requested.some((v) => v !== undefined)) return false;
     return this.children.some((c) => c.needsBoundedMain(horizontal));
+  }
+
+  /** A Box stacks its children vertically inside its border, which is on both sides of the axis. */
+  override minIntrinsicMain(horizontal: boolean, ctx: LayoutContext): number {
+    const content =
+      stackMinIntrinsic(this.children, 0, !horizontal, horizontal, ctx) + 2 * this.borderWidth;
+    return withDeclaredExtent(content, horizontal ? this.sizeMemory.width : this.sizeMemory.height);
   }
 
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {

--- a/src/lib/elements/row-element.ts
+++ b/src/lib/elements/row-element.ts
@@ -7,6 +7,7 @@ import {
   resolveSize,
 } from "../layout/box-constraints.ts";
 import { FlexLayoutHelper, HORIZONTAL_AXIS, MainAlign, CrossAlign } from "../utils/flex-layout.ts";
+import { stackMinIntrinsic, withDeclaredExtent } from "../layout/min-intrinsic.ts";
 import {
   FlexiblePDFElement,
   LayoutContext,
@@ -123,6 +124,19 @@ export class RowElement extends SizedPDFElement {
     if (requested.some((v) => v !== undefined)) return false;
     const ownFlexChild = horizontal && this.children.some((c) => c instanceof FlexiblePDFElement);
     return ownFlexChild || this.children.some((c) => c.needsBoundedMain(horizontal));
+  }
+
+  /** A Row lays out side by side, so widths add up (gaps included) and heights overlap. */
+  override minIntrinsicMain(horizontal: boolean, ctx: LayoutContext): number {
+    const content = stackMinIntrinsic(
+      this.children,
+      this.gap,
+      horizontal,
+      horizontal,
+      ctx,
+      this.wrap,
+    );
+    return withDeclaredExtent(content, horizontal ? this.requested.width : this.requested.height);
   }
 
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {

--- a/src/lib/elements/row-element.ts
+++ b/src/lib/elements/row-element.ts
@@ -136,7 +136,11 @@ export class RowElement extends SizedPDFElement {
       ctx,
       this.wrap,
     );
-    return withDeclaredExtent(content, horizontal ? this.requested.width : this.requested.height);
+    return withDeclaredExtent(
+      content,
+      horizontal ? this.requested.width : this.requested.height,
+      horizontal ? this.requested.minWidth : this.requested.minHeight,
+    );
   }
 
   calculateLayout(constraints: BoxConstraints, offset: Offset, ctx: LayoutContext): Size {

--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -589,7 +589,14 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       style: FontStyle,
       letterSpacing: number,
     ): number => {
-      const font = { fontFamily: family, fontSize: size, fontStyle: style };
+      // `ligatures` belongs to the FONT: it decides which glyphs are drawn and therefore how wide the
+      // piece is. Leaving it out here would measure a floor the drawing never matches.
+      const font = {
+        fontFamily: family,
+        fontSize: size,
+        fontStyle: style,
+        ligatures: this.ligatures,
+      };
       // Split on the same boundaries the breaker uses - a hard break ends a line too.
       const pieces = this.breakWord || this.hyphenate ? [...text] : text.split(/[ \n]/);
       return pieces.reduce(

--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -11,6 +11,7 @@ import { BoxConstraints, Offset, Size } from "../layout/box-constraints.ts";
 import type { Direction } from "../text/bidi.ts";
 import { applyTextTransform, type TextTransform } from "../text/text-style.ts";
 import { splitByFont } from "../text/font-fallback.ts";
+import { runAdvance } from "../text/advance.ts";
 import { Fragmentable, FragmentResult } from "../layout/fragmentation.ts";
 import {
   type LineOptions,
@@ -564,6 +565,58 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
           seg.letterSpacing ?? this.letterSpacing,
         ),
       indent,
+    );
+  }
+
+  /**
+   * The widest piece of this text that cannot be broken - CSS's `min-content` width. A shrinking flex
+   * parent floors the width it hands us here, so a squeezed paragraph stops at its longest word
+   * instead of becoming one word per line.
+   *
+   * With `breakWord` or `hyphenate` on, the text may be cut mid-word, so the unbreakable piece is a
+   * single character - the same reasoning CSS applies to `word-break: break-all`.
+   */
+  override minIntrinsicMain(horizontal: boolean, ctx: LayoutContext): number {
+    // Only the width is a question here: the height of a text is whatever its lines add up to, and a
+    // column squeezing it vertically is the paginator's business, not the shrink pass's.
+    if (!horizontal) return 0;
+    this.resolveStyle(ctx);
+    const metrics = ctx.metrics;
+    const widest = (
+      text: string,
+      family: string,
+      size: number,
+      style: FontStyle,
+      letterSpacing: number,
+    ): number => {
+      const font = { fontFamily: family, fontSize: size, fontStyle: style };
+      // Split on the same boundaries the breaker uses - a hard break ends a line too.
+      const pieces = this.breakWord || this.hyphenate ? [...text] : text.split(/[ \n]/);
+      return pieces.reduce(
+        (max, piece) => Math.max(max, runAdvance(metrics, piece, font, letterSpacing)),
+        0,
+      );
+    };
+    const content = this.display(metrics);
+    if (typeof content === "string") {
+      return widest(content, this.fontFamily, this.fontSize, this.fontStyle, this.letterSpacing);
+    }
+    // Segments join without a space, so a word may straddle two of them; taking the widest piece per
+    // segment can therefore UNDER-estimate. That errs towards squeezing a little too far, which lands
+    // back on the old overflow behaviour rather than on something new.
+    return content.reduce(
+      (max, seg) =>
+        Math.max(
+          max,
+          widest(
+            seg.content,
+            seg.fontFamily ?? this.fontFamily,
+            seg.fontSize ?? this.fontSize,
+            seg.fontStyle ?? this.fontStyle,
+            seg.letterSpacing ?? this.letterSpacing,
+          ),
+        ),
+      0,
     );
   }
 

--- a/src/lib/layout/min-intrinsic.ts
+++ b/src/lib/layout/min-intrinsic.ts
@@ -40,6 +40,15 @@ export function stackMinIntrinsic(
  * around content needing 500 cannot go below 400. An extent given as a fraction is not a suggestion
  * at all - it has no size of its own until the parent is known - so it is ignored here.
  */
-export function withDeclaredExtent(contentFloor: number, declared: number | undefined): number {
-  return declared === undefined ? contentFloor : Math.min(declared, contentFloor);
+export function withDeclaredExtent(
+  contentFloor: number,
+  declared: number | undefined,
+  explicitMin?: number,
+): number {
+  const automatic = declared === undefined ? contentFloor : Math.min(declared, contentFloor);
+  // An explicit `minWidth`/`minHeight` REPLACES the automatic minimum rather than competing with it -
+  // CSS's automatic minimum only applies while `min-width` is `auto`. Without this the shrink pass
+  // aims below a bound the child will refuse anyway, so the child keeps its size, the share it was
+  // supposed to give never arrives, and the line stays over its width.
+  return explicitMin === undefined ? automatic : Math.max(automatic, explicitMin);
 }

--- a/src/lib/layout/min-intrinsic.ts
+++ b/src/lib/layout/min-intrinsic.ts
@@ -45,10 +45,15 @@ export function withDeclaredExtent(
   declared: number | undefined,
   explicitMin?: number,
 ): number {
-  const automatic = declared === undefined ? contentFloor : Math.min(declared, contentFloor);
-  // An explicit `minWidth`/`minHeight` REPLACES the automatic minimum rather than competing with it -
-  // CSS's automatic minimum only applies while `min-width` is `auto`. Without this the shrink pass
-  // aims below a bound the child will refuse anyway, so the child keeps its size, the share it was
-  // supposed to give never arrives, and the line stays over its width.
-  return explicitMin === undefined ? automatic : Math.max(automatic, explicitMin);
+  // An explicit `minWidth`/`minHeight` REPLACES the automatic minimum - it does not compete with it.
+  // CSS applies the automatic minimum only while `min-width` is `auto`, so a smaller explicit value
+  // wins too: `min-width: 0` is the standard way to let a flex item shrink past its longest word, and
+  // taking the larger of the two would quietly ignore it. Measured in Chrome on one long word in a
+  // 200pt line: 132.08pt with `auto`, 84.64pt with `0`.
+  if (explicitMin !== undefined) return explicitMin;
+  // Without an explicit bound the floor is CSS's content-based minimum: the smaller of what the
+  // element declares and what its content actually needs. It matters because the shrink pass must not
+  // aim below a size the child will refuse - the share it was supposed to give would never arrive,
+  // and the line would stay over its width.
+  return declared === undefined ? contentFloor : Math.min(declared, contentFloor);
 }

--- a/src/lib/layout/min-intrinsic.ts
+++ b/src/lib/layout/min-intrinsic.ts
@@ -1,0 +1,45 @@
+/**
+ * `min-content` sizing - the smallest extent a subtree can be squeezed into and still hold together.
+ *
+ * The shrink pass in `FlexLayoutHelper` floors every child at this, so an overflowing line stops
+ * squeezing instead of grinding a paragraph down to one word per line. It is the same rule a browser
+ * applies through the automatic `min-width` of a flex item (CSS Flexbox 4.5).
+ *
+ * Only the leaves know a real number - a `Text` its longest word, everything else nothing in
+ * particular. These helpers are how a container folds its children's answers into its own.
+ */
+import type { LayoutContext } from "../elements/pdf-element.ts";
+import type { PDFElement } from "../elements/pdf-element.ts";
+
+/**
+ * The children's floor, folded along one axis: children laid out ALONG the queried axis have to fit
+ * side by side, so their floors add up (plus the gaps between them); across it they merely overlap,
+ * so the widest one wins.
+ *
+ * A wrapping stack adds up nothing: it may put every child on its own line, so it is only as wide as
+ * its widest child - which is what CSS says about a multi-line flex container too.
+ */
+export function stackMinIntrinsic(
+  children: PDFElement[],
+  gap: number,
+  alongAxis: boolean,
+  horizontal: boolean,
+  ctx: LayoutContext,
+  wraps = false,
+): number {
+  const floors = children.map((c) => c.minIntrinsicMain(horizontal, ctx));
+  if (floors.length === 0) return 0;
+  if (!alongAxis || wraps) return Math.max(...floors);
+  return floors.reduce((sum, f) => sum + f, 0) + gap * (floors.length - 1);
+}
+
+/**
+ * Folds an element's own declared extent into the floor its content asks for. CSS calls these the
+ * "specified size suggestion" and the "content size suggestion" and takes the SMALLER: a box that
+ * declares 400pt around content needing 50 may still be squeezed to 50, while one declaring 400
+ * around content needing 500 cannot go below 400. An extent given as a fraction is not a suggestion
+ * at all - it has no size of its own until the parent is known - so it is ignored here.
+ */
+export function withDeclaredExtent(contentFloor: number, declared: number | undefined): number {
+  return declared === undefined ? contentFloor : Math.min(declared, contentFloor);
+}

--- a/src/lib/utils/flex-layout.ts
+++ b/src/lib/utils/flex-layout.ts
@@ -457,7 +457,11 @@ export class FlexLayoutHelper {
       const stretch = align === "stretch";
       let mainExtent: number;
       if (child instanceof FlexiblePDFElement) {
-        mainExtent = child.getBasis(percentBase) + (child.getFlex() / totalFlex) * remaining;
+        // `totalFlex` is 0 when every flex child asked for `flex: 0` (a pure `flexBasis` slot). The
+        // share is then 0/0 - a NaN that becomes the offset of every later sibling, which is the
+        // shape of the old Spacer bug. Such a child simply takes its basis.
+        const share = totalFlex > 0 ? (child.getFlex() / totalFlex) * remaining : 0;
+        mainExtent = child.getBasis(percentBase) + share;
         // A flex child fills the MAIN axis, and its cross size is only known after layout - there is
         // nothing to align against. So alignSelf is a no-op here, and that has to hold for the CROSS
         // CONSTRAINT too: reading the per-child alignment would hand an `alignSelf: "start"` flex child

--- a/src/lib/utils/flex-layout.ts
+++ b/src/lib/utils/flex-layout.ts
@@ -335,28 +335,71 @@ export class FlexLayoutHelper {
     );
     const overflow = fixedMain + totalBasis + totalGap - mainAvail;
     if (shrinkers.length > 0 && Number.isFinite(mainAvail) && overflow > 0) {
-      const weight = (c: PDFElement) => c.flexShrink * axis.mainOf(fixedSize.get(c)!);
-      const totalWeight = shrinkers.reduce((n, c) => n + weight(c), 0);
-      if (totalWeight > 0) {
-        for (const child of shrinkers) {
-          const natural = axis.mainOf(fixedSize.get(child)!);
-          // Never below zero: when the GAPS alone outgrow the line, a proportional share asks for more
-          // than a child has. No test can tell this clamp apart from its absence - `constrainWidth`
-          // floors at 0 further down either way - but handing out a negative constraint is nonsense,
-          // and the next reader should not have to work out that it happens to be harmless.
-          const target = Math.max(0, natural - (weight(child) / totalWeight) * overflow);
-          shrunkCap.set(child, target);
-          // Re-measure NOW, not in pass 2: a narrower child may wrap to more lines, and the line's
-          // cross extent is settled just below.
-          const size = child.calculateLayout(
-            axis.measureConstraints(crossAvail, target),
-            axis.offsetAt(mainStart, crossOrigin),
-            ctx,
-          );
-          fixedMain += axis.mainOf(size) - natural;
-          crossUsed = Math.max(crossUsed, axis.crossOf(size));
-          fixedSize.set(child, size);
+      // Every child is floored at what it can actually hold - its `min-content` extent, which is CSS's
+      // automatic `min-width` on a flex item. Without it a badly overflowing line would grind a
+      // paragraph down to one word per line: the box gets narrow, the text gets tall, and nothing is
+      // gained. Past that floor a child overflows again, which is what a browser does too.
+      const naturalOf = (c: PDFElement) => axis.mainOf(fixedSize.get(c)!);
+      const floorOf = new Map<PDFElement, number>(
+        shrinkers.map((c) => [
+          c,
+          // Never above its natural size: the shrink pass may only take space away, never hand it out.
+          // Never below zero either - when the GAPS alone outgrow the line a proportional share asks
+          // for more than a child has, and a negative constraint is nonsense even though
+          // `constrainWidth` would floor it further down anyway.
+          Math.min(naturalOf(c), Math.max(0, c.minIntrinsicMain(axis.mainHorizontal, ctx))),
+        ]),
+      );
+
+      // CSS resolves this iteratively (Flexbox 9.7): a child that lands on its floor is FROZEN there
+      // and the share it could not absorb is handed to the rest. A single pass would leave that share
+      // unspent, so one unsqueezable child would keep the whole line overflowing while its neighbours
+      // still had room to give.
+      const target = new Map<PDFElement, number>(shrinkers.map((c) => [c, naturalOf(c)]));
+      const frozen = new Set<PDFElement>();
+      let flexible = [...shrinkers];
+      // What the frozen ones took off the overflow; the rest is always shared out from scratch, never
+      // from what a previous round already assigned.
+      let absorbedByFrozen = 0;
+      while (flexible.length > 0) {
+        const toAbsorb = overflow - absorbedByFrozen;
+        if (toAbsorb <= 1e-9) break;
+        const weight = (c: PDFElement) => c.flexShrink * naturalOf(c);
+        const totalWeight = flexible.reduce((n, c) => n + weight(c), 0);
+        if (totalWeight <= 0) break;
+        const froze: PDFElement[] = [];
+        for (const child of flexible) {
+          const natural = naturalOf(child);
+          const floor = floorOf.get(child)!;
+          const wanted = natural - (weight(child) / totalWeight) * toAbsorb;
+          if (wanted < floor) {
+            target.set(child, floor);
+            froze.push(child);
+            absorbedByFrozen += natural - floor;
+          } else {
+            target.set(child, wanted);
+          }
         }
+        if (froze.length === 0) break;
+        for (const c of froze) frozen.add(c);
+        flexible = flexible.filter((c) => !frozen.has(c));
+      }
+
+      for (const child of shrinkers) {
+        const natural = naturalOf(child);
+        const capped = target.get(child)!;
+        if (capped >= natural) continue;
+        shrunkCap.set(child, capped);
+        // Re-measure NOW, not in pass 2: a narrower child may wrap to more lines, and the line's
+        // cross extent is settled just below.
+        const size = child.calculateLayout(
+          axis.measureConstraints(crossAvail, capped),
+          axis.offsetAt(mainStart, crossOrigin),
+          ctx,
+        );
+        fixedMain += axis.mainOf(size) - natural;
+        crossUsed = Math.max(crossUsed, axis.crossOf(size));
+        fixedSize.set(child, size);
       }
     }
 

--- a/tests/unit/api/flex-shrink-floor.test.ts
+++ b/tests/unit/api/flex-shrink-floor.test.ts
@@ -79,4 +79,20 @@ describe("min-content is the floor under shrinking", () => {
     expect(Number.isFinite(e.getProps().width)).toBe(true);
     expect(e.getProps().width).toBe(300);
   });
+
+  it("lets an explicit minWidth REPLACE the automatic floor, downwards too", () => {
+    // `min-width: 0` is CSS's standard way to let a flex item shrink past its longest word. Taking the
+    // larger of the two floors would quietly ignore it. Chrome on the same shape: 132.08pt with the
+    // automatic minimum, 84.64pt with `min-width: 0`.
+    const word = "Verpflichtungserklaerung";
+    const auto = Box({ width: 300 }, [Text(word, { size: 12 })]);
+    const zero = Box({ width: 300, minWidth: 0 }, [Text(word, { size: 12 })]);
+    const floor = Text(word, { size: 12 }).minIntrinsicMain(true, ctx());
+
+    layout(Row({ gap: 0 }, [auto, Box({ width: 300 }, [])]), 100);
+    layout(Row({ gap: 0 }, [zero, Box({ width: 300 }, [])]), 100);
+
+    expect(auto.getProps().width).toBeCloseTo(floor, 5);
+    expect(zero.getProps().width).toBeLessThan(floor);
+  });
 });

--- a/tests/unit/api/flex-shrink-floor.test.ts
+++ b/tests/unit/api/flex-shrink-floor.test.ts
@@ -1,7 +1,7 @@
 // The floor under `flexShrink`: a squeezed child stops at its `min-content` extent - CSS's automatic
 // `min-width` on a flex item - instead of being ground down to one word per line.
 import { describe, it, expect } from "vitest";
-import { Box, Row } from "../../../src/lib/api/layout.ts";
+import { Box, Row, Expanded } from "../../../src/lib/api/layout.ts";
 import { Text } from "../../../src/lib/api/text.ts";
 import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
 import { testMetrics } from "../support/metrics.ts";
@@ -58,5 +58,25 @@ describe("min-content is the floor under shrinking", () => {
     expect(a + b).toBeLessThanOrEqual(400.01);
     expect(a).toBeGreaterThan(150); // it kept its word
     expect(b).toBeLessThan(150); // so the other gave up more than half
+  });
+
+  it("treats an explicit minWidth as the floor, and hands the rest to the neighbour", () => {
+    // 2 x 300 in a 400pt line: 200 has to go. An equal split would put both at 200, but the first
+    // refuses to go under 250 - so the second has to give up 150, not 100, or the line still overflows.
+    const a = Box({ width: 300, minWidth: 250 }, []);
+    const b = Box({ width: 300 }, []);
+    layout(Row({ gap: 0 }, [a, b]), 400);
+    expect(a.getProps().width).toBe(250);
+    expect(b.getProps().width).toBe(150);
+  });
+
+  it("a flex child asking for a basis but no growth keeps its basis, not NaN", () => {
+    // `flex: 0` with a basis makes `totalFlex` zero, and the share used to be 0/0. A NaN there becomes
+    // the offset of every later sibling - the shape of the Spacer bug (#10).
+    const e = Expanded({ flex: 0, flexBasis: 300 }, Box({ height: 20 }, []));
+    const f = Box({ width: 300, height: 20 }, []);
+    layout(Row({ gap: 0 }, [e, f]), 400);
+    expect(Number.isFinite(e.getProps().width)).toBe(true);
+    expect(e.getProps().width).toBe(300);
   });
 });

--- a/tests/unit/api/flex-shrink-floor.test.ts
+++ b/tests/unit/api/flex-shrink-floor.test.ts
@@ -1,0 +1,62 @@
+// The floor under `flexShrink`: a squeezed child stops at its `min-content` extent - CSS's automatic
+// `min-width` on a flex item - instead of being ground down to one word per line.
+import { describe, it, expect } from "vitest";
+import { Box, Row } from "../../../src/lib/api/layout.ts";
+import { Text } from "../../../src/lib/api/text.ts";
+import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
+import { testMetrics } from "../support/metrics.ts";
+
+const ctx = () =>
+  ({ metrics: testMetrics(), pageConfig: { width: 595, height: 842, margin: 0 } }) as never;
+
+const layout = (el: ReturnType<typeof Row>, width: number) =>
+  el.calculateLayout(BoxConstraints.loose(width, Infinity), { x: 0, y: 0 }, ctx());
+
+describe("min-content is the floor under shrinking", () => {
+  it("a Text reports its longest word, not its whole line", () => {
+    const t = Text("short Verpflichtungserklaerung short", { size: 12 });
+    const whole = t.minIntrinsicMain(true, ctx());
+    const shorter = Text("short short short", { size: 12 }).minIntrinsicMain(true, ctx());
+    expect(whole).toBeGreaterThan(shorter);
+    // The long word alone, measured on its own, is exactly what came back.
+    expect(whole).toBeCloseTo(
+      Text("Verpflichtungserklaerung", { size: 12 }).minIntrinsicMain(true, ctx()),
+      6,
+    );
+  });
+
+  it("breakWord lowers the floor to a single character", () => {
+    const opts = { size: 12 } as const;
+    const plain = Text("Verpflichtungserklaerung", opts).minIntrinsicMain(true, ctx());
+    const broken = Text("Verpflichtungserklaerung", { ...opts, breakWord: true }).minIntrinsicMain(
+      true,
+      ctx(),
+    );
+    expect(broken).toBeLessThan(plain / 5);
+  });
+
+  it("stops squeezing a paragraph at its longest word instead of stacking it up", () => {
+    const para = () =>
+      Text("A paragraph with one Verpflichtungserklaerung inside it", { size: 12 });
+    const floor = para().minIntrinsicMain(true, ctx());
+    const child = Box({ width: 600 }, [para()]);
+    // Offer far less than the floor: the child must stop there and overflow, not keep wrapping.
+    layout(Row([child]), Math.round(floor / 3));
+    expect(child.getProps().width as number).toBeGreaterThanOrEqual(floor - 0.01);
+  });
+
+  it("hands an unsqueezable child's share to the ones that can still give", () => {
+    // Two children, 300pt each, in a 400pt line: 200pt has to go. The first cannot go below its long
+    // word, so the second must absorb more than its own half.
+    const wall = Box({ width: 300 }, [
+      Text("Verpflichtungserklaerungsbescheinigung", { size: 14 }),
+    ]);
+    const soft = Box({ width: 300 });
+    const row = Row({ gap: 0 }, [wall, soft]);
+    layout(row, 400);
+    const [a, b] = [wall.getProps().width as number, soft.getProps().width as number];
+    expect(a + b).toBeLessThanOrEqual(400.01);
+    expect(a).toBeGreaterThan(150); // it kept its word
+    expect(b).toBeLessThan(150); // so the other gave up more than half
+  });
+});

--- a/tests/unit/api/flex-shrink.test.ts
+++ b/tests/unit/api/flex-shrink.test.ts
@@ -6,8 +6,9 @@ import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
 import { LayoutContext } from "../../../src/lib/elements/pdf-element.ts";
 
 // `flexShrink` gives main-axis space back when the line overflows, weighted by the child's OWN size -
-// so a wide item yields more than a narrow one. Default 0, deliberately unlike CSS's 1: shrinking
-// changes what a document looks like, and every document written before this must lay out unchanged.
+// so a wide item yields more than a narrow one. Default 1, as in CSS; `0` opts a child out and keeps
+// it at its natural size. An empty Box has nothing it must hold, so it can be squeezed to nothing -
+// the min-content floor that stops a real child is covered in `flex-shrink-floor.test.ts`.
 
 const ctx = {} as LayoutContext;
 const tile = (width: number, opts: Record<string, unknown> = {}) =>
@@ -21,17 +22,22 @@ const widths = (children: unknown[], line = 400) => {
   );
 };
 
-describe("nothing shrinks unless it says so", () => {
-  it("leaves an overflowing line alone by default", () => {
-    // 3 x 200 in a 400pt line: it overflows, and that is exactly what it did before this existed.
-    expect(widths([tile(200), tile(200), tile(200)])).toEqual([200, 200, 200]);
+describe("an overflowing line pulls its children back in", () => {
+  it("shrinks them all by default, in proportion to their own size", () => {
+    // 3 x 200 in a 400pt line: 200 too much, shared equally because the three are the same size.
+    expect(widths([tile(200), tile(200), tile(200)])).toEqual([400 / 3, 400 / 3, 400 / 3]);
+  });
+
+  it("leaves a child alone when it opts out", () => {
+    // The first refuses, so the other two carry the whole 200pt overflow between them.
+    expect(widths([tile(200, { flexShrink: 0 }), tile(200), tile(200)])).toEqual([200, 100, 100]);
   });
 });
 
 describe("giving space back", () => {
-  it("shrinks the one child that volunteered, by the whole overflow", () => {
-    // 200 + 300 = 500 in a 400pt line: 100 too much, and only the second offered.
-    expect(widths([tile(200), tile(300, { flexShrink: 1 })])).toEqual([200, 200]);
+  it("shrinks the one child that has not opted out, by the whole overflow", () => {
+    // 200 + 300 = 500 in a 400pt line: 100 too much, and only the second is willing.
+    expect(widths([tile(200, { flexShrink: 0 }), tile(300)])).toEqual([200, 200]);
   });
 
   it("weights the share by each child's own size, as CSS does", () => {
@@ -86,7 +92,7 @@ describe("an Image is a flex child like any other", () => {
     expect(b!).toBeCloseTo(160, 5);
   });
 
-  it("still leaves an Image alone without it", () => {
-    expect(widths([pic(300), pic(300)])).toEqual([300, 300]);
+  it("leaves an Image alone when it opts out", () => {
+    expect(widths([pic(300, { flexShrink: 0 }), pic(300, { flexShrink: 0 })])).toEqual([300, 300]);
   });
 });

--- a/tests/unit/api/flex-wrap.test.ts
+++ b/tests/unit/api/flex-wrap.test.ts
@@ -7,7 +7,8 @@ import { LayoutContext } from "../../../src/lib/elements/pdf-element.ts";
 // unchanged and simply runs once per line - which is what keeps every non-wrapping document identical.
 
 const ctx = {} as LayoutContext;
-const tile = (w: number, h = 20) => Box({ borderWidth: 0, width: w, height: h }, []);
+const tile = (w: number, h = 20, opts: Record<string, unknown> = {}) =>
+  Box({ borderWidth: 0, width: w, height: h, ...opts }, []);
 
 /** Where each child ended up: [x, y] per child, in tree order. */
 const places = (row: ReturnType<typeof Row>, w = 300, h = 400) => {
@@ -17,9 +18,21 @@ const places = (row: ReturnType<typeof Row>, w = 300, h = 400) => {
   );
 };
 
-describe("without wrap nothing changes", () => {
-  it("keeps overflowing on one line, as it always did", () => {
+describe("without wrap everything stays on one line", () => {
+  it("squeezes the children back inside instead of opening a second line", () => {
+    // 2 x 200 in a 300pt line: no wrap, so they shrink to 150 each and stay side by side.
     const row = Row({ width: 300 }, [tile(200), tile(200)]);
+    expect(places(row)).toEqual([
+      [0, 0],
+      [150, 0],
+    ]);
+  });
+
+  it("still overflows on one line when the children refuse to shrink", () => {
+    const row = Row({ width: 300 }, [
+      tile(200, 20, { flexShrink: 0 }),
+      tile(200, 20, { flexShrink: 0 }),
+    ]);
     expect(places(row)).toEqual([
       [0, 0],
       [200, 0],
@@ -46,10 +59,14 @@ describe("wrapping", () => {
     ]);
   });
 
-  it("lets a child wider than the line OVERFLOW rather than squashing it", () => {
-    // CSS does not shrink an item to make it fit - that is what `flexShrink` is for, and it is off by
-    // default. The child keeps its width, takes a line of its own, and runs past the edge.
-    const row = Row({ width: 100, wrap: true }, [tile(50), tile(400), tile(50)]);
+  it("lets a child wider than the line OVERFLOW when it refuses to shrink", () => {
+    // Wrapping puts a too-wide child on a line of its own; whether it then fits is `flexShrink`'s
+    // business. Opted out, it keeps its width and runs past the edge.
+    const row = Row({ width: 100, wrap: true }, [
+      tile(50),
+      tile(400, 20, { flexShrink: 0 }),
+      tile(50),
+    ]);
     row.calculateLayout(BoxConstraints.loose(100, 400), { x: 0, y: 0 }, ctx);
     const kids = (row as unknown as { children: { getProps(): { width?: number; y: number } }[] })
       .children;


### PR DESCRIPTION
## Description

flexShrink is true by default just now - same as in CSS

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flex layouts now shrink by default, following CSS-like behavior.
  * Improved intrinsic sizing preserves minimum content dimensions across text, padding, borders, gaps, and wrapping.
  * Shrink space is redistributed iteratively when items reach their minimum size.
  * Set `flexShrink: 0` to preserve overflow behavior.

* **Bug Fixes**
  * Prevented invalid layout results when flex items have no available growth.

* **Documentation**
  * Updated flexbox guidance and expanded PDF capability documentation, including accessibility and layout support.

* **Tests**
  * Added coverage for sizing floors, redistribution, default shrinking, and opt-out behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->