### PR TITLE
fix: performance - stop measuring the same run over and over

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ packages/playground/*.pdf
 packages/playground/*.png
 # npm pack / release tarballs
 *.tgz
+
+# Benchmark harness - lives here, shown on the landing later, not committed yet
+bench/

--- a/src/lib/text/advance.ts
+++ b/src/lib/text/advance.ts
@@ -47,14 +47,16 @@ export function codePointCount(text: string): number {
  * Keyed by nested maps on primitives, never a composed string key: building one allocates per call,
  * which costs more than the lookup saves.
  *
- * Not in the key: `letterSpacing` (added outside, so a spaced and an unspaced run share the width) and
- * kerning (a document-level flag, and the outer WeakMap is already per document). Font size IS in it -
- * scaling a cached em width drifts in the last bit, which is enough to move a line break.
+ * `letterSpacing` is not in the key: it is added outside, so a spaced and an unspaced run share the
+ * width. Font size IS in it - scaling a cached em width drifts in the last bit, which is enough to
+ * move a line break. Kerning is a flag on the metrics rather than a key, so the entry records it and
+ * is thrown away when it flips; the same document can be rendered twice with different options.
  */
 const ADVANCE_CACHE = new WeakMap<
   FontMetrics,
   {
     epoch: number;
+    kerning: boolean;
     byFamily: Map<string, Map<FontStyle, Map<unknown, Map<number, Map<string, number>>>>>;
   }
 >();
