### PR TITLE
fix: performance - parse and cover once

### DIFF
--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -246,6 +246,22 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     this.applyStyle(ctx.textStyle ?? DEFAULT_TEXT_STYLE);
   }
 
+  /**
+   * The last `display(metrics)` result, with what it depended on - recasing, coverage and the fallback
+   * split each walk the whole text, and every measure, break and draw asks again.
+   *
+   * COMPARED, not cleared in `resolveStyle`: that runs on every pass and resolves to the same values,
+   * so clearing would drop the answer exactly when it is about to be reused.
+   */
+  private displayed?: {
+    metrics: FontMetrics;
+    family: string;
+    style: FontStyle;
+    transform: TextTransform;
+    fallback: readonly string[];
+    value: string | TextSegment[];
+  };
+
   /** Justified lines may be squeezed to keep a word; every other alignment gets no slack. Read by the
    *  breaker in BOTH passes, or a measured line and a drawn one would disagree about where it ends. */
   /**
@@ -254,13 +270,35 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
    * same width in most fonts).
    */
   private display(metrics?: FontMetrics): string | TextSegment[] {
+    const memo = this.displayed;
+    if (
+      metrics &&
+      memo &&
+      memo.metrics === metrics &&
+      memo.family === this.fontFamily &&
+      memo.style === this.fontStyle &&
+      memo.transform === this.textTransform &&
+      memo.fallback === this.fontFallback
+    )
+      return memo.value;
     const cased = this.recased();
     // A SPAN may bring its own stack, so the element's being empty is not enough to skip the pass.
     const anyStack =
       this.fontFallback.length > 0 ||
       (typeof cased !== "string" && cased.some((seg) => (seg.fontFallback?.length ?? 0) > 0));
     if (!metrics) return cased;
-    if (!anyStack) return this.covered(cased, metrics);
+    const remember = (value: string | TextSegment[]) => {
+      this.displayed = {
+        metrics,
+        family: this.fontFamily,
+        style: this.fontStyle,
+        transform: this.textTransform,
+        fallback: this.fontFallback,
+        value,
+      };
+      return value;
+    };
+    if (!anyStack) return remember(this.covered(cased, metrics));
     // Font fallback turns the content into spans - one per family - which every later pass already
     // knows how to handle. Nothing new downstream.
     const pieces = typeof cased === "string" ? [{ content: cased } as TextSegment] : cased;
@@ -277,7 +315,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       else
         for (const run of runs) out.push({ ...seg, content: run.text, fontFamily: run.fontFamily });
     }