@@ -62,9 +64,11 @@ const ADVANCE_CACHE = new WeakMap<
 function baseAdvance(metrics: FontMetrics, text: string, font: RunFont): number {
   let entry = ADVANCE_CACHE.get(metrics);
   const epoch = metrics.fontEpoch ?? 0;
-  if (!entry || entry.epoch !== epoch) {
-    // A face was registered since we measured, so a family name may mean something else now.
-    entry = { epoch, byFamily: new Map() };
+  const kerning = metrics.kerningEnabled;
+  // A face registered since we measured makes a family name mean something else; a flipped kerning
+  // flag makes every width wrong. Either way the answers are stale.
+  if (!entry || entry.epoch !== epoch || entry.kerning !== kerning) {
+    entry = { epoch, kerning, byFamily: new Map() };
     ADVANCE_CACHE.set(metrics, entry);
   }
   let byStyle = entry.byFamily.get(font.fontFamily);

--- a/src/lib/text/advance.ts
+++ b/src/lib/text/advance.ts
@@ -40,6 +40,62 @@ export function codePointCount(text: string): number {
   return n;
 }
 
+/**
+ * Glyph widths plus kerning, memoised per metrics object - the line breaker asks for the same run
+ * many times over.
+ *
+ * Keyed by nested maps on primitives, never a composed string key: building one allocates per call,
+ * which costs more than the lookup saves.
+ *
+ * Not in the key: `letterSpacing` (added outside, so a spaced and an unspaced run share the width) and
+ * kerning (a document-level flag, and the outer WeakMap is already per document). Font size IS in it -
+ * scaling a cached em width drifts in the last bit, which is enough to move a line break.
+ */
+const ADVANCE_CACHE = new WeakMap<
+  FontMetrics,
+  {
+    epoch: number;
+    byFamily: Map<string, Map<FontStyle, Map<unknown, Map<number, Map<string, number>>>>>;
+  }
+>();
+
+function baseAdvance(metrics: FontMetrics, text: string, font: RunFont): number {
+  let entry = ADVANCE_CACHE.get(metrics);
+  const epoch = metrics.fontEpoch ?? 0;
+  if (!entry || entry.epoch !== epoch) {
+    // A face was registered since we measured, so a family name may mean something else now.
+    entry = { epoch, byFamily: new Map() };
+    ADVANCE_CACHE.set(metrics, entry);
+  }
+  let byStyle = entry.byFamily.get(font.fontFamily);
+  if (!byStyle) entry.byFamily.set(font.fontFamily, (byStyle = new Map()));
+  let byLigatures = byStyle.get(font.fontStyle);
+  if (!byLigatures) byStyle.set(font.fontStyle, (byLigatures = new Map()));
+  let bySize = byLigatures.get(font.ligatures);
+  if (!bySize) byLigatures.set(font.ligatures, (bySize = new Map()));
+  let byText = bySize.get(font.fontSize);
+  if (!byText) bySize.set(font.fontSize, (byText = new Map()));
+
+  const hit = byText.get(text);
+  if (hit !== undefined) return hit;
+
+  let advance = metrics.getStringWidth(
+    text,
+    font.fontFamily,
+    font.fontSize,
+    font.fontStyle,
+    font.ligatures,
+  );
+  if (metrics.kerningEnabled) {
+    let units = 0;
+    for (const k of metrics.getKernPairs(text, font.fontFamily, font.fontStyle, font.ligatures))
+      units += k;
+    advance += (units / 1000) * font.fontSize; // kern units are em/1000
+  }
+  byText.set(text, advance);
+  return advance;
+}
+
 /** The advance of `text` in points: the plain glyph widths, plus kerning (if the document has it on),
  *  plus one `letterSpacing` per code point. */
 export function runAdvance(
@@ -48,13 +104,7 @@ export function runAdvance(
   font: RunFont,
   letterSpacing = 0,
 ): number {
-  let advance = metrics.getStringWidth(
-    text,
-    font.fontFamily,
-    font.fontSize,
-    font.fontStyle,
-    font.ligatures,
-  );
+  let advance = baseAdvance(metrics, text, font);
   if (letterSpacing !== 0) {
     // Per DRAWN glyph, which is what `Tc` applies to; only a ligature makes that differ.
     const glyphs =
@@ -62,11 +112,6 @@ export function runAdvance(
       codePointCount(text);
     advance += glyphs * letterSpacing;
   }
-  if (metrics.kerningEnabled) {
-    let units = 0;
-    for (const k of metrics.getKernPairs(text, font.fontFamily, font.fontStyle, font.ligatures))
-      units += k;
-    advance += (units / 1000) * font.fontSize; // kern units are em/1000
-  }
+
   return advance;
 }

--- a/src/lib/utils/afm-parser.ts
+++ b/src/lib/utils/afm-parser.ts
@@ -1,11 +1,24 @@
 import { AGL } from "../assets/font-data.ts";
+
+/** The Adobe Glyph List: code point -> glyph name. Constant, so it is parsed once per process and
+ *  shared by every face rather than rebuilt per `AFMParser`. */
+let sharedGlyphMap: Record<string, string> | undefined;
+function glyphList(): Record<string, string> {
+  if (sharedGlyphMap) return sharedGlyphMap;
+  const map: Record<string, string> = {};
+  for (const line of AGL.split("\n")) {
+    const parts = line.trim().split(";");
+    if (parts.length >= 2) map[String.fromCharCode(parseInt(parts[0]!, 16))] = parts[1]!;
+  }
+  return (sharedGlyphMap = map);
+}
 import type { FontVerticals } from "../text/line-metrics.ts";
 import type { FontDecoration } from "../text/text-decoration.ts";
 
 export class AFMParser {
   private advanceWidths: Record<string, number> = {};
   private kerningPairs: Record<string, Record<string, number>> = {};
-  private glyphMap: Record<string, string> = {};
+  private glyphMap: Record<string, string> = glyphList();
 
   // The font's bounding box in glyph space (1000 units / em), from the AFM header. This - not the
   // `Ascender` line - is what a line box is built from; see `verticals()`.
@@ -22,25 +35,6 @@ export class AFMParser {
 
   constructor(afmData: string) {
     this.parseAFMData(afmData);
-    this.loadGlyphList();
-  }
-
-  private loadGlyphList(): void {
-    const lines = AGL.split("\n");
-
-    for (const line of lines) {
-      const parts = line.trim().split(";");
-      if (parts.length >= 2) {
-        const unicodeHex = parts[0];
-        const glyphName = parts[1];
-
-        // Converts the Unicode hex code into the corresponding character
-        const unicodeChar = String.fromCharCode(parseInt(unicodeHex, 16));
-
-        // Adds the character as the key and the glyph name as the value in the list
-        this.glyphMap[unicodeChar] = glyphName;
-      }
-    }
   }
 
   private getGlyphName(char: string): string {

--- a/src/lib/utils/font-metrics.ts
+++ b/src/lib/utils/font-metrics.ts
@@ -38,6 +38,10 @@ export interface FontMetrics {
    *  drawn one (the backend emits a `TJ` under the same flag). */
   readonly kerningEnabled: boolean;
 
+  /** Bumped whenever a face is registered, so a memoised measurement knows to drop it: the same family
+   *  name can mean a different face afterwards. Optional - leaving it out means never invalidating. */
+  readonly fontEpoch?: number;
+
   /** Per-adjacent-pair kerning of `text`, in em/1000 (negative tightens); length `codePoints - 1`,
    *  zero next to a space. Only meaningful when `kerningEnabled`. */
   getKernPairs(

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -15,9 +15,19 @@ import { shapeRun, type ShapedGlyph } from "../text/shape.ts";
  *  drew for it. On by default like kerning - CSS, browsers and every other renderer do the same,
  *  and nobody should have to know the word to get text that is set properly. */
 const LATIN_FEATURES = ["liga"] as const;
+/** Stable, so `features(false)` does not allocate per call. */
+const NO_FEATURES: readonly string[] = [];
 
-/** What a run is shaped with. Arabic joining is unconditional; this is only the Latin part. */
-const features = (ligatures: boolean): readonly string[] => (ligatures ? LATIN_FEATURES : []);
+/** A feature set's cache key, joined once per distinct array rather than per lookup. */
+const FEATURE_KEYS = new WeakMap<readonly string[], string>();
+export function featureKey(f: readonly string[]): string {
+  let key = FEATURE_KEYS.get(f);
+  if (key === undefined) FEATURE_KEYS.set(f, (key = f.join(",")));
+  return key;
+}
+
+const features = (ligatures: boolean): readonly string[] =>
+  ligatures ? LATIN_FEATURES : NO_FEATURES;
 import { getArrayBuffer, isWindows1252 } from "./utf8-to-windows1252-encoder.ts";
 import type { SecurityHandler } from "../crypto/security-handler.ts";
 import type { Gradient, GradientStop } from "../ir/display-list.ts";
@@ -224,7 +234,13 @@ export class PDFObjectManager implements FontMetrics {
   >();
 
   // Shaped runs, keyed by font + text; `null` means "asked, and there was nothing to shape".
-  private shapeCache = new Map<string, ShapedGlyph[] | null>();
+  /** Shaped runs, cached face -> feature set -> text. Nested, not one map under a composed key: that
+   *  key would carry the whole run's text, so every lookup would copy it into a fresh string. */
+  private shapeCache = new Map<TTFParser, Map<string, Map<string, ShapedGlyph[] | null>>>();
+
+  /** Bumped by every font registration; `runAdvance` watches it to drop memoised widths, since a
+   *  family name can mean a different face afterwards. */
+  fontEpoch = 0;
   // Per font, glyph -> the code points it stands for. A shaped glyph is often absent from the cmap (a
   // ligature) or maps back to a presentation form, so `ToUnicode` cannot come from the cmap alone.
   private shapedOrigins = new Map<string, Map<number, number[]>>();
@@ -703,6 +719,7 @@ endstream`;
     fontStyle: FontStyle = FontStyle.Normal,
     fullName: string = fontName,
   ): FontIndexes {
+    this.fontEpoch++;
     if (this.fonts.hasFont(fontName, fontStyle)) {
       return this.fonts.getFont(fontName, fontStyle)!; // Already exists? Return it!
     }
@@ -738,6 +755,7 @@ endstream`;
   // metrics and emits its PDF font objects. All variants share the family `name`; bold/italic are
   // separate .ttf files registered under the same name with a different style.
   registerCustomFont(name: string, data: Uint8Array, style: FontStyle = FontStyle.Normal): void {
+    this.fontEpoch++;
     let byStyle = this.customFonts.get(name);
     if (!byStyle) {
       byStyle = new Map();
@@ -957,17 +975,20 @@ endstream`;
   ) {
     const resolved = this.resolveCustomStyle(fontFamily, fontStyle);
     if (!resolved) return undefined;
-    const key = `${this.customKey(fontFamily!, resolved)}\u0000${features.join(",")}\u0000${text}`;
-    const cached = this.shapeCache.get(key);
-    if (cached !== undefined) return cached ?? undefined;
     const ttf = this.customFonts.get(fontFamily!)!.get(resolved)!;
+    let byFeature = this.shapeCache.get(ttf);
+    if (!byFeature) this.shapeCache.set(ttf, (byFeature = new Map()));
+    let byText = byFeature.get(featureKey(features));
+    if (!byText) byFeature.set(featureKey(features), (byText = new Map()));
+    const cached = byText.get(text);
+    if (cached !== undefined) return cached ?? undefined;
     const shaped =
       shapeRun(
         [...text].map((c) => c.codePointAt(0)!),
         ttf,
         features,
       ) ?? null;
-    this.shapeCache.set(key, shaped);
+    byText.set(text, shaped);
     if (shaped) {
       // Recorded at shaping time - the only moment the glyph and its code points are known together.
       const fontKey = this.customKey(fontFamily!, resolved);

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -18,12 +18,14 @@ const LATIN_FEATURES = ["liga"] as const;
 /** Stable, so `features(false)` does not allocate per call. */
 const NO_FEATURES: readonly string[] = [];
 
-/** A feature set's cache key, joined once per distinct array rather than per lookup. */
-const FEATURE_KEYS = new WeakMap<readonly string[], string>();
+/** A feature set's cache key. Memoised only for the two arrays this module owns - a caller's array is
+ *  joined every time, since holding on to its key would outlive a mutation of it. */
+const OWN_FEATURE_KEYS = new Map<readonly string[], string>([
+  [LATIN_FEATURES, LATIN_FEATURES.join(",")],
+  [NO_FEATURES, ""],
+]);
 export function featureKey(f: readonly string[]): string {
-  let key = FEATURE_KEYS.get(f);
-  if (key === undefined) FEATURE_KEYS.set(f, (key = f.join(",")));
-  return key;
+  return OWN_FEATURE_KEYS.get(f) ?? f.join(",");
 }
 
 const features = (ligatures: boolean): readonly string[] =>

--- a/src/lib/utils/utf8-to-windows1252-encoder.ts
+++ b/src/lib/utils/utf8-to-windows1252-encoder.ts
@@ -40,8 +40,10 @@ const CP1252_FROM_UNICODE: Record<number, number> = {
  * except the C1 range, which the table above fills with printable punctuation instead.
  */
 export function isWindows1252(codePoint: number): boolean {
-  if (codePoint in CP1252_FROM_UNICODE) return true;
-  return codePoint <= 0xff && !(codePoint >= 0x80 && codePoint <= 0x9f);
+  // Latin-1 first: every key in the table above is > 0xff, so this range can never be in it. Order
+  // matters - this runs per character of every measured string, and the object lookup is the slow half.
+  if (codePoint <= 0xff) return codePoint < 0x80 || codePoint > 0x9f;
+  return codePoint in CP1252_FROM_UNICODE;
 }
 
 /** Encodes a JavaScript string to a Windows-1252 byte buffer (the PDF text encoding). */

--- a/tests/unit/text/advance-memo.test.ts
+++ b/tests/unit/text/advance-memo.test.ts
@@ -1,0 +1,83 @@
+// `runAdvance` memoises what it measures; this pins that its key covers every property which changes
+// a width. Asserting one combination's number would pass with a broken key, so each is read alone,
+// then read again through a metrics object that has measured all the others in between.
+import { describe, it, expect } from "vitest";
+import { runAdvance } from "../../../src/lib/text/advance.ts";
+import { FontStyle } from "../../../src/lib/utils/pdf-object-manager.ts";
+import type { FontMetrics } from "../../../src/lib/utils/font-metrics.ts";
+import { testMetrics } from "../support/metrics.ts";
+
+const TEXT = "Waffle office five";
+
+/** Metrics whose width differs for every property the memo must tell apart - the shared `testMetrics`
+ *  varies only with the size, so a broken key would slip through it. */
+const discriminating = () => {
+  let epoch = 0;
+  const m = testMetrics({
+    getStringWidth: (text, family, size, style, ligatures) =>
+      text.length * size +
+      family.length * 100 +
+      String(style).charCodeAt(0) * 7 +
+      (ligatures === false ? 3 : 0),
+    kerningEnabled: true,
+    getKernPairs: (text, family, style) =>
+      [...text].slice(1).map(() => family.length + String(style).charCodeAt(0)),
+  });
+  return Object.defineProperty(m, "fontEpoch", {
+    get: () => epoch,
+    configurable: true,
+  }) as FontMetrics & { bump(): void };
+};
+
+const COMBOS = [
+  { fontFamily: "Helvetica", fontSize: 10, fontStyle: FontStyle.Normal, ligatures: true },
+  { fontFamily: "Helvetica", fontSize: 10, fontStyle: FontStyle.Normal, ligatures: false },
+  { fontFamily: "Helvetica", fontSize: 24, fontStyle: FontStyle.Normal, ligatures: true },
+  { fontFamily: "Helvetica", fontSize: 10, fontStyle: FontStyle.Bold, ligatures: true },
+  { fontFamily: "Times", fontSize: 10, fontStyle: FontStyle.Normal, ligatures: true },
+  { fontFamily: "Times", fontSize: 24, fontStyle: FontStyle.Italic, ligatures: false },
+];
+
+describe("the run-advance memo", () => {
+  it("keys on every property that changes a width", () => {
+    // The truth, each read through a metrics object that has measured nothing else.
+    const alone = COMBOS.map((font) => runAdvance(discriminating(), TEXT, font));
+
+    // The same readings through ONE object, with every other combination measured in between.
+    const shared = discriminating();
+    for (const font of COMBOS) runAdvance(shared, TEXT, font);
+    const together = COMBOS.map((font) => runAdvance(shared, TEXT, font));
+
+    for (const [i, font] of COMBOS.entries()) {
+      expect(
+        together[i],
+        `${font.fontFamily} ${font.fontSize} ${font.fontStyle} lig=${font.ligatures}`,
+      ).toBeCloseTo(alone[i]!, 10);
+    }
+    // ...and the combinations differ, or the check above proves nothing.
+    expect(new Set(alone.map((a) => a.toFixed(6))).size).toBe(COMBOS.length);
+  });
+
+  it("adds letterSpacing on top of the shared cached width", () => {
+    const m = discriminating();
+    const font = COMBOS[0]!;
+    const plain = runAdvance(m, TEXT, font);
+    const spaced = runAdvance(m, TEXT, font, 2);
+    // Not part of the key: added outside, so both readings share one cached width.
+    expect(spaced).toBeGreaterThan(plain);
+    expect(runAdvance(m, TEXT, font)).toBeCloseTo(plain, 10);
+  });
+
+  it("forgets what it measured when a face is registered under a name it has seen", () => {
+    let epoch = 0;
+    const m = testMetrics({
+      getStringWidth: (text, _f, size) => text.length * size + epoch * 1000,
+    });
+    Object.defineProperty(m, "fontEpoch", { get: () => epoch });
+    const font = COMBOS[0]!;
+    const before = runAdvance(m, TEXT, font);
+    // What `registerFont` does.
+    epoch = 1;
+    expect(runAdvance(m, TEXT, font)).toBeCloseTo(before + 1000, 10);
+  });
+});

--- a/tests/unit/text/advance-memo.test.ts
+++ b/tests/unit/text/advance-memo.test.ts
@@ -80,4 +80,24 @@ describe("the run-advance memo", () => {
     epoch = 1;
     expect(runAdvance(m, TEXT, font)).toBeCloseTo(before + 1000, 10);
   });
+
+  it("forgets what it measured when kerning is switched off", () => {
+    // `setKerning` runs on every render, and a document keeps its metrics object - so the same
+    // document rendered twice with different options flips this under a warm cache.
+    let kerning = true;
+    const m = testMetrics({
+      getStringWidth: (text, _f, size) => text.length * size,
+      getKernPairs: (text) => [...text].slice(1).map(() => -50),
+    });
+    Object.defineProperty(m, "kerningEnabled", { get: () => kerning });
+    const font = COMBOS[0]!;
+
+    const kerned = runAdvance(m, TEXT, font);
+    kerning = false;
+    const plain = runAdvance(m, TEXT, font);
+    kerning = true;
+
+    expect(plain).toBeGreaterThan(kerned); // the pairs are negative, so dropping them widens the run
+    expect(runAdvance(m, TEXT, font)).toBeCloseTo(kerned, 10);
+  });
 });


### PR DESCRIPTION
## Summary

Big performance update - stop measuring the same run over and over

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [ ] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved text measurement and shaping efficiency through memoized calculations.
  * Cache updates now respond correctly when registered fonts or kerning settings change.

* **Compatibility**
  * Preserved supported Windows-1252 character handling while streamlining encoding checks.

* **Quality**
  * Added coverage for measurement caching, font settings, letter spacing, ligatures, kerning, and font updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->