-    return this.covered(out, metrics) as TextSegment[];
+    return remember(this.covered(out, metrics)) as TextSegment[];
   }
 
   /**

--- a/src/lib/elements/text-element.ts
+++ b/src/lib/elements/text-element.ts
@@ -255,6 +255,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
    */
   private displayed?: {
     metrics: FontMetrics;
+    epoch: number;
     family: string;
     style: FontStyle;
     transform: TextTransform;
@@ -275,6 +276,8 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
       metrics &&
       memo &&
       memo.metrics === metrics &&
+      // A face registered since then changes what is drawable and how the fallback stack splits.
+      memo.epoch === (metrics.fontEpoch ?? 0) &&
       memo.family === this.fontFamily &&
       memo.style === this.fontStyle &&
       memo.transform === this.textTransform &&
@@ -290,6 +293,7 @@ export class TextElement extends SizedPDFElement implements Fragmentable {
     const remember = (value: string | TextSegment[]) => {
       this.displayed = {
         metrics,
+        epoch: metrics.fontEpoch ?? 0,
         family: this.fontFamily,
         style: this.fontStyle,
         transform: this.textTransform,

--- a/src/lib/text/advance.ts
+++ b/src/lib/text/advance.ts
@@ -61,6 +61,23 @@ const ADVANCE_CACHE = new WeakMap<
   }
 >();
 
+/**
+ * The innermost map a `RunFont` resolves to, remembered on the font object itself. The breaker builds
+ * one font per run and asks for every word with it, so without this each word walks five maps of which
+ * four hold a single entry.
+ */
+const BY_FONT = new WeakMap<
+  RunFont,
+  {
+    entry: object;
+    family: string;
+    size: number;
+    style: FontStyle;
+    ligatures?: boolean;
+    byText: Map<string, number>;
+  }
+>();
+
 function baseAdvance(metrics: FontMetrics, text: string, font: RunFont): number {
   let entry = ADVANCE_CACHE.get(metrics);
   const epoch = metrics.fontEpoch ?? 0;
@@ -71,6 +88,22 @@ function baseAdvance(metrics: FontMetrics, text: string, font: RunFont): number 
     entry = { epoch, kerning, byFamily: new Map() };
     ADVANCE_CACHE.set(metrics, entry);
   }
+  // Same font object as last time, and the metrics entry has not been replaced: the map is already known.
+  // Its FIELDS are compared, not just its identity: a caller that reuses one object and changes the
+  // size on it would otherwise be handed the previous size's map.
+  const known = BY_FONT.get(font);
+  if (
+    known?.entry === entry &&
+    known.family === font.fontFamily &&
+    known.size === font.fontSize &&
+    known.style === font.fontStyle &&
+    known.ligatures === font.ligatures
+  ) {
+    const seen = known.byText.get(text);
+    if (seen !== undefined) return seen;
+    return measureAndStore(metrics, text, font, known.byText);
+  }
+
   let byStyle = entry.byFamily.get(font.fontFamily);
   if (!byStyle) entry.byFamily.set(font.fontFamily, (byStyle = new Map()));
   let byLigatures = byStyle.get(font.fontStyle);
@@ -80,9 +113,27 @@ function baseAdvance(metrics: FontMetrics, text: string, font: RunFont): number 
   let byText = bySize.get(font.fontSize);
   if (!byText) bySize.set(font.fontSize, (byText = new Map()));
 
+  BY_FONT.set(font, {
+    entry,
+    family: font.fontFamily,
+    size: font.fontSize,
+    style: font.fontStyle,
+    ligatures: font.ligatures,
+    byText,
+  });
+
   const hit = byText.get(text);
   if (hit !== undefined) return hit;
+  return measureAndStore(metrics, text, font, byText);
+}
 
+/** The measurement itself, once a miss has found the map it belongs in. */
+function measureAndStore(
+  metrics: FontMetrics,
+  text: string,
+  font: RunFont,
+  byText: Map<string, number>,
+): number {
   let advance = metrics.getStringWidth(
     text,
     font.fontFamily,

--- a/src/lib/utils/afm-parser.ts
+++ b/src/lib/utils/afm-parser.ts
@@ -15,6 +15,15 @@ function glyphList(): Record<string, string> {
 import type { FontVerticals } from "../text/line-metrics.ts";
 import type { FontDecoration } from "../text/text-decoration.ts";
 
+/** One parser per standard-14 face for the whole process: the AFM data is a constant and a parsed
+ *  face is read-only, so every document can share one. */
+const STANDARD_PARSERS = new Map<string, AFMParser>();
+export function standardParser(fullName: string, data: string): AFMParser {
+  let parser = STANDARD_PARSERS.get(fullName);
+  if (!parser) STANDARD_PARSERS.set(fullName, (parser = new AFMParser(data)));
+  return parser;
+}
+
 export class AFMParser {
   private advanceWidths: Record<string, number> = {};
   private kerningPairs: Record<string, Record<string, number>> = {};

--- a/src/lib/utils/pdf-object-manager.ts
+++ b/src/lib/utils/pdf-object-manager.ts
@@ -4,7 +4,7 @@ import { STANDARD_AFM } from "../assets/font-data.ts";
 import { md5, md5Hex } from "./md5.ts";
 import { zlibSync } from "fflate";
 import { bytesFromLatin1, latin1FromBytes } from "./bytes.ts";
-import { AFMParser } from "./afm-parser.ts";
+import { AFMParser, standardParser } from "./afm-parser.ts";
 import { mergeSpans, TTFParser } from "./ttf-parser.ts";
 import { WoffError, isWoff, woffToSfnt } from "./woff.ts";
 import { isWoff2 } from "./woff2.ts";
@@ -734,7 +734,7 @@ endstream`;
         fontName,
         fontStyle,
         fullFontName: fullName,
-        parser: new AFMParser(data),
+        parser: standardParser(fullName, data),
       });
     }
 

--- a/tests/unit/elements/display-memo.test.ts
+++ b/tests/unit/elements/display-memo.test.ts
@@ -1,0 +1,28 @@
+// `display()` memoises recasing, glyph coverage and the fallback split. Both are answers ABOUT the
+// registered fonts, so a face registered afterwards has to invalidate them - the same reason
+// `runAdvance` watches `fontEpoch`.
+import { describe, it, expect } from "vitest";
+import { TextElement } from "../../../src/lib/elements/text-element.ts";
+import { BoxConstraints } from "../../../src/lib/layout/box-constraints.ts";
+import { testMetrics } from "../support/metrics.ts";
+
+describe("the display memo", () => {
+  it("recomputes coverage when a face is registered on the same metrics", () => {
+    let epoch = 0;
+    let knows = false; // the tick mark is undrawable until a face brings it
+    const m = testMetrics({
+      hasGlyph: (cp) => cp !== 0x2713 || knows,
+    });
+    Object.defineProperty(m, "fontEpoch", { get: () => epoch });
+
+    const ctx = { metrics: m, pageConfig: { width: 595, height: 842, margin: 0 } } as never;
+    const el = new TextElement({ content: "ok ✓", fontSize: 10 });
+    el.calculateLayout(BoxConstraints.loose(400, Infinity), { x: 0, y: 0 }, ctx);
+    expect(el.getProps().content).toBe("ok "); // dropped, nothing can draw it
+
+    knows = true;
+    epoch = 1; // what registerFont does
+    el.calculateLayout(BoxConstraints.loose(400, Infinity), { x: 0, y: 0 }, ctx);
+    expect(el.getProps().content).toBe("ok ✓");
+  });
+});


### PR DESCRIPTION
## Summary

Extreme performance update for the rendering

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved text rendering efficiency by reusing cached display results for matching font and formatting settings.
  - Reuses standard-font parsing results to reduce repeated processing during document generation.
  - Reuses resolved character-width calculations to improve repeated text layout performance.

- **Bug Fixes**
  - Text display caches now refresh correctly when font registration changes, ensuring newly available glyphs render as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->