### PR TITLE
feat: e-invoice field gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -700,6 +700,53 @@ wordWidth > maxWidth` and forgot the SPACE that would join the word. It went uns
   A code point no family in the stack has stays with the first one and shows its `.notdef`, as a browser
   does — dropping it would make the text read differently than it was written.
 
+- ✅ **EN 16931 - audited field by field, and the gaps closed** (2026-09-09, `@jasy/e-invoice`). The
+  question "do we cover everything?" had been answered "yes" five times without anyone opening
+  `src/invoice.ts`, whose own header comment had listed its deferred groups since the first commit.
+  The register is now **`packages/e-invoice/COVERAGE.md`** (gitignored, ours): every business term,
+  read out of the source, with the counts DERIVED from the rows rather than hand-counted - the first
+  hand-count was wrong because a row like `BT-35…BT-40` is six terms, not one. **That file is the only
+  way the completeness question gets answered from here.** Built the same day, each verified against
+  veraPDF (PDF/A-3b), the vendored CII and UBL XSDs via `xmllint`, and Flo's KoSIT run:
+  - **Skonto** (BT-20 structured, `payment.cashDiscounts`) - FIRST because it was the only gap that
+    could produce a WRONG invoice. Skonto is not an allowance: a discount conditional on early payment
+    must not reduce the total. Entered as a document allowance - the obvious workaround - it deducts
+    immediately, which is schema-valid and factually false, and no validator sees it. `profile-check`
+    now names that mistake by matching the allowance's reason text.
+  - **Percentage allowances/charges** (BT-93/94, BT-100/101, BT-137/138, BT-142/143). `AllowanceCharge`
+    became a UNION - either an `amount` or a `baseAmount`+`percent` - so "neither" fails to compile.
+    `src/allowance.ts` is the ONE place the amount is resolved; four separate `base*percent/100`
+    expressions is how the totals and the printed figure start disagreeing.
+  - **BG-3 preceding invoice** (`precedingInvoices`), **BG-24 attachments** (`supportingDocuments` -
+    base64 in the XML AND an embedded file in the PDF/A-3, `Supplement` not `Data`), **BG-19 SEPA
+    direct debit** (`payment.directDebit`), **BT-114 rounding** (moves the PAYABLE, not the total),
+    fifteen scalar references (BT-11/14/17/18/19/21/29/46/60/61/71/128/132/133/159), and
+    **BT-6/BT-111** the VAT accounting currency.
+  - **BT-6/BT-111 was built ahead of the other edge cases on purpose**: a non-EUR invoice went out
+    with no Euro tax figure and NO warning - the Skonto trap again. `xrechnungProblems` now says so.
+    The amount is never derived: which exchange rate applies is a tax question.
+  - **The schemas are the authority, not memory.** `schema/cii` and `schema/ubl` are vendored, and
+    `cii-order.test.ts` / `ubl-order.test.ts` DERIVE the expected sequence from them. They caught two
+    real ordering bugs in this work (`AccountingCost` before `BuyerReference`,
+    `OriginatorDocumentReference` before `ContractDocumentReference`) - both would have produced a
+    schema-invalid file that the business-rule validator waves through. Things the XSD settled that
+    would otherwise have been guesses: BT-26 is `qdt:` not `udt:` (a namespace we had never emitted);
+    `TaxTotalAmount` has `maxOccurs="2"`, which is exactly how BT-110 and BT-111 are told apart; the
+    two syntaxes disagree constantly (BT-13/BT-14 are two CII elements but one UBL `OrderReference`;
+    BT-21 has a CII element and NO UBL element, where the binding prefixes the note with `#CODE#`).
+  - **`fixture-is-maximal` and `completeness` earned their keep repeatedly**: the first refused every
+    new field until the maximal fixture set it, the second refused eleven fields that reached the XML
+    but not the paper. Known weakness, unfixed: `fixture-is-maximal` matches a field NAME anywhere in
+    the file, so `baseAmount`/`percent` passed vacuously once `cashDiscounts` introduced those names.
+  - **Left for 1.1, recorded in the board description** (github.com/orgs/jasy-pdf/projects/2):
+    BT-147/148 (list price + discount; a BG-27 line allowance already expresses the same money),
+    BT-7/BT-8 (VAT point date; prepayments), BT-15/BT-16 (receiving/despatch advice; logistics).
+    Deliberately deferred and documented in `src/invoice.ts`: BG-11/12 tax representative, BG-18
+    payment card, BG-32 item attributes, BT-158 classification.
+  - **Still open, and it matters:** the term list in `COVERAGE.md` was compiled from knowledge of
+    EN 16931, not from a machine-readable copy. Read it once against the official list before it
+    becomes a public promise.
+
 - ✅ **Invoicing period, BG-14 + BG-26** (2026-08-02, `@jasy/e-invoice`) — `invoice.period` and
   `line.period` (`{ start, end }`) emit `ram:BillingSpecifiedPeriod` in CII and `cac:InvoicePeriod` in
   UBL, at document AND line level. Why it matters: §14 Abs. 4 Nr. 6 UStG wants a delivery DATE or a

--- a/packages/e-invoice/src/allowance.ts
+++ b/packages/e-invoice/src/allowance.ts
@@ -1,0 +1,39 @@
+import { AllowanceCharge } from "./invoice.ts";
+
+// The ONE place an allowance/charge turns into a number.
+//
+// It exists because the amount can now be stated two ways - as a fixed sum, or as a percentage of a
+// base - and four consumers need it: the totals, the CII generator, the UBL generator and the PDF.
+// Four separate `ac.amount ?? base * percent / 100` expressions is exactly how the totals and the
+// printed figure start disagreeing, which is the defect class this package cares about most.
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+/**
+ * What this allowance/charge is worth, in currency.
+ *
+ * An explicit `amount` always wins: a user who states both has done the arithmetic themselves, and
+ * silently overruling them would hide a typo rather than surface it. `profile-check` reports the
+ * disagreement instead, where the message can name the field.
+ */
+export function acAmount(ac: AllowanceCharge): number {
+  if (ac.amount !== undefined) return round2(ac.amount);
+  // The union guarantees these are present when `amount` is not.
+  return round2((ac.baseAmount! * ac.percent!) / 100);
+}
+
+/** The amount a percentage WOULD produce, or null when it was not stated that way. */
+export function acDerivedAmount(ac: AllowanceCharge): number | null {
+  if (ac.baseAmount === undefined || ac.percent === undefined) return null;
+  return round2((ac.baseAmount * ac.percent) / 100);
+}
+
+/**
+ * Whether the percentage pair should be written to XML and paper. Both halves or neither: BT-94
+ * without BT-93 states a rate with nothing to apply it to.
+ */
+export function hasPercentage(
+  ac: AllowanceCharge,
+): ac is AllowanceCharge & { baseAmount: number; percent: number } {
+  return ac.baseAmount !== undefined && ac.percent !== undefined;
+}

--- a/packages/e-invoice/src/attachment.ts
+++ b/packages/e-invoice/src/attachment.ts
@@ -26,6 +26,43 @@ export function toBase64(bytes: Uint8Array): string {
 }
 
 /**
+ * File names a ZUGFeRD / Factur-X reader looks for when it wants THE INVOICE. A supporting document
+ * carrying one of these sits in the same name tree as the real thing, and a consumer picks whichever
+ * it finds first - possibly a spreadsheet parsed as an invoice.
+ */
+const RESERVED_NAMES = new Set([
+  "factur-x.xml",
+  "zugferd-invoice.xml",
+  "xrechnung.xml",
+  "order-x.xml",
+]);
+
+/**
+ * Why a collision is REFUSED rather than renamed: the file name is written twice, as the PDF name
+ * tree key and as the `filename` attribute inside the XML. Uniquifying one of them silently would
+ * make the two halves of the document disagree, which is the defect this package exists to prevent.
+ * Neither case is caught downstream - veraPDF calls a PDF with two `factur-x.xml` entries compliant.
+ */
+function assertUniqueNames(documents: SupportingDocument[]): void {
+  const seen = new Set<string>();
+  for (const [i, d] of documents.entries()) {
+    if (!d.file) continue;
+    const key = d.file.filename.toLowerCase();
+    if (RESERVED_NAMES.has(key)) {
+      throw new Error(
+        `invoice.supportingDocuments[${i}].file.filename is "${d.file.filename}", which is the name a reader looks for to find the invoice XML itself. Rename the attachment.`,
+      );
+    }
+    if (seen.has(key)) {
+      throw new Error(
+        `invoice.supportingDocuments[${i}].file.filename "${d.file.filename}" is used twice. Two attachments cannot share a name: the PDF would carry two entries under one key and a reader would show one of them.`,
+      );
+    }
+    seen.add(key);
+  }
+}
+
+/**
  * The documents that carry an actual file, ready for `renderToBytes({ attachments })`.
  *
  * `relationship: "Supplement"` is the PDF/A-3 term for "extra material" - the invoice XML itself is
@@ -34,7 +71,9 @@ export function toBase64(bytes: Uint8Array): string {
 export function pdfAttachments(
   documents: SupportingDocument[] | undefined,
 ): { name: string; data: Uint8Array; relationship: "Supplement"; mimeType: string }[] {
-  return (documents ?? [])
+  const docs = documents ?? [];
+  assertUniqueNames(docs);
+  return docs
     .filter((d) => d.file)
     .map((d) => ({
       name: d.file!.filename,
@@ -50,6 +89,7 @@ export function supportingDocumentProblems(
   where: string,
 ): string[] {
   const problems: string[] = [];
+  const names = new Set<string>();
   (documents ?? []).forEach((d, i) => {
     const at = `${where}[${i}]`;
     if (!d.reference) problems.push(`${at}.reference is required (BT-122).`);
@@ -60,6 +100,16 @@ export function supportingDocumentProblems(
       );
     }
     if (d.file && !d.file.filename) problems.push(`${at}.file.filename is required by the schema.`);
+    const key = d.file?.filename.toLowerCase();
+    if (key && RESERVED_NAMES.has(key)) {
+      problems.push(
+        `${at}.file.filename is "${d.file!.filename}", the name a reader looks for to find the invoice XML. Rename it.`,
+      );
+    }
+    if (key && names.has(key)) {
+      problems.push(`${at}.file.filename "${d.file!.filename}" is used twice.`);
+    }
+    if (key) names.add(key);
     if (d.file && !d.file.mimeType) problems.push(`${at}.file.mimeType is required by the schema.`);
   });
   return problems;

--- a/packages/e-invoice/src/attachment.ts
+++ b/packages/e-invoice/src/attachment.ts
@@ -1,0 +1,66 @@
+import { SupportingDocument } from "./invoice.ts";
+
+// BG-24 - the extra documents that travel with an invoice: a timesheet, a proof of service, a
+// delivery note. Anyone billing by effort has one, and sending it separately by mail is exactly the
+// break in the chain that e-invoicing exists to close.
+//
+// A supporting document reaches the recipient TWICE and that is deliberate: base64 inside the XML,
+// where a machine finds it, and as a PDF/A-3 embedded file, where a person double-clicks it. Doing
+// only the first would hide the document from every human reader of the invoice.
+
+/** Base64, written out rather than borrowed: `Buffer` is Node-only and `btoa` mangles bytes > 0x7f. */
+const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+export function toBase64(bytes: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i += 3) {
+    const a = bytes[i]!;
+    const b = i + 1 < bytes.length ? bytes[i + 1]! : 0;
+    const c = i + 2 < bytes.length ? bytes[i + 2]! : 0;
+    const triple = (a << 16) | (b << 8) | c;
+    out += ALPHABET[(triple >> 18) & 63]! + ALPHABET[(triple >> 12) & 63]!;
+    out += i + 1 < bytes.length ? ALPHABET[(triple >> 6) & 63]! : "=";
+    out += i + 2 < bytes.length ? ALPHABET[triple & 63]! : "=";
+  }
+  return out;
+}
+
+/**
+ * The documents that carry an actual file, ready for `renderToBytes({ attachments })`.
+ *
+ * `relationship: "Supplement"` is the PDF/A-3 term for "extra material" - the invoice XML itself is
+ * "Data", and calling both the same would tell a reader that the timesheet is the invoice.
+ */
+export function pdfAttachments(
+  documents: SupportingDocument[] | undefined,
+): { name: string; data: Uint8Array; relationship: "Supplement"; mimeType: string }[] {
+  return (documents ?? [])
+    .filter((d) => d.file)
+    .map((d) => ({
+      name: d.file!.filename,
+      data: d.file!.content,
+      relationship: "Supplement" as const,
+      mimeType: d.file!.mimeType,
+    }));
+}
+
+/** Problems with a supporting document, in the wording `profile-check` uses. */
+export function supportingDocumentProblems(
+  documents: SupportingDocument[] | undefined,
+  where: string,
+): string[] {
+  const problems: string[] = [];
+  (documents ?? []).forEach((d, i) => {
+    const at = `${where}[${i}]`;
+    if (!d.reference) problems.push(`${at}.reference is required (BT-122).`);
+    // Neither a file nor a link means the reference points at nothing the recipient can reach.
+    if (!d.file && !d.url) {
+      problems.push(
+        `${at} has neither a file nor a url - a supporting document the recipient cannot open is only a name (BT-124 or BT-125).`,
+      );
+    }
+    if (d.file && !d.file.filename) problems.push(`${at}.file.filename is required by the schema.`);
+    if (d.file && !d.file.mimeType) problems.push(`${at}.file.mimeType is required by the schema.`);
+  });
+  return problems;
+}

--- a/packages/e-invoice/src/cii.ts
+++ b/packages/e-invoice/src/cii.ts
@@ -1,6 +1,7 @@
 import {
   AllowanceCharge,
   PrecedingInvoice,
+  SupportingDocument,
   Buyer,
   Invoice,
   InvoiceLine,
@@ -11,6 +12,7 @@ import {
 import { ComputedInvoice, VatBreakdownEntry } from "./compute.ts";
 import { paymentTermsText } from "./skonto.ts";
 import { acAmount, hasPercentage } from "./allowance.ts";
+import { toBase64 } from "./attachment.ts";
 
 // Emits the UN/CEFACT Cross Industry Invoice (CII) XML for the EN16931 profile. The structure is
 // order-sensitive (it follows the CII XSD sequence); every element is mapped to its BT/BG code.
@@ -74,6 +76,24 @@ const date102 = (iso: string) =>
 /** The same date in the QUALIFIED namespace, which FormattedIssueDateTime (BT-26) requires. */
 const qdtDate102 = (iso: string) =>
   `<qdt:DateTimeString format="102">${iso.replace(/-/g, "")}</qdt:DateTimeString>`;
+
+/**
+ * BG-24: an extra document. TypeCode 916 ("related document") is what Factur-X uses for the group;
+ * `mimeCode` and `filename` are REQUIRED attributes on the binary, so a file without them is refused
+ * by `profile-check` rather than written out and rejected by the schema.
+ */
+function supportingDocument(doc: SupportingDocument): string {
+  const binary = doc.file
+    ? `<ram:AttachmentBinaryObject mimeCode="${escAttr(doc.file.mimeType)}" filename="${escAttr(doc.file.filename)}">${toBase64(doc.file.content)}</ram:AttachmentBinaryObject>`
+    : "";
+  return wrap("ram:AdditionalReferencedDocument", [
+    el("ram:IssuerAssignedID", doc.reference), // BT-122
+    el("ram:URIID", doc.url), // BT-124
+    el("ram:TypeCode", "916"),
+    el("ram:Name", doc.description), // BT-123
+    binary, // BT-125
+  ]);
+}
 
 /** BG-3: the invoice this one corrects or credits. Sits AFTER the totals in the XSD sequence. */
 function precedingInvoice(ref: PrecedingInvoice): string {
@@ -290,6 +310,8 @@ export function toCII(
           el("ram:IssuerAssignedID", invoice.contractRef), // BT-12
         ])
       : "",
+    // AdditionalReferencedDocument follows the contract reference in HeaderTradeAgreementType.
+    ...(invoice.supportingDocuments ?? []).map(supportingDocument), // BG-24
   ]);
 
   const d = invoice.delivery;

--- a/packages/e-invoice/src/cii.ts
+++ b/packages/e-invoice/src/cii.ts
@@ -1,5 +1,6 @@
 import {
   AllowanceCharge,
+  PrecedingInvoice,
   Buyer,
   Invoice,
   InvoiceLine,
@@ -19,6 +20,8 @@ const NS = {
   rsm: "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100",
   ram: "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100",
   udt: "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100",
+  // BT-26 is the only qualified type we emit: FormattedIssueDateTime is qdt, not udt.
+  qdt: "urn:un:unece:uncefact:data:standard:QualifiedDataType:100",
 };
 
 /** The profiles this generator emits CII for. */
@@ -68,6 +71,17 @@ function wrap(tag: string, children: string[]): string {
 
 const date102 = (iso: string) =>
   `<udt:DateTimeString format="102">${iso.replace(/-/g, "")}</udt:DateTimeString>`;
+/** The same date in the QUALIFIED namespace, which FormattedIssueDateTime (BT-26) requires. */
+const qdtDate102 = (iso: string) =>
+  `<qdt:DateTimeString format="102">${iso.replace(/-/g, "")}</qdt:DateTimeString>`;
+
+/** BG-3: the invoice this one corrects or credits. Sits AFTER the totals in the XSD sequence. */
+function precedingInvoice(ref: PrecedingInvoice): string {
+  return wrap("ram:InvoiceReferencedDocument", [
+    el("ram:IssuerAssignedID", ref.number), // BT-25
+    ref.issueDate ? wrap("ram:FormattedIssueDateTime", [qdtDate102(ref.issueDate)]) : "", // BT-26
+  ]);
+}
 const amount = (n: number) => n.toFixed(2);
 
 function address(a: PostalAddress): string {
@@ -360,6 +374,9 @@ export function toCII(
     ...(invoice.allowancesCharges ?? []).map(docAllowanceCharge), // BG-20 / BG-21
     paymentTerms,
     totals, // BG-22
+    // AFTER the summation, per the HeaderTradeSettlementType sequence - it reads as an
+    // afterthought but the XSD puts it there.
+    ...(invoice.precedingInvoices ?? []).map(precedingInvoice), // BG-3
   ]);
 
   const transaction = wrap("rsm:SupplyChainTradeTransaction", [
@@ -381,7 +398,7 @@ export function toCII(
 
   return (
     `<?xml version="1.0" encoding="UTF-8"?>\n` +
-    `<rsm:CrossIndustryInvoice xmlns:rsm="${NS.rsm}" xmlns:ram="${NS.ram}" xmlns:udt="${NS.udt}">` +
+    `<rsm:CrossIndustryInvoice xmlns:rsm="${NS.rsm}" xmlns:ram="${NS.ram}" xmlns:qdt="${NS.qdt}" xmlns:udt="${NS.udt}">` +
     context +
     header +
     transaction +

--- a/packages/e-invoice/src/cii.ts
+++ b/packages/e-invoice/src/cii.ts
@@ -339,6 +339,12 @@ export function toCII(
       ? wrap("ram:SpecifiedTradeSettlementPaymentMeans", [
           el("ram:TypeCode", p.meansCode ?? "58"), // BT-81 (58 = SEPA credit transfer)
           el("ram:Information", p.meansText), // BT-82
+          // PAYER before PAYEE - the type's sequence, and the two are easy to mix up.
+          p.directDebit?.debitedIban
+            ? wrap("ram:PayerPartyDebtorFinancialAccount", [
+                el("ram:IBANID", p.directDebit.debitedIban), // BT-91
+              ])
+            : "",
           p.iban
             ? wrap("ram:PayeePartyCreditorFinancialAccount", [
                 el("ram:IBANID", p.iban), // BT-84
@@ -361,12 +367,13 @@ export function toCII(
     computed.grandTotal,
   );
   const paymentTerms =
-    invoice.dueDate || termsText
+    invoice.dueDate || termsText || p?.directDebit?.mandateReference
       ? wrap("ram:SpecifiedTradePaymentTerms", [
           el("ram:Description", termsText), // BT-20
           invoice.dueDate
             ? wrap("ram:DueDateDateTime", [date102(invoice.dueDate)]) // BT-9
             : "",
+          el("ram:DirectDebitMandateID", p?.directDebit?.mandateReference), // BT-89
         ])
       : "";
 
@@ -387,6 +394,7 @@ export function toCII(
   ]);
 
   const settlement = wrap("ram:ApplicableHeaderTradeSettlement", [
+    el("ram:CreditorReferenceID", invoice.payment?.directDebit?.creditorId), // BT-90
     el("ram:PaymentReference", invoice.payment?.reference ?? invoice.number), // BT-83
     el("ram:InvoiceCurrencyCode", invoice.currency), // BT-5
     invoice.payeeName ? wrap("ram:PayeeTradeParty", [el("ram:Name", invoice.payeeName)]) : "", // BG-10

--- a/packages/e-invoice/src/cii.ts
+++ b/packages/e-invoice/src/cii.ts
@@ -388,6 +388,7 @@ export function toCII(
       : "",
     el("ram:TaxBasisTotalAmount", amount(computed.taxBasisTotal)), // BT-109
     el("ram:TaxTotalAmount", amount(computed.taxTotal), { currencyID: invoice.currency }), // BT-110
+    computed.roundingAmount ? el("ram:RoundingAmount", amount(computed.roundingAmount)) : "", // BT-114
     el("ram:GrandTotalAmount", amount(computed.grandTotal)), // BT-112
     computed.paidAmount ? el("ram:TotalPrepaidAmount", amount(computed.paidAmount)) : "", // BT-113
     el("ram:DuePayableAmount", amount(computed.duePayable)), // BT-115

--- a/packages/e-invoice/src/cii.ts
+++ b/packages/e-invoice/src/cii.ts
@@ -95,6 +95,16 @@ function supportingDocument(doc: SupportingDocument): string {
   ]);
 }
 
+/** A bare reference that only differs from its neighbours by TypeCode (BT-17, BT-18, BT-128). */
+function typedReference(id: string | undefined, typeCode: string): string {
+  return id
+    ? wrap("ram:AdditionalReferencedDocument", [
+        el("ram:IssuerAssignedID", id),
+        el("ram:TypeCode", typeCode),
+      ])
+    : "";
+}
+
 /** BG-3: the invoice this one corrects or credits. Sits AFTER the totals in the XSD sequence. */
 function precedingInvoice(ref: PrecedingInvoice): string {
   return wrap("ram:InvoiceReferencedDocument", [
@@ -118,6 +128,7 @@ function address(a: PostalAddress): string {
 
 function sellerParty(s: Seller): string {
   return wrap("ram:SellerTradeParty", [
+    el("ram:ID", s.identifier), // BT-29 - ID is the FIRST child of TradePartyType
     el("ram:Name", s.name), // BT-27
     el("ram:Description", s.additionalLegalInfo), // BT-33
     wrap("ram:SpecifiedLegalOrganization", [
@@ -142,6 +153,7 @@ function sellerParty(s: Seller): string {
 
 function buyerParty(b: Buyer): string {
   return wrap("ram:BuyerTradeParty", [
+    el("ram:ID", b.identifier), // BT-46
     el("ram:Name", b.name), // BT-44
     wrap("ram:SpecifiedLegalOrganization", [
       el("ram:ID", b.legalRegistrationId), // BT-47
@@ -250,8 +262,14 @@ function line(l: InvoiceLine, net: number, index: number): string {
       el("ram:BuyerAssignedID", l.buyerItemId), // BT-156
       el("ram:Name", l.name), // BT-153
       el("ram:Description", l.description), // BT-154
+      l.originCountry
+        ? wrap("ram:OriginTradeCountry", [el("ram:ID", l.originCountry)]) // BT-159
+        : "",
     ]),
     wrap("ram:SpecifiedLineTradeAgreement", [
+      l.orderLineRef
+        ? wrap("ram:BuyerOrderReferencedDocument", [el("ram:LineID", l.orderLineRef)]) // BT-132
+        : "",
       wrap("ram:NetPriceProductTradePrice", [
         el("ram:ChargeAmount", amount(l.netUnitPrice)), // BT-146
         l.priceBaseQuantity
@@ -276,6 +294,13 @@ function line(l: InvoiceLine, net: number, index: number): string {
       wrap("ram:SpecifiedTradeSettlementLineMonetarySummation", [
         el("ram:LineTotalAmount", amount(net)), // BT-131
       ]),
+      // Both sit AFTER the summation in LineTradeSettlementType, which reads oddly and is binding.
+      typedReference(l.objectRef, "130"), // BT-128
+      l.buyerAccountingRef
+        ? wrap("ram:ReceivableSpecifiedTradeAccountingAccount", [
+            el("ram:ID", l.buyerAccountingRef), // BT-133
+          ])
+        : "",
     ]),
   ]);
 }
@@ -285,7 +310,13 @@ export function toCII(
   computed: ComputedInvoice,
   profile: CiiProfile = "en16931",
 ): string {
-  const notes = (invoice.notes ?? []).map((n) => wrap("ram:IncludedNote", [el("ram:Content", n)])); // BG-1 / BT-22
+  // BG-1. SubjectCode follows Content in NoteType, and says what the note is ABOUT (BT-21).
+  const notes = (invoice.notes ?? []).map((n) =>
+    wrap("ram:IncludedNote", [
+      el("ram:Content", n), // BT-22
+      el("ram:SubjectCode", invoice.noteSubjectCode), // BT-21
+    ]),
+  );
 
   const header = wrap("rsm:ExchangedDocument", [
     el("ram:ID", invoice.number), // BT-1
@@ -300,6 +331,11 @@ export function toCII(
     el("ram:BuyerReference", invoice.buyerReference), // BT-10 (Leitweg-ID for XRechnung)
     sellerParty(invoice.seller), // BG-4
     buyerParty(invoice.buyer), // BG-7
+    invoice.salesOrderRef
+      ? wrap("ram:SellerOrderReferencedDocument", [
+          el("ram:IssuerAssignedID", invoice.salesOrderRef), // BT-14
+        ])
+      : "",
     invoice.purchaseOrderRef
       ? wrap("ram:BuyerOrderReferencedDocument", [
           el("ram:IssuerAssignedID", invoice.purchaseOrderRef), // BT-13
@@ -311,14 +347,25 @@ export function toCII(
         ])
       : "",
     // AdditionalReferencedDocument follows the contract reference in HeaderTradeAgreementType.
+    // Several business terms share the element and are told apart by their TypeCode: 50 tender,
+    // 130 invoiced object, 916 a supporting document.
+    typedReference(invoice.tenderRef, "50"), // BT-17
+    typedReference(invoice.objectRef, "130"), // BT-18
     ...(invoice.supportingDocuments ?? []).map(supportingDocument), // BG-24
+    invoice.projectRef
+      ? wrap("ram:SpecifiedProcuringProject", [
+          el("ram:ID", invoice.projectRef), // BT-11
+          el("ram:Name", invoice.projectRef),
+        ])
+      : "",
   ]);
 
   const d = invoice.delivery;
   // ApplicableHeaderTradeDelivery is mandatory (1..1) even when empty - emit the wrapper always.
   const deliveryChildren = [
-    d?.recipientName || d?.address
+    d?.locationId || d?.recipientName || d?.address
       ? wrap("ram:ShipToTradeParty", [
+          el("ram:ID", d?.locationId), // BT-71 - a site number instead of an address
           el("ram:Name", d?.recipientName), // BT-70
           d?.address ? address(d.address) : "", // BG-15
         ])
@@ -398,7 +445,17 @@ export function toCII(
     el("ram:CreditorReferenceID", invoice.payment?.directDebit?.creditorId), // BT-90
     el("ram:PaymentReference", invoice.payment?.reference ?? invoice.number), // BT-83
     el("ram:InvoiceCurrencyCode", invoice.currency), // BT-5
-    invoice.payeeName ? wrap("ram:PayeeTradeParty", [el("ram:Name", invoice.payeeName)]) : "", // BG-10
+    invoice.payeeName || invoice.payeeIdentifier
+      ? wrap("ram:PayeeTradeParty", [
+          el("ram:ID", invoice.payeeIdentifier), // BT-60
+          el("ram:Name", invoice.payeeName), // BT-59
+          invoice.payeeLegalRegistrationId
+            ? wrap("ram:SpecifiedLegalOrganization", [
+                el("ram:ID", invoice.payeeLegalRegistrationId), // BT-61
+              ])
+            : "",
+        ])
+      : "", // BG-10
     paymentMeans, // BG-16
     ...computed.vatBreakdown.map(tradeTax), // BG-23
     billingPeriod(invoice.period), // BG-14
@@ -408,6 +465,11 @@ export function toCII(
     // AFTER the summation, per the HeaderTradeSettlementType sequence - it reads as an
     // afterthought but the XSD puts it there.
     ...(invoice.precedingInvoices ?? []).map(precedingInvoice), // BG-3
+    invoice.buyerAccountingRef
+      ? wrap("ram:ReceivableSpecifiedTradeAccountingAccount", [
+          el("ram:ID", invoice.buyerAccountingRef), // BT-19
+        ])
+      : "",
   ]);
 
   const transaction = wrap("rsm:SupplyChainTradeTransaction", [

--- a/packages/e-invoice/src/cii.ts
+++ b/packages/e-invoice/src/cii.ts
@@ -8,6 +8,7 @@ import {
   ServicePeriod,
 } from "./invoice.ts";
 import { ComputedInvoice, VatBreakdownEntry } from "./compute.ts";
+import { paymentTermsText } from "./skonto.ts";
 
 // Emits the UN/CEFACT Cross Industry Invoice (CII) XML for the EN16931 profile. The structure is
 // order-sensitive (it follows the CII XSD sequence); every element is mapped to its BT/BG code.
@@ -310,10 +311,17 @@ export function toCII(
         ])
       : "";
 
+  // BT-20 carries the human terms AND, beneath them, one machine-readable line per Skonto tier.
+  const termsText = paymentTermsText(
+    p?.terms,
+    p?.cashDiscounts,
+    invoice.issueDate,
+    computed.grandTotal,
+  );
   const paymentTerms =
-    invoice.dueDate || p?.terms
+    invoice.dueDate || termsText
       ? wrap("ram:SpecifiedTradePaymentTerms", [
-          el("ram:Description", p?.terms), // BT-20
+          el("ram:Description", termsText), // BT-20
           invoice.dueDate
             ? wrap("ram:DueDateDateTime", [date102(invoice.dueDate)]) // BT-9
             : "",

--- a/packages/e-invoice/src/cii.ts
+++ b/packages/e-invoice/src/cii.ts
@@ -9,6 +9,7 @@ import {
 } from "./invoice.ts";
 import { ComputedInvoice, VatBreakdownEntry } from "./compute.ts";
 import { paymentTermsText } from "./skonto.ts";
+import { acAmount, hasPercentage } from "./allowance.ts";
 
 // Emits the UN/CEFACT Cross Industry Invoice (CII) XML for the EN16931 profile. The structure is
 // order-sensitive (it follows the CII XSD sequence); every element is mapped to its BT/BG code.
@@ -142,7 +143,10 @@ function contact(c: { name?: string; phone?: string; email?: string } | undefine
 function docAllowanceCharge(ac: AllowanceCharge): string {
   return wrap("ram:SpecifiedTradeAllowanceCharge", [
     wrap("ram:ChargeIndicator", [el("udt:Indicator", String(ac.isCharge))]),
-    el("ram:ActualAmount", amount(ac.amount)), // BT-92 / BT-99
+    // PERCENT and BASIS before the amount - TradeAllowanceChargeType's sequence in the XSD.
+    hasPercentage(ac) ? el("ram:CalculationPercent", ac.percent) : "", // BT-94 / BT-101
+    hasPercentage(ac) ? el("ram:BasisAmount", amount(ac.baseAmount)) : "", // BT-93 / BT-100
+    el("ram:ActualAmount", amount(acAmount(ac))), // BT-92 / BT-99
     // CODE before REASON - the XSD sequence, which reads backwards from how one says it.
     el("ram:ReasonCode", ac.reasonCode), // BT-98 / BT-105
     el("ram:Reason", ac.reason), // BT-97 / BT-104
@@ -162,7 +166,9 @@ function docAllowanceCharge(ac: AllowanceCharge): string {
 function lineAllowanceCharge(ac: AllowanceCharge): string {
   return wrap("ram:SpecifiedTradeAllowanceCharge", [
     wrap("ram:ChargeIndicator", [el("udt:Indicator", String(ac.isCharge))]),
-    el("ram:ActualAmount", amount(ac.amount)), // BT-136 / BT-141
+    hasPercentage(ac) ? el("ram:CalculationPercent", ac.percent) : "", // BT-138 / BT-143
+    hasPercentage(ac) ? el("ram:BasisAmount", amount(ac.baseAmount)) : "", // BT-137 / BT-142
+    el("ram:ActualAmount", amount(acAmount(ac))), // BT-136 / BT-141
     el("ram:ReasonCode", ac.reasonCode), // BT-140 / BT-145
     el("ram:Reason", ac.reason), // BT-139 / BT-144
   ]);

--- a/packages/e-invoice/src/cii.ts
+++ b/packages/e-invoice/src/cii.ts
@@ -435,6 +435,13 @@ export function toCII(
       : "",
     el("ram:TaxBasisTotalAmount", amount(computed.taxBasisTotal)), // BT-109
     el("ram:TaxTotalAmount", amount(computed.taxTotal), { currencyID: invoice.currency }), // BT-110
+    // The schema allows this element exactly TWICE, which is how BT-110 and BT-111 are told
+    // apart: same tag, different currencyID.
+    invoice.taxCurrency && invoice.taxTotalInTaxCurrency !== undefined
+      ? el("ram:TaxTotalAmount", amount(invoice.taxTotalInTaxCurrency), {
+          currencyID: invoice.taxCurrency,
+        }) // BT-111
+      : "",
     computed.roundingAmount ? el("ram:RoundingAmount", amount(computed.roundingAmount)) : "", // BT-114
     el("ram:GrandTotalAmount", amount(computed.grandTotal)), // BT-112
     computed.paidAmount ? el("ram:TotalPrepaidAmount", amount(computed.paidAmount)) : "", // BT-113
@@ -444,6 +451,7 @@ export function toCII(
   const settlement = wrap("ram:ApplicableHeaderTradeSettlement", [
     el("ram:CreditorReferenceID", invoice.payment?.directDebit?.creditorId), // BT-90
     el("ram:PaymentReference", invoice.payment?.reference ?? invoice.number), // BT-83
+    el("ram:TaxCurrencyCode", invoice.taxCurrency), // BT-6
     el("ram:InvoiceCurrencyCode", invoice.currency), // BT-5
     invoice.payeeName || invoice.payeeIdentifier
       ? wrap("ram:PayeeTradeParty", [

--- a/packages/e-invoice/src/compute.ts
+++ b/packages/e-invoice/src/compute.ts
@@ -35,7 +35,8 @@ export interface ComputedInvoice {
   taxTotal: number; // BT-110  sum of VAT group tax amounts
   grandTotal: number; // BT-112  = taxBasisTotal + taxTotal
   paidAmount: number; // BT-113
-  duePayable: number; // BT-115  = grandTotal - paidAmount
+  roundingAmount: number; // BT-114  the deliberate cent, 0 when nobody asked for one
+  duePayable: number; // BT-115  = grandTotal - paidAmount + roundingAmount
   vatBreakdown: VatBreakdownEntry[]; // BG-23
 }
 
@@ -97,7 +98,10 @@ export function computeInvoice(invoice: Invoice): ComputedInvoice {
   const taxTotal = round2(sum(vatBreakdown.map((g) => g.taxAmount)));
   const grandTotal = round2(taxBasisTotal + taxTotal);
   const paidAmount = round2(invoice.paidAmount ?? 0);
-  const duePayable = round2(grandTotal - paidAmount);
+  // BT-114 is ADDED, per EN 16931: it moves the PAYABLE, not the invoice total. The CII XSD puts
+  // the element before the grand total, which reads as though it moved that instead - it does not.
+  const roundingAmount = round2(invoice.roundingAmount ?? 0);
+  const duePayable = round2(grandTotal - paidAmount + roundingAmount);
 
   return {
     lineNets,
@@ -108,6 +112,7 @@ export function computeInvoice(invoice: Invoice): ComputedInvoice {
     taxTotal,
     grandTotal,
     paidAmount,
+    roundingAmount,
     duePayable,
     vatBreakdown,
   };

--- a/packages/e-invoice/src/compute.ts
+++ b/packages/e-invoice/src/compute.ts
@@ -1,3 +1,4 @@
+import { acAmount } from "./allowance.ts";
 import {
   AllowanceCharge,
   Invoice,
@@ -43,7 +44,7 @@ function lineNet(line: InvoiceLine): number {
   const base = line.priceBaseQuantity && line.priceBaseQuantity > 0 ? line.priceBaseQuantity : 1;
   const gross = line.quantity * (line.netUnitPrice / base);
   const adjustment = (line.allowancesCharges ?? []).reduce(
-    (sum, ac) => sum + (ac.isCharge ? ac.amount : -ac.amount),
+    (sum, ac) => sum + (ac.isCharge ? acAmount(ac) : -acAmount(ac)),
     0,
   );
   return round2(gross + adjustment);
@@ -57,8 +58,8 @@ export function computeInvoice(invoice: Invoice): ComputedInvoice {
   const lineTotal = round2(sum(lineNets));
 
   const docAC: AllowanceCharge[] = invoice.allowancesCharges ?? [];
-  const allowanceTotal = round2(sum(docAC.filter((a) => !a.isCharge).map((a) => a.amount)));
-  const chargeTotal = round2(sum(docAC.filter((a) => a.isCharge).map((a) => a.amount)));
+  const allowanceTotal = round2(sum(docAC.filter((a) => !a.isCharge).map(acAmount)));
+  const chargeTotal = round2(sum(docAC.filter((a) => a.isCharge).map(acAmount)));
 
   // BG-23: group by (category, rate). Taxable = matching line nets ± matching document-level
   // allowances/charges. The tax of each group is taxable × rate.
@@ -77,7 +78,7 @@ export function computeInvoice(invoice: Invoice): ComputedInvoice {
   });
   docAC.forEach((ac) => {
     const group = groupFor(ac.vat.category, ac.vat.ratePercent ?? 0);
-    group.taxableAmount += ac.isCharge ? ac.amount : -ac.amount;
+    group.taxableAmount += ac.isCharge ? acAmount(ac) : -acAmount(ac);
   });
 
   const vatBreakdown: VatBreakdownEntry[] = [...groups.values()].map((g) => {

--- a/packages/e-invoice/src/i18n.ts
+++ b/packages/e-invoice/src/i18n.ts
@@ -45,6 +45,8 @@ export interface InvoiceLabels {
   percentOf: string;
   /** BG-3 - which invoice this one corrects or credits. */
   precedingInvoice: string;
+  /** BG-24 - the extra documents that came with the invoice. */
+  attachments: string;
   itemNumber: string;
   perQuantity: string;
   page: string;
@@ -98,6 +100,7 @@ const de: InvoiceLabels = {
   cashDiscountUntil: "bei Zahlung bis",
   percentOf: "von",
   precedingInvoice: "Bezug auf Rechnung",
+  attachments: "Anlagen",
   itemNumber: "Art.-Nr.",
   perQuantity: "je",
   page: "Seite",
@@ -151,6 +154,7 @@ const en: InvoiceLabels = {
   cashDiscountUntil: "if paid by",
   percentOf: "of",
   precedingInvoice: "Refers to invoice",
+  attachments: "Attachments",
   itemNumber: "Item no.",
   perQuantity: "per",
   page: "Page",
@@ -204,6 +208,7 @@ const fr: InvoiceLabels = {
   cashDiscountUntil: "si payé avant le",
   percentOf: "de",
   precedingInvoice: "Se rapporte à la facture",
+  attachments: "Pièces jointes",
   itemNumber: "Réf. article",
   perQuantity: "par",
   page: "Page",

--- a/packages/e-invoice/src/i18n.ts
+++ b/packages/e-invoice/src/i18n.ts
@@ -22,6 +22,8 @@ export interface InvoiceLabels {
   plusVat: string;
   grandTotal: string;
   alreadyPaid: string;
+  /** BT-114 - the deliberate cent that makes the payable a round figure. */
+  rounding: string;
   amountDue: string;
   payment: string;
   payableBy: string;
@@ -84,6 +86,7 @@ const de: InvoiceLabels = {
   plusVat: "zzgl. USt",
   grandTotal: "Gesamtbetrag",
   alreadyPaid: "bereits gezahlt",
+  rounding: "Rundung",
   amountDue: "Zahlbetrag",
   payment: "Zahlung",
   payableBy: "Zahlbar bis",
@@ -142,6 +145,7 @@ const en: InvoiceLabels = {
   plusVat: "plus VAT",
   grandTotal: "Total",
   alreadyPaid: "already paid",
+  rounding: "Rounding",
   amountDue: "Amount due",
   payment: "Payment",
   payableBy: "Payable by",
@@ -200,6 +204,7 @@ const fr: InvoiceLabels = {
   plusVat: "TVA",
   grandTotal: "Total TTC",
   alreadyPaid: "déjà payé",
+  rounding: "Arrondi",
   amountDue: "Net à payer",
   payment: "Paiement",
   payableBy: "À payer avant le",

--- a/packages/e-invoice/src/i18n.ts
+++ b/packages/e-invoice/src/i18n.ts
@@ -34,6 +34,8 @@ export interface InvoiceLabels {
   deliveryLocation: string;
   orderLine: string;
   originCountry: string;
+  /** BT-111 - the VAT total in the accounting currency, when that is a different one. */
+  vatIn: string;
   amountDue: string;
   payment: string;
   payableBy: string;
@@ -106,6 +108,7 @@ const de: InvoiceLabels = {
   deliveryLocation: "Lieferort-Nr.",
   orderLine: "Bestellposition",
   originCountry: "Ursprungsland",
+  vatIn: "USt in",
   amountDue: "Zahlbetrag",
   payment: "Zahlung",
   payableBy: "Zahlbar bis",
@@ -174,6 +177,7 @@ const en: InvoiceLabels = {
   deliveryLocation: "Location no.",
   orderLine: "Order line",
   originCountry: "Country of origin",
+  vatIn: "VAT in",
   amountDue: "Amount due",
   payment: "Payment",
   payableBy: "Payable by",
@@ -242,6 +246,7 @@ const fr: InvoiceLabels = {
   deliveryLocation: "N° de lieu",
   orderLine: "Ligne de commande",
   originCountry: "Pays d'origine",
+  vatIn: "TVA en",
   amountDue: "Net à payer",
   payment: "Paiement",
   payableBy: "À payer avant le",
@@ -299,6 +304,12 @@ export function resolveLabels(
 export interface Formatters {
   /** A currency amount, e.g. de → "1.234,56 €", en → "€1,234.56". */
   money(n: number): string;
+  /**
+   * The same, in a currency that is NOT the document's - only BT-111 needs this. `money` binds
+   * the document currency at construction, and `number` drops the second decimal, which on a
+   * tax figure reads as a typo.
+   */
+  moneyIn(n: number, currency: string): string;
   /** A plain number, e.g. a quantity. */
   number(n: number): string;
   /** A VAT rate given in percent (19 → de "19 %", en "19%"). */
@@ -332,6 +343,8 @@ export function makeFormatters(locale: Locale = "de", currency: string): Formatt
   const currencyNames = new Intl.DisplayNames([tag], { type: "currency" });
   return {
     money: (n) => money.format(n),
+    moneyIn: (n, other) =>
+      new Intl.NumberFormat(tag, { style: "currency", currency: other }).format(n),
     number: (n) => number.format(n),
     percent: (ratePercent) => percent.format(ratePercent / 100),
     date: (iso) => date.format(utc(iso)),

--- a/packages/e-invoice/src/i18n.ts
+++ b/packages/e-invoice/src/i18n.ts
@@ -24,6 +24,16 @@ export interface InvoiceLabels {
   alreadyPaid: string;
   /** BT-114 - the deliberate cent that makes the payable a round figure. */
   rounding: string;
+  /** The scalar references that only exist to be quoted back (BT-11, BT-14, BT-17…BT-19, …). */
+  salesOrderNumber: string;
+  projectReference: string;
+  tenderReference: string;
+  objectReference: string;
+  accountingReference: string;
+  partyIdentifier: string;
+  deliveryLocation: string;
+  orderLine: string;
+  originCountry: string;
   amountDue: string;
   payment: string;
   payableBy: string;
@@ -87,6 +97,15 @@ const de: InvoiceLabels = {
   grandTotal: "Gesamtbetrag",
   alreadyPaid: "bereits gezahlt",
   rounding: "Rundung",
+  salesOrderNumber: "Auftragsnummer",
+  projectReference: "Projekt",
+  tenderReference: "Vergabenummer",
+  objectReference: "Objekt",
+  accountingReference: "Kostenstelle",
+  partyIdentifier: "Kennung",
+  deliveryLocation: "Lieferort-Nr.",
+  orderLine: "Bestellposition",
+  originCountry: "Ursprungsland",
   amountDue: "Zahlbetrag",
   payment: "Zahlung",
   payableBy: "Zahlbar bis",
@@ -146,6 +165,15 @@ const en: InvoiceLabels = {
   grandTotal: "Total",
   alreadyPaid: "already paid",
   rounding: "Rounding",
+  salesOrderNumber: "Sales order",
+  projectReference: "Project",
+  tenderReference: "Tender",
+  objectReference: "Object",
+  accountingReference: "Cost centre",
+  partyIdentifier: "Identifier",
+  deliveryLocation: "Location no.",
+  orderLine: "Order line",
+  originCountry: "Country of origin",
   amountDue: "Amount due",
   payment: "Payment",
   payableBy: "Payable by",
@@ -205,6 +233,15 @@ const fr: InvoiceLabels = {
   grandTotal: "Total TTC",
   alreadyPaid: "déjà payé",
   rounding: "Arrondi",
+  salesOrderNumber: "Numéro de commande",
+  projectReference: "Projet",
+  tenderReference: "Appel d'offres",
+  objectReference: "Objet",
+  accountingReference: "Centre de coûts",
+  partyIdentifier: "Identifiant",
+  deliveryLocation: "N° de lieu",
+  orderLine: "Ligne de commande",
+  originCountry: "Pays d'origine",
   amountDue: "Net à payer",
   payment: "Paiement",
   payableBy: "À payer avant le",

--- a/packages/e-invoice/src/i18n.ts
+++ b/packages/e-invoice/src/i18n.ts
@@ -41,6 +41,8 @@ export interface InvoiceLabels {
   paymentMeans: string;
   cashDiscount: string;
   cashDiscountUntil: string;
+  /** Joins a rate to its base: "10 % <percentOf> 1.000,00 EUR". */
+  percentOf: string;
   itemNumber: string;
   perQuantity: string;
   page: string;
@@ -92,6 +94,7 @@ const de: InvoiceLabels = {
   paymentMeans: "Zahlungsart",
   cashDiscount: "Skonto",
   cashDiscountUntil: "bei Zahlung bis",
+  percentOf: "von",
   itemNumber: "Art.-Nr.",
   perQuantity: "je",
   page: "Seite",
@@ -143,6 +146,7 @@ const en: InvoiceLabels = {
   paymentMeans: "Payment method",
   cashDiscount: "Early payment discount",
   cashDiscountUntil: "if paid by",
+  percentOf: "of",
   itemNumber: "Item no.",
   perQuantity: "per",
   page: "Page",
@@ -194,6 +198,7 @@ const fr: InvoiceLabels = {
   paymentMeans: "Mode de paiement",
   cashDiscount: "Escompte",
   cashDiscountUntil: "si payé avant le",
+  percentOf: "de",
   itemNumber: "Réf. article",
   perQuantity: "par",
   page: "Page",

--- a/packages/e-invoice/src/i18n.ts
+++ b/packages/e-invoice/src/i18n.ts
@@ -43,6 +43,8 @@ export interface InvoiceLabels {
   cashDiscountUntil: string;
   /** Joins a rate to its base: "10 % <percentOf> 1.000,00 EUR". */
   percentOf: string;
+  /** BG-3 - which invoice this one corrects or credits. */
+  precedingInvoice: string;
   itemNumber: string;
   perQuantity: string;
   page: string;
@@ -95,6 +97,7 @@ const de: InvoiceLabels = {
   cashDiscount: "Skonto",
   cashDiscountUntil: "bei Zahlung bis",
   percentOf: "von",
+  precedingInvoice: "Bezug auf Rechnung",
   itemNumber: "Art.-Nr.",
   perQuantity: "je",
   page: "Seite",
@@ -147,6 +150,7 @@ const en: InvoiceLabels = {
   cashDiscount: "Early payment discount",
   cashDiscountUntil: "if paid by",
   percentOf: "of",
+  precedingInvoice: "Refers to invoice",
   itemNumber: "Item no.",
   perQuantity: "per",
   page: "Page",
@@ -199,6 +203,7 @@ const fr: InvoiceLabels = {
   cashDiscount: "Escompte",
   cashDiscountUntil: "si payé avant le",
   percentOf: "de",
+  precedingInvoice: "Se rapporte à la facture",
   itemNumber: "Réf. article",
   perQuantity: "par",
   page: "Page",

--- a/packages/e-invoice/src/i18n.ts
+++ b/packages/e-invoice/src/i18n.ts
@@ -47,6 +47,11 @@ export interface InvoiceLabels {
   precedingInvoice: string;
   /** BG-24 - the extra documents that came with the invoice. */
   attachments: string;
+  /** BG-19 - SEPA direct debit. */
+  directDebit: string;
+  mandateReference: string;
+  creditorId: string;
+  debitedAccount: string;
   itemNumber: string;
   perQuantity: string;
   page: string;
@@ -101,6 +106,10 @@ const de: InvoiceLabels = {
   percentOf: "von",
   precedingInvoice: "Bezug auf Rechnung",
   attachments: "Anlagen",
+  directDebit: "SEPA-Lastschrift",
+  mandateReference: "Mandatsreferenz",
+  creditorId: "Gläubiger-ID",
+  debitedAccount: "Belastetes Konto",
   itemNumber: "Art.-Nr.",
   perQuantity: "je",
   page: "Seite",
@@ -155,6 +164,10 @@ const en: InvoiceLabels = {
   percentOf: "of",
   precedingInvoice: "Refers to invoice",
   attachments: "Attachments",
+  directDebit: "SEPA direct debit",
+  mandateReference: "Mandate reference",
+  creditorId: "Creditor ID",
+  debitedAccount: "Debited account",
   itemNumber: "Item no.",
   perQuantity: "per",
   page: "Page",
@@ -209,6 +222,10 @@ const fr: InvoiceLabels = {
   percentOf: "de",
   precedingInvoice: "Se rapporte à la facture",
   attachments: "Pièces jointes",
+  directDebit: "Prélèvement SEPA",
+  mandateReference: "Référence du mandat",
+  creditorId: "Identifiant créancier",
+  debitedAccount: "Compte débité",
   itemNumber: "Réf. article",
   perQuantity: "par",
   page: "Page",

--- a/packages/e-invoice/src/i18n.ts
+++ b/packages/e-invoice/src/i18n.ts
@@ -39,6 +39,8 @@ export interface InvoiceLabels {
   deliverTo: string;
   payee: string;
   paymentMeans: string;
+  cashDiscount: string;
+  cashDiscountUntil: string;
   itemNumber: string;
   perQuantity: string;
   page: string;
@@ -88,6 +90,8 @@ const de: InvoiceLabels = {
   deliverTo: "Lieferanschrift",
   payee: "Zahlungsempfänger",
   paymentMeans: "Zahlungsart",
+  cashDiscount: "Skonto",
+  cashDiscountUntil: "bei Zahlung bis",
   itemNumber: "Art.-Nr.",
   perQuantity: "je",
   page: "Seite",
@@ -137,6 +141,8 @@ const en: InvoiceLabels = {
   deliverTo: "Delivery address",
   payee: "Payee",
   paymentMeans: "Payment method",
+  cashDiscount: "Early payment discount",
+  cashDiscountUntil: "if paid by",
   itemNumber: "Item no.",
   perQuantity: "per",
   page: "Page",
@@ -186,6 +192,8 @@ const fr: InvoiceLabels = {
   deliverTo: "Adresse de livraison",
   payee: "Bénéficiaire",
   paymentMeans: "Mode de paiement",
+  cashDiscount: "Escompte",
+  cashDiscountUntil: "si payé avant le",
   itemNumber: "Réf. article",
   perQuantity: "par",
   page: "Page",

--- a/packages/e-invoice/src/invoice.ts
+++ b/packages/e-invoice/src/invoice.ts
@@ -316,6 +316,20 @@ export interface Invoice {
   type?: InvoiceTypeCode;
   /** Document currency (BT-5)  (MANDATORY). */
   currency: CurrencyCode;
+  /**
+   * The currency VAT is ACCOUNTED in (BT-6), when that differs from the invoice currency. A German
+   * seller invoicing in a foreign currency has to state the tax amount in Euro, so this is `"EUR"`
+   * for them - and `taxTotalInTaxCurrency` (BT-111) must come with it.
+   */
+  taxCurrency?: CurrencyCode;
+  /**
+   * The total VAT expressed in `taxCurrency` (BT-111).
+   *
+   * Deliberately NOT derived: converting it needs an exchange rate, and which rate applies is a tax
+   * question (the rate of the supply date, of the invoice date, the monthly average). Inventing one
+   * would put a number on an invoice that nobody chose.
+   */
+  taxTotalInTaxCurrency?: number;
   /** Payment due date (BT-9). */
   dueDate?: IsoDate;
   /**

--- a/packages/e-invoice/src/invoice.ts
+++ b/packages/e-invoice/src/invoice.ts
@@ -66,6 +66,8 @@ export interface Contact {
 /** The seller / supplier (BG-4 + address BG-5 + contact BG-6). */
 export interface Seller {
   name: string; // BT-27  (MANDATORY) registered legal name
+  /** A directory identifier for the seller, e.g. a GLN (BT-29). Peppol and retail ask for it. */
+  identifier?: string;
   tradingName?: string; // BT-28  business/trading name if different
   /** Seller VAT identifier, e.g. `"DE123456789"` (BT-31). Needed whenever VAT is charged. */
   vatId?: string;
@@ -84,6 +86,8 @@ export interface Seller {
 /** The buyer / customer (BG-7 + address BG-8 + contact BG-9). */
 export interface Buyer {
   name: string; // BT-44  (MANDATORY)
+  /** A directory identifier for the buyer (BT-46) - the counterpart to the seller's BT-29. */
+  identifier?: string;
   tradingName?: string; // BT-45
   /** Buyer VAT identifier (BT-48) - required e.g. for reverse-charge / intra-community supply. */
   vatId?: string;
@@ -151,6 +155,8 @@ export interface SupportingDocument {
 /** Where the goods/services were delivered (BG-13). Optional; used when it differs from the buyer. */
 export interface Delivery {
   date?: IsoDate; // BT-72  actual delivery date
+  /** Identifier of the delivery location, e.g. a GLN (BT-71) - a site number instead of an address. */
+  locationId?: string;
   recipientName?: string; // BT-70  deliver-to party name
   address?: PostalAddress; // BG-15 deliver-to address
 }
@@ -230,6 +236,14 @@ export interface InvoiceLine {
   /** Per-line allowances/charges (BG-27 / BG-28). Net line amount BT-131 is computed from these. */
   allowancesCharges?: AllowanceCharge[];
   note?: string; // BT-127
+  /** What this line invoices, when it is a thing - a device or meter number (BT-128). */
+  objectRef?: string;
+  /** Which line of the buyer's order this settles (BT-132). Large customers reconcile on it. */
+  orderLineRef?: string;
+  /** The buyer's cost centre for THIS line (BT-133) - BT-19 per position. */
+  buyerAccountingRef?: string;
+  /** Country the item originates from (BT-159). Asked for in export and customs. */
+  originCountry?: CountryCode;
 }
 
 /**
@@ -312,8 +326,27 @@ export interface Invoice {
   /** Seller order/contract references: purchase order (BT-13), contract (BT-12). */
   purchaseOrderRef?: string;
   contractRef?: string;
+  /** The SELLER's own order number (BT-14), as opposed to the buyer's BT-13. */
+  salesOrderRef?: string;
+  /** Project the invoice belongs to (BT-11). Agencies and construction are asked for it. */
+  projectRef?: string;
+  /** Tender or lot reference (BT-17). Public procurement can require it. */
+  tenderRef?: string;
+  /** What is being invoiced, when it is a thing: a meter number, a contract object (BT-18). */
+  objectRef?: string;
+  /**
+   * The BUYER's cost centre or booking reference (BT-19). Large customers require it so their
+   * accounting can route the invoice without a human reading it.
+   */
+  buyerAccountingRef?: string;
   /** Free-text document notes (BG-1 / BT-22). */
   notes?: string[];
+  /**
+   * What the notes are ABOUT, as a code (BT-21, UNCL 4451 - e.g. `"AAI"` general information,
+   * `"REG"` regulatory). Applies to every note; the standard allows one subject per note, but a
+   * second note with a different subject is rare enough not to warrant an array of pairs yet.
+   */
+  noteSubjectCode?: string;
   /**
    * The invoice(s) this one corrects, credits or supplements (BG-3). Set it on every credit note
    * (`type: 381`) - without it the recipient cannot match the correction to its original.
@@ -333,6 +366,10 @@ export interface Invoice {
   period?: ServicePeriod;
   /** Payee if different from the seller (BG-10). */
   payeeName?: string; // BT-59
+  /** Identifier of that payee (BT-60). */
+  payeeIdentifier?: string;
+  /** Legal registration id of that payee (BT-61). */
+  payeeLegalRegistrationId?: string;
 
   /** The invoice lines (BG-25)  (MANDATORY, at least one). */
   lines: InvoiceLine[];

--- a/packages/e-invoice/src/invoice.ts
+++ b/packages/e-invoice/src/invoice.ts
@@ -117,17 +117,41 @@ export interface Delivery {
   address?: PostalAddress; // BG-15 deliver-to address
 }
 
-/** A document-level allowance (discount, BG-20) or charge (surcharge, BG-21). */
-export interface AllowanceCharge {
+/** What every allowance/charge carries, whether it is stated as an amount or as a percentage. */
+interface AllowanceChargeBase {
   /** `true` = charge (adds, BG-21), `false` = allowance/discount (subtracts, BG-20). */
   isCharge: boolean;
-  amount: number; // BT-92 (allowance) / BT-99 (charge)  (MANDATORY)
   /** The VAT category + rate this allowance/charge falls under (BT-95/96 or BT-102/103). */
   vat: LineVat;
   reason?: string; // BT-97 / BT-104  human reason
   /** Coded reason (UNCL 5189 allowance / UNCL 7161 charge), BT-98 / BT-105. */
   reasonCode?: string;
 }
+
+/** Stated as a fixed amount. The base and percentage may still be given, and are then shown. */
+export interface AllowanceChargeByAmount extends AllowanceChargeBase {
+  amount: number; // BT-92 / BT-99 / BT-136 / BT-141
+  baseAmount?: number; // BT-93 / BT-100 / BT-137 / BT-142
+  percent?: number; // BT-94 / BT-101 / BT-138 / BT-143
+}
+
+/** Stated as a percentage of a base - the amount is derived, so "10 %" survives into XML and paper. */
+export interface AllowanceChargeByPercent extends AllowanceChargeBase {
+  amount?: number;
+  /** The amount the percentage applies to (BT-93 / BT-100 / BT-137 / BT-142). */
+  baseAmount: number;
+  /** The rate, e.g. `10` for 10 % (BT-94 / BT-101 / BT-138 / BT-143). */
+  percent: number;
+}
+
+/**
+ * A document-level allowance (BG-20) / charge (BG-21), or the line-level pair (BG-27 / BG-28).
+ *
+ * A union rather than three optional fields: EN 16931 needs the AMOUNT either way, so an entry that
+ * gives neither an amount nor a base-and-percentage is not a valid allowance. The union makes that
+ * combination fail to compile instead of failing at a validator.
+ */
+export type AllowanceCharge = AllowanceChargeByAmount | AllowanceChargeByPercent;
 
 /** VAT treatment of a line / allowance / charge: a category and (for taxed categories) a rate. */
 export interface LineVat {

--- a/packages/e-invoice/src/invoice.ts
+++ b/packages/e-invoice/src/invoice.ts
@@ -124,6 +124,30 @@ export interface PrecedingInvoice {
   issueDate?: IsoDate;
 }
 
+/**
+ * An extra document that belongs to the invoice (BG-24) - a timesheet, a proof of service, a
+ * delivery note. Give it a `file`, a `url`, or both.
+ *
+ * A `file` travels twice: base64 inside the XML for a machine, and as an embedded file in the
+ * PDF/A-3 for a person. That is the only way both halves of the document see the same evidence.
+ */
+export interface SupportingDocument {
+  /** A reference for the document, e.g. `"TIMESHEET-2026-09"` (BT-122)  (MANDATORY). */
+  reference: string;
+  /** What it is, in words (BT-123). */
+  description?: string;
+  /** Where the recipient can fetch it instead (BT-124). */
+  url?: string;
+  /** The file itself (BT-125). `mimeType` and `filename` are required by the schema. */
+  file?: {
+    content: Uint8Array;
+    /** e.g. `"application/pdf"`, `"text/csv"`. */
+    mimeType: string;
+    /** The name it is saved under, e.g. `"stundennachweis.pdf"`. */
+    filename: string;
+  };
+}
+
 /** Where the goods/services were delivered (BG-13). Optional; used when it differs from the buyer. */
 export interface Delivery {
   date?: IsoDate; // BT-72  actual delivery date
@@ -277,6 +301,8 @@ export interface Invoice {
    * (`type: 381`) - without it the recipient cannot match the correction to its original.
    */
   precedingInvoices?: PrecedingInvoice[];
+  /** Extra documents that belong to this invoice (BG-24) - timesheets, proofs of service. */
+  supportingDocuments?: SupportingDocument[];
 
   seller: Seller; // BG-4  (MANDATORY)
   buyer: Buyer; // BG-7  (MANDATORY)

--- a/packages/e-invoice/src/invoice.ts
+++ b/packages/e-invoice/src/invoice.ts
@@ -251,6 +251,22 @@ export interface CashDiscount {
   baseAmount?: number;
 }
 
+/**
+ * SEPA direct debit (BG-19) - what the payer needs in order to recognise the collection on their
+ * statement and to check it against the mandate they signed.
+ *
+ * Set `payment.meansCode` to `"59"` (SEPA direct debit) or `"49"` alongside it; the pre-flight asks
+ * for a mandate reference whenever one of those is used.
+ */
+export interface DirectDebit {
+  /** The reference of the mandate the payer signed (BT-89)  (MANDATORY). */
+  mandateReference: string;
+  /** The seller's creditor identifier - the German Glaeubiger-ID (BT-90). */
+  creditorId?: string;
+  /** IBAN of the account that will be debited (BT-91). */
+  debitedIban?: string;
+}
+
 /** How the invoice is to be paid (BG-16 + credit transfer BG-17). */
 export interface Payment {
   /** Payment means code (UNCL 4461), e.g. `58` SEPA credit transfer, `30` credit transfer (BT-81). */
@@ -272,6 +288,8 @@ export interface Payment {
    * Written into BT-20 beneath `terms` in the machine-readable form, and printed on the PDF.
    */
   cashDiscounts?: CashDiscount[];
+  /** SEPA direct debit details (BG-19), when the seller collects rather than being paid. */
+  directDebit?: DirectDebit;
 }
 
 /** The complete invoice - the single input to `renderZugferd(invoice, …)`. */

--- a/packages/e-invoice/src/invoice.ts
+++ b/packages/e-invoice/src/invoice.ts
@@ -349,4 +349,10 @@ export interface Invoice {
 
   /** Amount already paid (BT-113), subtracted from the total to give the amount due (BT-115). */
   paidAmount?: number;
+  /**
+   * Rounding applied to reach a clean payable amount (BT-114), e.g. `0.03` to collect 100.40 on a
+   * total of 100.37, or `-0.02` to collect 100.35. ADDED to the amount due, so the sign matters:
+   * a positive figure asks for more than the invoice totals, a negative one for less.
+   */
+  roundingAmount?: number;
 }

--- a/packages/e-invoice/src/invoice.ts
+++ b/packages/e-invoice/src/invoice.ts
@@ -13,7 +13,7 @@
 // Scope: this first model covers every MANDATORY EN16931 term plus the fields a real invoice needs.
 // Deferred (addable later, none block a valid EN16931 invoice): tax representative (BG-11/12),
 // payment card / direct debit (BG-18/BG-19), item attributes (BG-32), item classification (BT-158),
-// preceding-invoice references (BG-3), per-line object/order references.
+// per-line object/order references. (BG-3 preceding invoices landed 2026-09-09.)
 
 /** ISO 8601 calendar date, `"YYYY-MM-DD"` (e.g. BT-2 issue date). */
 export type IsoDate = string;
@@ -108,6 +108,20 @@ export interface ServicePeriod {
   start: IsoDate;
   /** Last day, inclusive (BT-74 / BT-135). */
   end: IsoDate;
+}
+
+/**
+ * The invoice this one refers back to (BG-3) - what makes a credit note or a correction traceable.
+ *
+ * EN 16931 allows several, because one corrective document may settle more than one original. The
+ * date is optional in the standard but is what lets a recipient find the original when the number
+ * alone is ambiguous across years.
+ */
+export interface PrecedingInvoice {
+  /** Number of the earlier invoice (BT-25)  (MANDATORY within the group). */
+  number: string;
+  /** Its issue date (BT-26). */
+  issueDate?: IsoDate;
 }
 
 /** Where the goods/services were delivered (BG-13). Optional; used when it differs from the buyer. */
@@ -258,6 +272,11 @@ export interface Invoice {
   contractRef?: string;
   /** Free-text document notes (BG-1 / BT-22). */
   notes?: string[];
+  /**
+   * The invoice(s) this one corrects, credits or supplements (BG-3). Set it on every credit note
+   * (`type: 381`) - without it the recipient cannot match the correction to its original.
+   */
+  precedingInvoices?: PrecedingInvoice[];
 
   seller: Seller; // BG-4  (MANDATORY)
   buyer: Buyer; // BG-7  (MANDATORY)

--- a/packages/e-invoice/src/invoice.ts
+++ b/packages/e-invoice/src/invoice.ts
@@ -170,6 +170,25 @@ export interface InvoiceLine {
   note?: string; // BT-127
 }
 
+/**
+ * An early-payment discount - Skonto (BT-20).
+ *
+ * Deliberately NOT an `AllowanceCharge`: the standard has no business term for Skonto, because a
+ * discount conditional on early payment must not reduce the invoice total. It is carried in the
+ * payment terms in the structured form XRechnung prescribes; see `skonto.ts`.
+ */
+export interface CashDiscount {
+  /** Days from the issue date within which paying earns the discount, e.g. `14`. */
+  days: number;
+  /** The discount in percent, e.g. `2` for 2 %. */
+  percent: number;
+  /**
+   * The amount the percentage applies to. Defaults to the invoice total including VAT (BT-112),
+   * which is what German practice calculates Skonto on.
+   */
+  baseAmount?: number;
+}
+
 /** How the invoice is to be paid (BG-16 + credit transfer BG-17). */
 export interface Payment {
   /** Payment means code (UNCL 4461), e.g. `58` SEPA credit transfer, `30` credit transfer (BT-81). */
@@ -186,6 +205,11 @@ export interface Payment {
   bic?: string;
   /** Free-text payment terms, e.g. "Zahlbar innerhalb 14 Tagen netto" (BT-20). */
   terms?: string;
+  /**
+   * Early-payment discounts (Skonto), one entry per tier - "2 % within 14 days, 1 % within 30".
+   * Written into BT-20 beneath `terms` in the machine-readable form, and printed on the PDF.
+   */
+  cashDiscounts?: CashDiscount[];
 }
 
 /** The complete invoice - the single input to `renderZugferd(invoice, …)`. */

--- a/packages/e-invoice/src/profile-check.ts
+++ b/packages/e-invoice/src/profile-check.ts
@@ -1,5 +1,6 @@
 import { Invoice } from "./invoice.ts";
 import { computeInvoice } from "./compute.ts";
+import { acDerivedAmount } from "./allowance.ts";
 
 // A friendly pre-flight for the XRechnung (German B2G) profile: it lists, in plain language, the
 // fields XRechnung makes mandatory on top of EN16931 - so the user gets actionable guidance BEFORE
@@ -80,6 +81,30 @@ export function en16931Problems(invoice: Invoice): string[] {
       problems.push(
         `invoice.allowancesCharges[${i}] looks like Skonto ("${ac.reason}"). An early-payment discount is not an allowance - it would be deducted immediately although it is only due on early payment. Use invoice.payment.cashDiscounts instead (BT-20).`,
       );
+    }
+  }
+
+  // An allowance may state BOTH a fixed amount and a base-with-percentage. When the two disagree the
+  // amount wins (it is what the totals use), so silence here would print one number and bill another.
+  const everyAC = [
+    ...(invoice.allowancesCharges ?? []).map(
+      (ac, i) => [`invoice.allowancesCharges[${i}]`, ac] as const,
+    ),
+    ...invoice.lines.flatMap((line, li) =>
+      (line.allowancesCharges ?? []).map(
+        (ac, i) => [`invoice.lines[${li}].allowancesCharges[${i}]`, ac] as const,
+      ),
+    ),
+  ];
+  for (const [where, ac] of everyAC) {
+    const derived = acDerivedAmount(ac);
+    if (derived !== null && ac.amount !== undefined && Math.abs(derived - ac.amount) > 0.005) {
+      problems.push(
+        `${where}: amount is ${ac.amount}, but ${ac.percent}% of ${ac.baseAmount} is ${derived}. The amount is what gets billed - drop it to have it derived, or correct one of the two.`,
+      );
+    }
+    if (ac.percent !== undefined && (ac.percent <= 0 || ac.percent > 100)) {
+      problems.push(`${where}.percent must be greater than 0 and at most 100, got ${ac.percent}.`);
     }
   }
 

--- a/packages/e-invoice/src/profile-check.ts
+++ b/packages/e-invoice/src/profile-check.ts
@@ -1,6 +1,7 @@
 import { Invoice } from "./invoice.ts";
 import { computeInvoice } from "./compute.ts";
 import { acDerivedAmount } from "./allowance.ts";
+import { supportingDocumentProblems } from "./attachment.ts";
 
 // A friendly pre-flight for the XRechnung (German B2G) profile: it lists, in plain language, the
 // fields XRechnung makes mandatory on top of EN16931 - so the user gets actionable guidance BEFORE
@@ -71,6 +72,10 @@ export function en16931Problems(invoice: Invoice): string[] {
       );
     }
   }
+
+  problems.push(
+    ...supportingDocumentProblems(invoice.supportingDocuments, "invoice.supportingDocuments"),
+  );
 
   // NOT a standard rule - the trap that exists because Skonto had no field until 2026-09-09. Entered
   // as an allowance it deducts immediately, although it is only due on early payment: schema-valid,

--- a/packages/e-invoice/src/profile-check.ts
+++ b/packages/e-invoice/src/profile-check.ts
@@ -162,10 +162,18 @@ export function xrechnungProblems(invoice: Invoice): string[] {
   require(invoice.dueDate ||
     payment?.terms, "XRechnung needs a due date or payment terms - set invoice.dueDate (BT-9) or invoice.payment.terms (BT-20).");
 
-  // A credit transfer (the default / codes 30, 58, 59) must carry an IBAN.
-  const creditTransfer = !payment?.meansCode || ["30", "58", "59"].includes(payment.meansCode);
+  // A credit transfer (the default, or codes 30 / 58) must carry an IBAN. 59 used to be in this
+  // list and is NOT a credit transfer - UNCL 4461 has 58 = SEPA credit transfer, 59 = SEPA DIRECT
+  // DEBIT - so a direct-debit invoice was being told to supply the payee IBAN it does not need.
+  const creditTransfer = !payment?.meansCode || ["30", "58"].includes(payment.meansCode);
   require(!creditTransfer ||
     payment?.iban, "XRechnung credit transfer needs an IBAN - set invoice.payment.iban (BT-84).");
+
+  // ... and its mirror image: a collection without a mandate reference cannot be checked by the payer.
+  const directDebit = ["49", "59"].includes(payment?.meansCode ?? "");
+  require(!directDebit ||
+    payment?.directDebit
+      ?.mandateReference, "A SEPA direct debit needs a mandate reference - set invoice.payment.directDebit.mandateReference (BT-89).");
 
   // A period that runs backwards is silently accepted by the schema and read as nonsense downstream,
   // so it is worth catching here where the message can name the field.

--- a/packages/e-invoice/src/profile-check.ts
+++ b/packages/e-invoice/src/profile-check.ts
@@ -7,7 +7,11 @@ import { computeInvoice } from "./compute.ts";
 // This is a helper, not the authority: the official validator (KoSIT / veraPDF) stays the final gate.
 
 /**
- * Problems that would make ANY profile fail, so they are checked whatever the user asked for.
+ * Problems the user must see whatever profile they asked for.
+ *
+ * Two kinds, deliberately in one list: things a validator would REJECT, and one thing a validator
+ * would ACCEPT although the document is false. A rejected invoice costs an afternoon; a false one
+ * that passes every gate costs a customer relationship, so both belong in the same pre-flight.
  *
  * The wording of each rule below was read out of the vendored EN 16931 schematron, not recalled:
  * the alternatives it allows are load-bearing. Requiring a VAT id where the standard also accepts a
@@ -67,8 +71,34 @@ export function en16931Problems(invoice: Invoice): string[] {
     }
   }
 
+  // NOT a standard rule - the trap that exists because Skonto had no field until 2026-09-09. Entered
+  // as an allowance it deducts immediately, although it is only due on early payment: schema-valid,
+  // factually wrong, invisible to every validator. Matched on the reason text, which is where a user
+  // says what they meant.
+  for (const [i, ac] of (invoice.allowancesCharges ?? []).entries()) {
+    if (!ac.isCharge && SKONTO_WORDS.test(ac.reason ?? "")) {
+      problems.push(
+        `invoice.allowancesCharges[${i}] looks like Skonto ("${ac.reason}"). An early-payment discount is not an allowance - it would be deducted immediately although it is only due on early payment. Use invoice.payment.cashDiscounts instead (BT-20).`,
+      );
+    }
+  }
+
+  // The discount itself has to be a possible one, or the structured BT-20 line is nonsense.
+  for (const [i, d] of (invoice.payment?.cashDiscounts ?? []).entries()) {
+    const where = `invoice.payment.cashDiscounts[${i}]`;
+    if (!(d.percent > 0 && d.percent < 100)) {
+      problems.push(`${where}.percent must be greater than 0 and less than 100, got ${d.percent}.`);
+    }
+    if (!Number.isInteger(d.days) || d.days < 0) {
+      problems.push(`${where}.days must be a whole number of days, got ${d.days}.`);
+    }
+  }
+
   return problems;
 }
+
+/** Words that mean "early-payment discount" in the languages this template speaks. */
+const SKONTO_WORDS = /\bskonto\b|\bescompte\b|early[- ]payment discount|cash discount/i;
 
 /** The VAT categories EN 16931 requires an exemption reason for. `S` and `Z` are taxed, so not those. */
 const NEEDS_EXEMPTION_REASON = ["E", "AE", "K", "G", "O"] as const;

--- a/packages/e-invoice/src/profile-check.ts
+++ b/packages/e-invoice/src/profile-check.ts
@@ -77,6 +77,19 @@ export function en16931Problems(invoice: Invoice): string[] {
     ...supportingDocumentProblems(invoice.supportingDocuments, "invoice.supportingDocuments"),
   );
 
+  // BR-53: naming a VAT accounting currency without the amount in it states a currency and no
+  // figure, which is worse than saying nothing.
+  if (invoice.taxCurrency && invoice.taxTotalInTaxCurrency === undefined) {
+    problems.push(
+      `invoice.taxCurrency is ${invoice.taxCurrency} (BT-6) but invoice.taxTotalInTaxCurrency (BT-111) is missing - the VAT total has to be stated in that currency.`,
+    );
+  }
+  if (invoice.taxTotalInTaxCurrency !== undefined && !invoice.taxCurrency) {
+    problems.push(
+      "invoice.taxTotalInTaxCurrency (BT-111) is set but invoice.taxCurrency (BT-6) is not - an amount without its currency cannot be read.",
+    );
+  }
+
   // NOT a standard rule - the trap that exists because Skonto had no field until 2026-09-09. Entered
   // as an allowance it deducts immediately, although it is only due on early payment: schema-valid,
   // factually wrong, invisible to every validator. Matched on the reason text, which is where a user
@@ -143,6 +156,12 @@ export function xrechnungProblems(invoice: Invoice): string[] {
   problems.push(...en16931Problems(invoice));
 
   require(invoice.buyerReference, "XRechnung needs the Leitweg-ID - set invoice.buyerReference (BT-10).");
+
+  // A German seller invoicing in a foreign currency still owes the tax authority a Euro figure.
+  // Nothing in the schema forces it, so without this the invoice goes out silently deficient -
+  // the same shape of trap as Skonto entered as an allowance.
+  require(invoice.currency === "EUR" ||
+    invoice.taxCurrency, `The invoice is in ${invoice.currency}, so the VAT total is also owed in EUR - set invoice.taxCurrency (BT-6) and invoice.taxTotalInTaxCurrency (BT-111).`);
 
   require(seller.electronicAddress, "XRechnung needs the seller's electronic address - set invoice.seller.electronicAddress (BT-34).");
   require(buyer.electronicAddress, "XRechnung needs the buyer's electronic address - set invoice.buyer.electronicAddress (BT-49).");

--- a/packages/e-invoice/src/render.ts
+++ b/packages/e-invoice/src/render.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import { pdfAttachments } from "./attachment.ts";
 import * as path from "path";
 import { fileURLToPath } from "node:url";
 import { type PDFDocumentElement, renderToBytes } from "@jasy/pdf";
@@ -93,6 +94,9 @@ export async function renderZugferd(
         relationship: "Data",
         mimeType: "text/xml",
       },
+      // BG-24 files ride along as PDF/A-3 attachments too - inside the XML a machine finds them, here
+      // a person does. "Supplement", not "Data": only the invoice XML is the invoice.
+      ...pdfAttachments(invoice.supportingDocuments),
     ],
     xmp: facturxXmp({
       title: `Invoice ${invoice.number}`,

--- a/packages/e-invoice/src/skonto.ts
+++ b/packages/e-invoice/src/skonto.ts
@@ -1,0 +1,91 @@
+import { CashDiscount, IsoDate } from "./invoice.ts";
+
+// Skonto (early-payment discount) - the ONE place it is turned into numbers and into text.
+//
+// It is NOT an allowance. EN 16931 has no business term for it: a discount that only applies if the
+// buyer pays early cannot reduce the invoice total, because at the time of issue nobody knows whether
+// it will be taken. So it belongs in the payment terms, BT-20, and XRechnung fixes the wording so a
+// machine can read it back out of the free text:
+//
+//   #SKONTO#TAGE=14#PROZENT=2.00#
+//   #SKONTO#TAGE=30#PROZENT=1.00#BASISBETRAG=1000.00#
+//
+// One line per tier, appended after any human-readable terms. Modelling Skonto as a document-level
+// allowance instead - the obvious workaround while this was missing - produces a schema-valid but
+// FALSE invoice, because the amount is deducted immediately. `profile-check.ts` looks for that.
+
+/** A discount with its amounts and deadline worked out. */
+export interface ResolvedDiscount {
+  days: number;
+  percent: number;
+  /** The amount the percentage applies to (BASISBETRAG). */
+  baseAmount: number;
+  /** What the buyer saves by paying in time. */
+  discountAmount: number;
+  /** What is left to pay when the discount is taken. */
+  discountedTotal: number;
+  /** Last day the discount applies: issue date + `days`. */
+  deadline: IsoDate;
+}
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+/** `issueDate` plus `days`, in UTC so the result never depends on the machine's zone. */
+function addDays(issueDate: IsoDate, days: number): IsoDate {
+  const ms = Date.parse(`${issueDate}T00:00:00Z`);
+  if (Number.isNaN(ms)) return issueDate;
+  return new Date(ms + days * 86_400_000).toISOString().slice(0, 10);
+}
+
+/**
+ * Work out what each discount is worth. `grossTotal` is BT-112 (the total including VAT) - the base
+ * German practice calculates Skonto on, and the default when a discount names no `baseAmount`.
+ */
+export function resolveDiscounts(
+  discounts: CashDiscount[] | undefined,
+  issueDate: IsoDate,
+  grossTotal: number,
+): ResolvedDiscount[] {
+  return (discounts ?? []).map((d) => {
+    const baseAmount = round2(d.baseAmount ?? grossTotal);
+    const discountAmount = round2((baseAmount * d.percent) / 100);
+    return {
+      days: d.days,
+      percent: d.percent,
+      baseAmount,
+      discountAmount,
+      discountedTotal: round2(baseAmount - discountAmount),
+      deadline: addDays(issueDate, d.days),
+    };
+  });
+}
+
+/** Fixed two decimals with a dot, whatever the locale - this string is read by machines. */
+const decimal2 = (n: number) => n.toFixed(2);
+
+/**
+ * The structured line XRechnung reads Skonto out of. `BASISBETRAG` is written whenever the user gave
+ * one explicitly; left off it defaults to the payable amount on the reader's side too.
+ */
+export function skontoLine(d: ResolvedDiscount, explicitBase: boolean): string {
+  const base = explicitBase ? `BASISBETRAG=${decimal2(d.baseAmount)}#` : "";
+  return `#SKONTO#TAGE=${d.days}#PROZENT=${decimal2(d.percent)}#${base}`;
+}
+
+/**
+ * The complete BT-20 payload: the human terms, then one machine-readable line per discount.
+ *
+ * With no discounts this returns `terms` unchanged - including `undefined` - so an invoice that does
+ * not use Skonto produces byte-identical output to before this existed.
+ */
+export function paymentTermsText(
+  terms: string | undefined,
+  discounts: CashDiscount[] | undefined,
+  issueDate: IsoDate,
+  grossTotal: number,
+): string | undefined {
+  if (!discounts?.length) return terms;
+  const resolved = resolveDiscounts(discounts, issueDate, grossTotal);
+  const lines = resolved.map((d, i) => skontoLine(d, discounts[i]!.baseAmount !== undefined));
+  return [terms, ...lines].filter(Boolean).join("\n");
+}

--- a/packages/e-invoice/src/template.ts
+++ b/packages/e-invoice/src/template.ts
@@ -344,6 +344,12 @@ function totals(
   lines.push(Divider({ color: HAIR, margin: { y: 2 } }));
   lines.push(valueLine(L.grandTotal, fmt.money(c.grandTotal), { strong: true, size: 11 }));
   if (c.paidAmount > 0) lines.push(valueLine(L.alreadyPaid, `-${fmt.money(c.paidAmount)}`));
+  // BT-114. A payable that does not equal the total minus what was paid looks like an arithmetic
+  // error unless the difference is named, so the line is printed with its sign.
+  if (c.roundingAmount !== 0) {
+    const sign = c.roundingAmount > 0 ? "+" : "-";
+    lines.push(valueLine(L.rounding, `${sign}${fmt.money(Math.abs(c.roundingAmount))}`));
+  }
   lines.push(valueLine(L.amountDue, fmt.money(c.duePayable), { strong: true, size: 12 }));
   lines.push(
     Text(`${L.amountsIn} ${fmt.currencyName()} (${invoice.currency})`, {

--- a/packages/e-invoice/src/template.ts
+++ b/packages/e-invoice/src/template.ts
@@ -15,6 +15,7 @@ import {
 import { Delivery, Invoice, PostalAddress, Seller } from "./invoice.ts";
 import { ComputedInvoice, VatBreakdownEntry } from "./compute.ts";
 import { Formatters, InvoiceLabels } from "./i18n.ts";
+import { resolveDiscounts } from "./skonto.ts";
 
 // The built-in invoice layout: a complete, §14-UStG-aware invoice that renders everything the
 // Invoice carries. That is not a promise in prose - `tests/completeness.test.ts` sets EVERY field to
@@ -76,7 +77,7 @@ export function defaultInvoiceTemplate(
         ...notes(invoice),
         lineItemsTable(invoice, c, L, fmt),
         totals(invoice, c, L, fmt, valueLine),
-        paymentPanel(invoice, L, fmt),
+        paymentPanel(invoice, c, L, fmt),
       ],
     ),
   ]);
@@ -378,9 +379,17 @@ function vatLabel(v: VatBreakdownEntry, L: InvoiceLabels, fmt: Formatters): stri
 }
 
 // --- payment terms + bank details + remittance reference ---
-function paymentPanel(invoice: Invoice, L: InvoiceLabels, fmt: Formatters): PDFElement {
+function paymentPanel(
+  invoice: Invoice,
+  c: ComputedInvoice,
+  L: InvoiceLabels,
+  fmt: Formatters,
+): PDFElement {
   const p = invoice.payment;
   const reference = p?.reference ?? invoice.number;
+  // Skonto reaches the XML through BT-20, so it has to reach the paper too - the two halves of a
+  // ZUGFeRD file saying different things is the one defect no validator catches.
+  const discounts = resolveDiscounts(p?.cashDiscounts, invoice.issueDate, c.grandTotal);
   const left: PDFElement[] = [
     Text(L.payment, { size: 10, bold: true, color: INK }),
     ...(invoice.dueDate
@@ -388,6 +397,14 @@ function paymentPanel(invoice: Invoice, L: InvoiceLabels, fmt: Formatters): PDFE
       : []),
     ...(p?.meansText ? [Text(`${L.paymentMeans}  ${p.meansText}`, { size: 9, color: INK })] : []),
     ...(p?.terms ? [Text(p.terms, { size: 9, color: MUTED })] : []),
+    ...discounts.map((d) =>
+      Text(
+        `${L.cashDiscount} ${fmt.percent(d.percent)} ${L.cashDiscountUntil} ${fmt.date(d.deadline)}` +
+          // An arrow, not "saving X - paying Y": two amounts joined by a dash read as a range.
+          `  ${fmt.money(d.baseAmount)} \u2192 ${fmt.money(d.discountedTotal)}`,
+        { size: 9, color: INK },
+      ),
+    ),
   ];
   const right: PDFElement[] = [
     Text(L.bankDetails, { size: 10, bold: true, color: INK }),

--- a/packages/e-invoice/src/template.ts
+++ b/packages/e-invoice/src/template.ts
@@ -118,6 +118,7 @@ function deliverTo(delivery: Delivery | undefined, L: InvoiceLabels): PDFElement
   const lines = [
     delivery?.recipientName,
     ...(delivery?.address ? addressLines(delivery.address) : []),
+    delivery?.locationId ? `${L.deliveryLocation} ${delivery.locationId}` : undefined, // BT-71
   ].filter((s): s is string => Boolean(s));
 
   // ONE element, not loose lines: the page flow has a 16pt gap and would space the address apart.
@@ -187,6 +188,11 @@ function recipientAndMeta(invoice: Invoice, L: InvoiceLabels, fmt: Formatters): 
     [L.dueDate, invoice.dueDate ? fmt.date(invoice.dueDate) : undefined],
     [L.customerReference, invoice.buyerReference],
     [L.orderNumber, invoice.purchaseOrderRef],
+    [L.salesOrderNumber, invoice.salesOrderRef], // BT-14
+    [L.projectReference, invoice.projectRef], // BT-11
+    [L.tenderReference, invoice.tenderRef], // BT-17
+    [L.objectReference, invoice.objectRef], // BT-18
+    [L.accountingReference, invoice.buyerAccountingRef], // BT-19
     [L.contractReference, invoice.contractRef],
     // BG-3 - a credit note whose original is not named on the PAPER is unusable to the person
     // reading it, however well the XML carries it.
@@ -202,6 +208,7 @@ function recipientAndMeta(invoice: Invoice, L: InvoiceLabels, fmt: Formatters): 
     // that block shows through a DIN 5008 window, which may hold nothing but the postal address.
     [L.buyerVatId, buyer.vatId],
     [L.registration, buyer.legalRegistrationId],
+    [L.partyIdentifier, buyer.identifier], // BT-46
     [L.contactPerson, buyer.contact?.name],
     [L.phone, buyer.contact?.phone],
     [L.email, buyer.contact?.email],
@@ -275,6 +282,12 @@ function lineItemsTable(
       ...(linePeriod ? [sub(linePeriod)] : []),
       ...(itemIds ? [sub(`${L.itemNumber} ${itemIds}`)] : []),
       ...(line.note ? [sub(line.note)] : []), // BT-127
+      ...(line.orderLineRef ? [sub(`${L.orderLine} ${line.orderLineRef}`)] : []), // BT-132
+      ...(line.objectRef ? [sub(`${L.objectReference} ${line.objectRef}`)] : []), // BT-128
+      ...(line.buyerAccountingRef
+        ? [sub(`${L.accountingReference} ${line.buyerAccountingRef}`)]
+        : []), // BT-133
+      ...(line.originCountry ? [sub(`${L.originCountry} ${line.originCountry}`)] : []), // BT-159
       ...lineAdjustments.map(sub),
     ]);
     return [
@@ -480,6 +493,17 @@ function paymentPanel(
     ...(invoice.payeeName
       ? [Text(`${L.payee}  ${invoice.payeeName}`, { size: 9, color: INK })]
       : []),
+    ...(invoice.payeeIdentifier
+      ? [Text(`${L.partyIdentifier}  ${invoice.payeeIdentifier}`, { size: 9, color: MUTED })]
+      : []), // BT-60
+    ...(invoice.payeeLegalRegistrationId
+      ? [
+          Text(`${L.registration}  ${invoice.payeeLegalRegistrationId}`, {
+            size: 9,
+            color: MUTED,
+          }),
+        ]
+      : []), // BT-61
     ...(p?.accountName ? [Text(p.accountName, { size: 9, color: INK })] : []),
     ...(p?.iban ? [Text(`IBAN  ${p.iban}`, { size: 9, color: INK })] : []),
     ...(p?.bic ? [Text(`BIC  ${p.bic}`, { size: 9, color: INK })] : []),
@@ -520,6 +544,7 @@ function legalFooter(invoice: Invoice, L: InvoiceLabels): PDFElement {
       col([seller.name, ...addressLines(seller.address)]),
       col([
         seller.vatId && `${L.vatId} ${seller.vatId}`,
+        seller.identifier && `${L.partyIdentifier} ${seller.identifier}`, // BT-29
         seller.taxNumber && `${L.taxNumber} ${seller.taxNumber}`,
         seller.legalRegistrationId && `${L.registration} ${seller.legalRegistrationId}`,
         seller.additionalLegalInfo,

--- a/packages/e-invoice/src/template.ts
+++ b/packages/e-invoice/src/template.ts
@@ -76,6 +76,7 @@ export function defaultInvoiceTemplate(
         Text(documentTitle(invoice, L), { size: 21, bold: true, color: INK }),
         ...deliverTo(invoice.delivery, L),
         ...notes(invoice),
+        ...attachments(invoice, L),
         lineItemsTable(invoice, c, L, fmt),
         totals(invoice, c, L, fmt, valueLine),
         paymentPanel(invoice, c, L, fmt),
@@ -220,6 +221,22 @@ function recipientAndMeta(invoice: Invoice, L: InvoiceLabels, fmt: Formatters): 
 function notes(invoice: Invoice): PDFElement[] {
   if (!invoice.notes?.length) return [];
   return invoice.notes.map((n) => Text(n, { size: 10, color: INK }));
+}
+
+/**
+ * BG-24 on the paper. An attachment nobody is told about is an attachment nobody opens - the file
+ * sits in the PDF, but only a reader who thinks to look at the attachment pane would find it.
+ */
+function attachments(invoice: Invoice, L: InvoiceLabels): PDFElement[] {
+  const docs = invoice.supportingDocuments ?? [];
+  if (!docs.length) return [];
+  const line = docs
+    .map((d) => {
+      const what = d.description ? `${d.description} (${d.reference})` : d.reference;
+      return d.file ? `${what} - ${d.file.filename}` : d.url ? `${what} - ${d.url}` : what;
+    })
+    .join(" · ");
+  return [Text(`${L.attachments}: ${line}`, { size: 9, color: MUTED })];
 }
 
 // --- line items: No | Description | Qty | Unit price | VAT | Amount ---

--- a/packages/e-invoice/src/template.ts
+++ b/packages/e-invoice/src/template.ts
@@ -364,6 +364,16 @@ function totals(
     lines.push(valueLine(L.rounding, `${sign}${fmt.money(Math.abs(c.roundingAmount))}`));
   }
   lines.push(valueLine(L.amountDue, fmt.money(c.duePayable), { strong: true, size: 12 }));
+  // BT-111. The whole reason the field exists is that a tax office wants this figure on the
+  // PAPER, so an XML-only implementation would miss the point of it.
+  if (invoice.taxCurrency && invoice.taxTotalInTaxCurrency !== undefined) {
+    lines.push(
+      valueLine(
+        `${L.vatIn} ${invoice.taxCurrency}`,
+        fmt.moneyIn(invoice.taxTotalInTaxCurrency, invoice.taxCurrency),
+      ),
+    );
+  }
   lines.push(
     Text(`${L.amountsIn} ${fmt.currencyName()} (${invoice.currency})`, {
       size: 7.5,

--- a/packages/e-invoice/src/template.ts
+++ b/packages/e-invoice/src/template.ts
@@ -187,6 +187,16 @@ function recipientAndMeta(invoice: Invoice, L: InvoiceLabels, fmt: Formatters): 
     [L.customerReference, invoice.buyerReference],
     [L.orderNumber, invoice.purchaseOrderRef],
     [L.contractReference, invoice.contractRef],
+    // BG-3 - a credit note whose original is not named on the PAPER is unusable to the person
+    // reading it, however well the XML carries it.
+    [
+      L.precedingInvoice,
+      invoice.precedingInvoices?.length
+        ? invoice.precedingInvoices
+            .map((r) => (r.issueDate ? `${r.number} (${fmt.date(r.issueDate)})` : r.number))
+            .join(", ")
+        : undefined,
+    ],
     // BT-48 belongs on the paper (§14a Abs. 1 UStG for reverse charge), but NOT under the address:
     // that block shows through a DIN 5008 window, which may hold nothing but the postal address.
     [L.buyerVatId, buyer.vatId],

--- a/packages/e-invoice/src/template.ts
+++ b/packages/e-invoice/src/template.ts
@@ -12,10 +12,11 @@ import {
   Table,
   Text,
 } from "@jasy/pdf";
-import { Delivery, Invoice, PostalAddress, Seller } from "./invoice.ts";
+import { AllowanceCharge, Delivery, Invoice, PostalAddress, Seller } from "./invoice.ts";
 import { ComputedInvoice, VatBreakdownEntry } from "./compute.ts";
 import { Formatters, InvoiceLabels } from "./i18n.ts";
 import { resolveDiscounts } from "./skonto.ts";
+import { acAmount, hasPercentage } from "./allowance.ts";
 
 // The built-in invoice layout: a complete, §14-UStG-aware invoice that renders everything the
 // Invoice carries. That is not a promise in prose - `tests/completeness.test.ts` sets EVERY field to
@@ -229,7 +230,7 @@ function lineItemsTable(
     // BT-97/BT-104: a discount has to say WHY. §14 Abs. 4 Nr. 7 wants an agreed reduction named.
     const lineAdjustments = (line.allowancesCharges ?? []).map(
       (ac) =>
-        `${ac.reason ?? (ac.isCharge ? L.charge : L.allowance)}  ${ac.isCharge ? "" : "-"}${fmt.money(ac.amount)}`,
+        `${ac.reason ?? (ac.isCharge ? L.charge : L.allowance)}${acPercentSuffix(ac, L, fmt)}  ${ac.isCharge ? "" : "-"}${fmt.money(acAmount(ac))}`,
     );
     const sub = (t: string) => Text(t, { size: 8, color: MUTED });
 
@@ -298,8 +299,8 @@ function totals(
     for (const ac of invoice.allowancesCharges ?? []) {
       lines.push(
         valueLine(
-          ac.reason ?? (ac.isCharge ? L.charge : L.allowance),
-          `${ac.isCharge ? "" : "-"}${fmt.money(ac.amount)}`,
+          `${ac.reason ?? (ac.isCharge ? L.charge : L.allowance)}${acPercentSuffix(ac, L, fmt)}`,
+          `${ac.isCharge ? "" : "-"}${fmt.money(acAmount(ac))}`,
         ),
       );
     }
@@ -376,6 +377,19 @@ function hasVatBreakdown(c: ComputedInvoice): boolean {
 function vatLabel(v: VatBreakdownEntry, L: InvoiceLabels, fmt: Formatters): string {
   if (v.category === "S") return `${L.plusVat} ${fmt.percent(v.ratePercent)}`;
   return `${L.vat} ${fmt.percent(v.ratePercent)} (${v.category})`;
+}
+
+/**
+ * " (10 % of 1.200,00 EUR)" when the allowance was stated as a rate, "" otherwise.
+ *
+ * The percentage reaches the XML (BT-94), so it has to reach the paper: a reader who sees only
+ * "-120,00" cannot tell what it was 10 % of, and the two halves of the file would say different
+ * things - the one defect no validator looks for.
+ */
+function acPercentSuffix(ac: AllowanceCharge, L: InvoiceLabels, fmt: Formatters): string {
+  return hasPercentage(ac)
+    ? ` (${fmt.percent(ac.percent)} ${L.percentOf} ${fmt.money(ac.baseAmount)})`
+    : "";
 }
 
 // --- payment terms + bank details + remittance reference ---

--- a/packages/e-invoice/src/template.ts
+++ b/packages/e-invoice/src/template.ts
@@ -437,6 +437,28 @@ function paymentPanel(
       ? [Text(`${L.payableBy} ${fmt.date(invoice.dueDate)}`, { size: 9, color: INK })]
       : []),
     ...(p?.meansText ? [Text(`${L.paymentMeans}  ${p.meansText}`, { size: 9, color: INK })] : []),
+    // BG-19. A collection nobody was told about looks like an unauthorised debit on a statement,
+    // so the mandate and the creditor id belong on the paper, not only in the XML.
+    ...(p?.directDebit
+      ? [
+          Text(L.directDebit, { size: 9, bold: true, color: INK }),
+          Text(`${L.mandateReference}  ${p.directDebit.mandateReference}`, {
+            size: 9,
+            color: INK,
+          }),
+          ...(p.directDebit.creditorId
+            ? [Text(`${L.creditorId}  ${p.directDebit.creditorId}`, { size: 9, color: INK })]
+            : []),
+          ...(p.directDebit.debitedIban
+            ? [
+                Text(`${L.debitedAccount}  ${p.directDebit.debitedIban}`, {
+                  size: 9,
+                  color: INK,
+                }),
+              ]
+            : []),
+        ]
+      : []),
     ...(p?.terms ? [Text(p.terms, { size: 9, color: MUTED })] : []),
     ...discounts.map((d) =>
       Text(

--- a/packages/e-invoice/src/ubl.ts
+++ b/packages/e-invoice/src/ubl.ts
@@ -85,10 +85,15 @@ function contact(c: { name?: string; phone?: string; email?: string } | undefine
   ]);
 }
 
-function sellerParty(s: Seller): string {
+/** `creditorId` is BT-90: UBL puts it on the party, not on the payment means. */
+function sellerParty(s: Seller, creditorId?: string): string {
   return wrap("cac:AccountingSupplierParty", [
     wrap("cac:Party", [
       s.electronicAddress ? el("cbc:EndpointID", s.electronicAddress, { schemeID: "EM" }) : "", // BT-34
+      // BT-90, the creditor identifier. UBL hangs it on the SELLER party, not on the payment.
+      creditorId
+        ? wrap("cac:PartyIdentification", [el("cbc:ID", creditorId, { schemeID: "SEPA" })])
+        : "",
       s.tradingName ? wrap("cac:PartyName", [el("cbc:Name", s.tradingName)]) : "", // BT-28
       address(s.address),
       s.vatId
@@ -313,6 +318,16 @@ export function toUBL(
                 p.bic ? wrap("cac:FinancialInstitutionBranch", [el("cbc:ID", p.bic)]) : "", // BT-86
               ])
             : "",
+          // BG-19. UBL keeps the mandate together; CII scatters the same three fields over three
+          // different blocks, which is why they are read from one object rather than three.
+          p.directDebit
+            ? wrap("cac:PaymentMandate", [
+                el("cbc:ID", p.directDebit.mandateReference), // BT-89
+                p.directDebit.debitedIban
+                  ? wrap("cac:PayerFinancialAccount", [el("cbc:ID", p.directDebit.debitedIban)]) // BT-91
+                  : "",
+              ])
+            : "",
         ])
       : "";
 
@@ -351,7 +366,7 @@ export function toUBL(
     `<?xml version="1.0" encoding="UTF-8"?>\n` +
     `<Invoice xmlns="${NS.inv}" xmlns:cac="${NS.cac}" xmlns:cbc="${NS.cbc}">` +
     head.filter(Boolean).join("") +
-    sellerParty(invoice.seller) +
+    sellerParty(invoice.seller, invoice.payment?.directDebit?.creditorId) +
     buyerParty(invoice.buyer) +
     payee +
     delivery +

--- a/packages/e-invoice/src/ubl.ts
+++ b/packages/e-invoice/src/ubl.ts
@@ -9,6 +9,7 @@ import {
 } from "./invoice.ts";
 import { ComputedInvoice, VatBreakdownEntry } from "./compute.ts";
 import { BUSINESS_PROCESS, CiiProfile, GUIDELINE } from "./cii.ts";
+import { paymentTermsText } from "./skonto.ts";
 
 // Emits the OASIS UBL Invoice XML for the EN16931 profile - the SECOND permitted syntax (PEPPOL is
 // UBL, and XRechnung accepts it too). Same semantic model (BT/BG) + pre-computed totals as the CII
@@ -276,7 +277,14 @@ export function toUBL(
         ])
       : "";
 
-  const paymentTerms = p?.terms ? wrap("cac:PaymentTerms", [el("cbc:Note", p.terms)]) : ""; // BT-20
+  // BT-20 - the same text the CII gets, from the same function, or the two syntaxes would disagree.
+  const termsText = paymentTermsText(
+    p?.terms,
+    p?.cashDiscounts,
+    invoice.issueDate,
+    computed.grandTotal,
+  );
+  const paymentTerms = termsText ? wrap("cac:PaymentTerms", [el("cbc:Note", termsText)]) : "";
 
   const taxTotal = wrap("cac:TaxTotal", [
     money("cbc:TaxAmount", computed.taxTotal, cur), // BT-110

--- a/packages/e-invoice/src/ubl.ts
+++ b/packages/e-invoice/src/ubl.ts
@@ -11,7 +11,8 @@ import { ComputedInvoice, VatBreakdownEntry } from "./compute.ts";
 import { BUSINESS_PROCESS, CiiProfile, GUIDELINE } from "./cii.ts";
 import { paymentTermsText } from "./skonto.ts";
 import { acAmount, hasPercentage } from "./allowance.ts";
-import { PrecedingInvoice } from "./invoice.ts";
+import { PrecedingInvoice, SupportingDocument } from "./invoice.ts";
+import { toBase64 } from "./attachment.ts";
 
 // Emits the OASIS UBL Invoice XML for the EN16931 profile - the SECOND permitted syntax (PEPPOL is
 // UBL, and XRechnung accepts it too). Same semantic model (BT/BG) + pre-computed totals as the CII
@@ -184,6 +185,24 @@ function taxSubtotal(g: VatBreakdownEntry, currency: string): string {
   ]);
 }
 
+/**
+ * BG-24: an extra document. UBL nests the payload one level deeper than CII - the binary and the
+ * external link both live inside `cac:Attachment`, and the link is itself wrapped again.
+ */
+function supportingDocument(doc: SupportingDocument): string {
+  const binary = doc.file
+    ? `<cbc:EmbeddedDocumentBinaryObject mimeCode="${escAttr(doc.file.mimeType)}" filename="${escAttr(doc.file.filename)}">${toBase64(doc.file.content)}</cbc:EmbeddedDocumentBinaryObject>`
+    : "";
+  return wrap("cac:AdditionalDocumentReference", [
+    el("cbc:ID", doc.reference), // BT-122
+    el("cbc:DocumentDescription", doc.description), // BT-123
+    wrap("cac:Attachment", [
+      binary, // BT-125
+      doc.url ? wrap("cac:ExternalReference", [el("cbc:URI", doc.url)]) : "", // BT-124
+    ]),
+  ]);
+}
+
 /** BG-3: the invoice being corrected or credited. */
 function billingReference(ref: PrecedingInvoice): string {
   return wrap("cac:BillingReference", [
@@ -261,6 +280,7 @@ export function toUBL(
     invoice.contractRef
       ? wrap("cac:ContractDocumentReference", [el("cbc:ID", invoice.contractRef)]) // BT-12
       : "",
+    ...(invoice.supportingDocuments ?? []).map(supportingDocument), // BG-24
   ];
 
   const d = invoice.delivery;

--- a/packages/e-invoice/src/ubl.ts
+++ b/packages/e-invoice/src/ubl.ts
@@ -11,6 +11,7 @@ import { ComputedInvoice, VatBreakdownEntry } from "./compute.ts";
 import { BUSINESS_PROCESS, CiiProfile, GUIDELINE } from "./cii.ts";
 import { paymentTermsText } from "./skonto.ts";
 import { acAmount, hasPercentage } from "./allowance.ts";
+import { PrecedingInvoice } from "./invoice.ts";
 
 // Emits the OASIS UBL Invoice XML for the EN16931 profile - the SECOND permitted syntax (PEPPOL is
 // UBL, and XRechnung accepts it too). Same semantic model (BT/BG) + pre-computed totals as the CII
@@ -183,6 +184,16 @@ function taxSubtotal(g: VatBreakdownEntry, currency: string): string {
   ]);
 }
 
+/** BG-3: the invoice being corrected or credited. */
+function billingReference(ref: PrecedingInvoice): string {
+  return wrap("cac:BillingReference", [
+    wrap("cac:InvoiceDocumentReference", [
+      el("cbc:ID", ref.number), // BT-25
+      el("cbc:IssueDate", ref.issueDate), // BT-26
+    ]),
+  ]);
+}
+
 /** The service period (BG-14 on the document, BG-26 on a line) - UBL's `cac:InvoicePeriod`. */
 function invoicePeriod(p?: ServicePeriod): string {
   return p
@@ -245,6 +256,8 @@ export function toUBL(
     invoice.purchaseOrderRef
       ? wrap("cac:OrderReference", [el("cbc:ID", invoice.purchaseOrderRef)])
       : "", // BT-13
+    // BillingReference sits between the order and the contract reference in the InvoiceType sequence.
+    ...(invoice.precedingInvoices ?? []).map(billingReference), // BG-3
     invoice.contractRef
       ? wrap("cac:ContractDocumentReference", [el("cbc:ID", invoice.contractRef)]) // BT-12
       : "",

--- a/packages/e-invoice/src/ubl.ts
+++ b/packages/e-invoice/src/ubl.ts
@@ -90,6 +90,7 @@ function sellerParty(s: Seller, creditorId?: string): string {
   return wrap("cac:AccountingSupplierParty", [
     wrap("cac:Party", [
       s.electronicAddress ? el("cbc:EndpointID", s.electronicAddress, { schemeID: "EM" }) : "", // BT-34
+      s.identifier ? wrap("cac:PartyIdentification", [el("cbc:ID", s.identifier)]) : "", // BT-29
       // BT-90, the creditor identifier. UBL hangs it on the SELLER party, not on the payment.
       creditorId
         ? wrap("cac:PartyIdentification", [el("cbc:ID", creditorId, { schemeID: "SEPA" })])
@@ -122,6 +123,7 @@ function buyerParty(b: Buyer): string {
   return wrap("cac:AccountingCustomerParty", [
     wrap("cac:Party", [
       b.electronicAddress ? el("cbc:EndpointID", b.electronicAddress, { schemeID: "EM" }) : "", // BT-49
+      b.identifier ? wrap("cac:PartyIdentification", [el("cbc:ID", b.identifier)]) : "", // BT-46
       b.tradingName ? wrap("cac:PartyName", [el("cbc:Name", b.tradingName)]) : "", // BT-45
       address(b.address),
       b.vatId
@@ -234,7 +236,12 @@ function invoiceLine(l: InvoiceLine, net: number, index: number, currency: strin
     l.note ? el("cbc:Note", l.note) : "", // BT-127
     el("cbc:InvoicedQuantity", l.quantity, { unitCode: l.unit }), // BT-129 / BT-130
     money("cbc:LineExtensionAmount", net, currency), // BT-131
+    el("cbc:AccountingCost", l.buyerAccountingRef), // BT-133
     invoicePeriod(l.period), // BG-26
+    l.orderLineRef
+      ? wrap("cac:OrderLineReference", [el("cbc:LineID", l.orderLineRef)]) // BT-132
+      : "",
+    l.objectRef ? wrap("cac:DocumentReference", [el("cbc:ID", l.objectRef)]) : "", // BT-128
     ...(l.allowancesCharges ?? []).map((ac) => lineAllowanceCharge(ac, currency)), // BG-27 / BG-28
     wrap("cac:Item", [
       el("cbc:Description", l.description), // BT-154
@@ -246,6 +253,9 @@ function invoiceLine(l: InvoiceLine, net: number, index: number, currency: strin
         ? wrap("cac:StandardItemIdentification", [
             el("cbc:ID", l.standardItemId, { schemeID: "0160" }),
           ]) // BT-157
+        : "",
+      l.originCountry
+        ? wrap("cac:OriginCountry", [el("cbc:IdentificationCode", l.originCountry)]) // BT-159
         : "",
       taxCategory("cac:ClassifiedTaxCategory", l.vat.category, l.vat.ratePercent ?? 0), // BG-30
     ]),
@@ -273,28 +283,52 @@ export function toUBL(
     el("cbc:IssueDate", invoice.issueDate), // BT-2
     el("cbc:DueDate", invoice.dueDate), // BT-9
     el("cbc:InvoiceTypeCode", invoice.type ?? 380), // BT-3
-    ...(invoice.notes ?? []).map((n) => el("cbc:Note", n)), // BT-22
+    // BT-21 has no element of its own in UBL. The EN 16931 binding prefixes the note with the
+    // subject code in the form #CODE#, which is why this is string surgery and not a field.
+    ...(invoice.notes ?? []).map((n) =>
+      el("cbc:Note", invoice.noteSubjectCode ? `#${invoice.noteSubjectCode}#${n}` : n),
+    ), // BT-22 (+ BT-21)
     el("cbc:DocumentCurrencyCode", cur), // BT-5
+    el("cbc:AccountingCost", invoice.buyerAccountingRef), // BT-19 - BEFORE the buyer reference
     el("cbc:BuyerReference", invoice.buyerReference), // BT-10 (Leitweg-ID)
     invoicePeriod(invoice.period), // BG-14
-    invoice.purchaseOrderRef
-      ? wrap("cac:OrderReference", [el("cbc:ID", invoice.purchaseOrderRef)])
-      : "", // BT-13
+    invoice.purchaseOrderRef || invoice.salesOrderRef
+      ? wrap("cac:OrderReference", [
+          el("cbc:ID", invoice.purchaseOrderRef), // BT-13
+          el("cbc:SalesOrderID", invoice.salesOrderRef), // BT-14
+        ])
+      : "",
     // BillingReference sits between the order and the contract reference in the InvoiceType sequence.
     ...(invoice.precedingInvoices ?? []).map(billingReference), // BG-3
+    invoice.tenderRef
+      ? wrap("cac:OriginatorDocumentReference", [el("cbc:ID", invoice.tenderRef)]) // BT-17
+      : "",
     invoice.contractRef
       ? wrap("cac:ContractDocumentReference", [el("cbc:ID", invoice.contractRef)]) // BT-12
       : "",
     ...(invoice.supportingDocuments ?? []).map(supportingDocument), // BG-24
+    // BT-18 shares the element with BG-24 and is told apart by its document type code.
+    invoice.objectRef
+      ? wrap("cac:AdditionalDocumentReference", [
+          el("cbc:ID", invoice.objectRef),
+          el("cbc:DocumentTypeCode", "130"),
+        ])
+      : "",
+    invoice.projectRef ? wrap("cac:ProjectReference", [el("cbc:ID", invoice.projectRef)]) : "", // BT-11
   ];
 
   const d = invoice.delivery;
   const delivery =
-    d?.date || d?.recipientName || d?.address
+    d?.date || d?.recipientName || d?.address || d?.locationId
       ? wrap("cac:Delivery", [
           el("cbc:ActualDeliveryDate", d?.date), // BT-72
           // A LocationType holds cac:Address - `cac:PostalAddress` belongs to a Party, not here.
-          d?.address ? wrap("cac:DeliveryLocation", [wrapAddress("cac:Address", d.address)]) : "", // BG-15
+          d?.address || d?.locationId
+            ? wrap("cac:DeliveryLocation", [
+                el("cbc:ID", d?.locationId), // BT-71
+                d?.address ? wrapAddress("cac:Address", d.address) : "", // BG-15
+              ])
+            : "",
           d?.recipientName
             ? wrap("cac:DeliveryParty", [wrap("cac:PartyName", [el("cbc:Name", d.recipientName)])])
             : "", // BT-70
@@ -358,9 +392,18 @@ export function toUBL(
     money("cbc:PayableAmount", computed.duePayable, cur), // BT-115
   ]);
 
-  const payee = invoice.payeeName // BT-59 / BG-10
-    ? wrap("cac:PayeeParty", [wrap("cac:PartyName", [el("cbc:Name", invoice.payeeName)])])
-    : "";
+  const payee =
+    invoice.payeeName || invoice.payeeIdentifier // BG-10
+      ? wrap("cac:PayeeParty", [
+          invoice.payeeIdentifier
+            ? wrap("cac:PartyIdentification", [el("cbc:ID", invoice.payeeIdentifier)]) // BT-60
+            : "",
+          invoice.payeeName ? wrap("cac:PartyName", [el("cbc:Name", invoice.payeeName)]) : "", // BT-59
+          invoice.payeeLegalRegistrationId
+            ? wrap("cac:PartyLegalEntity", [el("cbc:CompanyID", invoice.payeeLegalRegistrationId)]) // BT-61
+            : "",
+        ])
+      : "";
   const lines = invoice.lines.map((l, i) => invoiceLine(l, computed.lineNets[i], i, cur));
 
   return (

--- a/packages/e-invoice/src/ubl.ts
+++ b/packages/e-invoice/src/ubl.ts
@@ -354,6 +354,7 @@ export function toUBL(
       : "", // BT-107
     docAC.some((a) => a.isCharge) ? money("cbc:ChargeTotalAmount", computed.chargeTotal, cur) : "", // BT-108
     computed.paidAmount ? money("cbc:PrepaidAmount", computed.paidAmount, cur) : "", // BT-113
+    computed.roundingAmount ? money("cbc:PayableRoundingAmount", computed.roundingAmount, cur) : "", // BT-114
     money("cbc:PayableAmount", computed.duePayable, cur), // BT-115
   ]);
 

--- a/packages/e-invoice/src/ubl.ts
+++ b/packages/e-invoice/src/ubl.ts
@@ -289,6 +289,7 @@ export function toUBL(
       el("cbc:Note", invoice.noteSubjectCode ? `#${invoice.noteSubjectCode}#${n}` : n),
     ), // BT-22 (+ BT-21)
     el("cbc:DocumentCurrencyCode", cur), // BT-5
+    el("cbc:TaxCurrencyCode", invoice.taxCurrency), // BT-6
     el("cbc:AccountingCost", invoice.buyerAccountingRef), // BT-19 - BEFORE the buyer reference
     el("cbc:BuyerReference", invoice.buyerReference), // BT-10 (Leitweg-ID)
     invoicePeriod(invoice.period), // BG-14
@@ -374,10 +375,18 @@ export function toUBL(
   );
   const paymentTerms = termsText ? wrap("cac:PaymentTerms", [el("cbc:Note", termsText)]) : "";
 
-  const taxTotal = wrap("cac:TaxTotal", [
-    money("cbc:TaxAmount", computed.taxTotal, cur), // BT-110
-    ...computed.vatBreakdown.map((g) => taxSubtotal(g, cur)), // BG-23
-  ]);
+  const taxTotal =
+    wrap("cac:TaxTotal", [
+      money("cbc:TaxAmount", computed.taxTotal, cur), // BT-110
+      ...computed.vatBreakdown.map((g) => taxSubtotal(g, cur)), // BG-23
+    ]) +
+    // BT-111 is a SECOND TaxTotal with nothing but the amount - the breakdown is not repeated,
+    // because it is the same tax expressed in another currency, not a second tax.
+    (invoice.taxCurrency && invoice.taxTotalInTaxCurrency !== undefined
+      ? wrap("cac:TaxTotal", [
+          money("cbc:TaxAmount", invoice.taxTotalInTaxCurrency, invoice.taxCurrency),
+        ])
+      : "");
 
   const monetaryTotal = wrap("cac:LegalMonetaryTotal", [
     money("cbc:LineExtensionAmount", computed.lineTotal, cur), // BT-106

--- a/packages/e-invoice/src/ubl.ts
+++ b/packages/e-invoice/src/ubl.ts
@@ -10,6 +10,7 @@ import {
 import { ComputedInvoice, VatBreakdownEntry } from "./compute.ts";
 import { BUSINESS_PROCESS, CiiProfile, GUIDELINE } from "./cii.ts";
 import { paymentTermsText } from "./skonto.ts";
+import { acAmount, hasPercentage } from "./allowance.ts";
 
 // Emits the OASIS UBL Invoice XML for the EN16931 profile - the SECOND permitted syntax (PEPPOL is
 // UBL, and XRechnung accepts it too). Same semantic model (BT/BG) + pre-computed totals as the CII
@@ -154,7 +155,10 @@ function docAllowanceCharge(ac: AllowanceCharge, currency: string): string {
     el("cbc:ChargeIndicator", String(ac.isCharge)),
     el("cbc:AllowanceChargeReasonCode", ac.reasonCode), // BT-98 / BT-105
     el("cbc:AllowanceChargeReason", ac.reason), // BT-97 / BT-104
-    money("cbc:Amount", ac.amount, currency), // BT-92 / BT-99
+    // UBL splits the pair around the amount: the factor before it, the base after.
+    hasPercentage(ac) ? el("cbc:MultiplierFactorNumeric", ac.percent) : "", // BT-94 / BT-101
+    money("cbc:Amount", acAmount(ac), currency), // BT-92 / BT-99
+    hasPercentage(ac) ? money("cbc:BaseAmount", ac.baseAmount, currency) : "", // BT-93 / BT-100
     taxCategory("cac:TaxCategory", ac.vat.category, ac.vat.ratePercent ?? 0),
   ]);
 }
@@ -165,7 +169,9 @@ function lineAllowanceCharge(ac: AllowanceCharge, currency: string): string {
     el("cbc:ChargeIndicator", String(ac.isCharge)),
     el("cbc:AllowanceChargeReasonCode", ac.reasonCode), // BT-140 / BT-145
     el("cbc:AllowanceChargeReason", ac.reason), // BT-139 / BT-144
-    money("cbc:Amount", ac.amount, currency), // BT-136 / BT-141
+    hasPercentage(ac) ? el("cbc:MultiplierFactorNumeric", ac.percent) : "", // BT-138 / BT-143
+    money("cbc:Amount", acAmount(ac), currency), // BT-136 / BT-141
+    hasPercentage(ac) ? money("cbc:BaseAmount", ac.baseAmount, currency) : "", // BT-137 / BT-142
   ]);
 }
 

--- a/packages/e-invoice/tests/allowance-percentage.test.ts
+++ b/packages/e-invoice/tests/allowance-percentage.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import { Invoice, AllowanceCharge } from "../src/invoice.ts";
+import { toCII } from "../src/cii.ts";
+import { toUBL } from "../src/ubl.ts";
+import { computeInvoice } from "../src/compute.ts";
+import { acAmount } from "../src/allowance.ts";
+import { en16931Problems } from "../src/profile-check.ts";
+import { defaultInvoiceTemplate } from "../src/template.ts";
+import { resolveLabels, makeFormatters } from "../src/i18n.ts";
+import { printedText } from "./support/printed.ts";
+
+/**
+ * An allowance stated as "10 % of 1000" instead of "100". The point is not the two extra elements -
+ * it is that ONE resolver feeds the totals, both syntaxes and the paper, so a percentage can never
+ * be shown as one figure and billed as another.
+ */
+
+const base: Invoice = {
+  number: "RE-2026-200",
+  issueDate: "2026-09-09",
+  currency: "EUR",
+  seller: {
+    name: "Muster GmbH",
+    vatId: "DE123456789",
+    address: { city: "Berlin", postCode: "10115", country: "DE" },
+  },
+  buyer: { name: "Kunde AG", address: { city: "München", postCode: "80331", country: "DE" } },
+  lines: [
+    {
+      name: "Beratung",
+      quantity: 1,
+      unit: "C62",
+      netUnitPrice: 1000,
+      vat: { category: "S", ratePercent: 19 },
+    },
+  ],
+};
+
+const withDocAC = (ac: AllowanceCharge): Invoice => ({ ...base, allowancesCharges: [ac] });
+
+const RATE: AllowanceCharge = {
+  isCharge: false,
+  baseAmount: 1000,
+  percent: 10,
+  vat: { category: "S", ratePercent: 19 },
+  reason: "Mengenrabatt",
+};
+
+describe("a percentage becomes an amount, in exactly one place", () => {
+  it("derives it", () => {
+    expect(acAmount(RATE)).toBe(100);
+  });
+
+  it("rounds to the cent, the way money is rounded", () => {
+    expect(acAmount({ ...RATE, baseAmount: 33.33, percent: 3 })).toBe(1); // 0.9999
+  });
+
+  it("lets an explicit amount win, because overruling a user hides their typo", () => {
+    expect(acAmount({ ...RATE, amount: 99 })).toBe(99);
+  });
+
+  it("feeds the totals, so the discount actually reduces what is owed", () => {
+    const c = computeInvoice(withDocAC(RATE));
+    expect(c.allowanceTotal).toBe(100);
+    expect(c.taxBasisTotal).toBe(900);
+    expect(c.taxTotal).toBe(171); // 19 % of 900, not of 1000
+    expect(c.grandTotal).toBe(1071);
+  });
+
+  it("gives the same totals whichever way it was written", () => {
+    const asRate = computeInvoice(withDocAC(RATE));
+    const asAmount = computeInvoice(
+      withDocAC({ isCharge: false, amount: 100, vat: RATE.vat, reason: RATE.reason }),
+    );
+    expect(asRate.grandTotal).toBe(asAmount.grandTotal);
+    expect(asRate.taxBasisTotal).toBe(asAmount.taxBasisTotal);
+  });
+});
+
+describe("both syntaxes carry the rate", () => {
+  const invoice = withDocAC(RATE);
+  const computed = computeInvoice(invoice);
+
+  it("CII writes percent and basis before the amount, per the XSD sequence", () => {
+    const xml = toCII(invoice, computed);
+    const block =
+      /<ram:SpecifiedTradeAllowanceCharge>[\s\S]*?<\/ram:SpecifiedTradeAllowanceCharge>/.exec(
+        xml,
+      )![0];
+    expect(block).toContain("<ram:CalculationPercent>10</ram:CalculationPercent>");
+    expect(block).toContain("<ram:BasisAmount>1000.00</ram:BasisAmount>");
+    expect(block.indexOf("CalculationPercent")).toBeLessThan(block.indexOf("BasisAmount"));
+    expect(block.indexOf("BasisAmount")).toBeLessThan(block.indexOf("ActualAmount"));
+  });
+
+  it("UBL writes the factor before the amount and the base after it", () => {
+    const xml = toUBL(invoice, computed);
+    const block = /<cac:AllowanceCharge>[\s\S]*?<\/cac:AllowanceCharge>/.exec(xml)![0];
+    expect(block).toContain("<cbc:MultiplierFactorNumeric>10</cbc:MultiplierFactorNumeric>");
+    expect(block).toContain('<cbc:BaseAmount currencyID="EUR">1000.00</cbc:BaseAmount>');
+    expect(block.indexOf("MultiplierFactorNumeric")).toBeLessThan(block.indexOf("cbc:Amount"));
+    expect(block.indexOf("cbc:Amount")).toBeLessThan(block.indexOf("BaseAmount"));
+  });
+
+  it("writes neither element when the allowance is a plain amount, so old output is untouched", () => {
+    const plain = withDocAC({ isCharge: false, amount: 100, vat: RATE.vat });
+    const c = computeInvoice(plain);
+    expect(toCII(plain, c)).not.toContain("CalculationPercent");
+    expect(toUBL(plain, c)).not.toContain("MultiplierFactorNumeric");
+  });
+});
+
+describe("the paper shows the rate, not just the euros", () => {
+  const printed = (invoice: Invoice) =>
+    printedText(
+      defaultInvoiceTemplate(
+        invoice,
+        computeInvoice(invoice),
+        resolveLabels("de"),
+        makeFormatters("de", "EUR"),
+      ),
+    ).join("\n");
+
+  it("prints the percentage and what it applies to", () => {
+    const text = printed(withDocAC(RATE));
+    expect(text).toContain("Mengenrabatt");
+    expect(text).toMatch(/10\s*%/);
+    expect(text).toMatch(/1\.000,00/);
+  });
+
+  it("does the same for a line-level rate", () => {
+    const text = printed({
+      ...base,
+      lines: [
+        { ...base.lines[0]!, allowancesCharges: [{ ...RATE, baseAmount: 1000, percent: 5 }] },
+      ],
+    });
+    expect(text).toMatch(/5\s*%/);
+  });
+});
+
+describe("a contradiction is reported, never silently resolved", () => {
+  it("names the mismatch when the amount and the rate disagree", () => {
+    const problems = en16931Problems(withDocAC({ ...RATE, amount: 90 }));
+    expect(problems.join(" ")).toContain("90");
+    expect(problems.join(" ")).toContain("100");
+  });
+
+  it("accepts a rounding-sized difference, which is not a contradiction", () => {
+    expect(
+      en16931Problems(withDocAC({ ...RATE, baseAmount: 33.33, percent: 3, amount: 1 })),
+    ).toEqual([]);
+  });
+
+  it("rejects an impossible rate", () => {
+    expect(en16931Problems(withDocAC({ ...RATE, percent: 0 })).join(" ")).toContain("percent");
+    expect(en16931Problems(withDocAC({ ...RATE, percent: 120 })).join(" ")).toContain("percent");
+  });
+
+  it("finds it on a line too, and says which line", () => {
+    const problems = en16931Problems({
+      ...base,
+      lines: [{ ...base.lines[0]!, allowancesCharges: [{ ...RATE, amount: 55 }] }],
+    });
+    expect(problems.join(" ")).toContain("invoice.lines[0].allowancesCharges[0]");
+  });
+});

--- a/packages/e-invoice/tests/direct-debit.test.ts
+++ b/packages/e-invoice/tests/direct-debit.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import { Invoice } from "../src/invoice.ts";
+import { toCII } from "../src/cii.ts";
+import { toUBL } from "../src/ubl.ts";
+import { computeInvoice } from "../src/compute.ts";
+import { xrechnungProblems } from "../src/profile-check.ts";
+import { defaultInvoiceTemplate } from "../src/template.ts";
+import { resolveLabels, makeFormatters } from "../src/i18n.ts";
+import { printedText } from "./support/printed.ts";
+
+/**
+ * BG-19, SEPA direct debit - three fields that CII scatters over THREE separate blocks (settlement,
+ * payment means, payment terms) while UBL keeps them in two. The position tests are the point: each
+ * one sits where its own XSD type puts it, and getting any of them wrong produces an invalid file
+ * that the business-rule validator still waves through.
+ */
+
+const base: Invoice = {
+  number: "RE-2026-400",
+  issueDate: "2026-09-09",
+  currency: "EUR",
+  buyerReference: "04011000-12345-34",
+  seller: {
+    name: "Muster GmbH",
+    vatId: "DE123456789",
+    electronicAddress: "re@muster.invalid",
+    address: { city: "Berlin", postCode: "10115", country: "DE" },
+    contact: { name: "A", phone: "1", email: "a@muster.invalid" },
+  },
+  buyer: {
+    name: "Kunde AG",
+    electronicAddress: "re@kunde.invalid",
+    address: { city: "München", postCode: "80331", country: "DE" },
+  },
+  delivery: { date: "2026-09-01" },
+  dueDate: "2026-09-23",
+  lines: [
+    {
+      name: "Wartung",
+      quantity: 1,
+      unit: "C62",
+      netUnitPrice: 100,
+      vat: { category: "S", ratePercent: 19 },
+    },
+  ],
+  payment: {
+    meansCode: "59", // SEPA direct debit
+    directDebit: {
+      mandateReference: "MND-2026-0042",
+      creditorId: "DE98ZZZ09999999999",
+      debitedIban: "DE02120300000000202051",
+    },
+  },
+};
+
+const computed = computeInvoice(base);
+
+describe("CII puts the three fields in three different places", () => {
+  const xml = toCII(base, computed);
+
+  it("BT-90 as the creditor reference, FIRST in the settlement", () => {
+    expect(xml).toContain("<ram:CreditorReferenceID>DE98ZZZ09999999999</ram:CreditorReferenceID>");
+    expect(xml.indexOf("CreditorReferenceID")).toBeLessThan(xml.indexOf("ram:PaymentReference"));
+  });
+
+  it("BT-91 as the payer account, BEFORE the payee account", () => {
+    expect(xml).toContain(
+      "<ram:PayerPartyDebtorFinancialAccount><ram:IBANID>DE02120300000000202051</ram:IBANID></ram:PayerPartyDebtorFinancialAccount>",
+    );
+  });
+
+  it("BT-89 as the mandate, inside the payment terms", () => {
+    expect(xml).toContain("<ram:DirectDebitMandateID>MND-2026-0042</ram:DirectDebitMandateID>");
+    expect(xml.indexOf("SpecifiedTradePaymentTerms")).toBeLessThan(
+      xml.indexOf("DirectDebitMandateID"),
+    );
+  });
+
+  it("emits the payment terms even when nothing but the mandate is set", () => {
+    const bare: Invoice = {
+      ...base,
+      dueDate: undefined,
+      payment: { meansCode: "59", directDebit: { mandateReference: "M-1" } },
+    };
+    expect(toCII(bare, computeInvoice(bare))).toContain(
+      "<ram:DirectDebitMandateID>M-1</ram:DirectDebitMandateID>",
+    );
+  });
+});
+
+describe("UBL keeps the mandate together and hangs the creditor id on the party", () => {
+  const xml = toUBL(base, computed);
+
+  it("BT-89 and BT-91 inside cac:PaymentMandate", () => {
+    expect(xml).toContain(
+      "<cac:PaymentMandate><cbc:ID>MND-2026-0042</cbc:ID><cac:PayerFinancialAccount><cbc:ID>DE02120300000000202051</cbc:ID></cac:PayerFinancialAccount></cac:PaymentMandate>",
+    );
+  });
+
+  it("BT-90 on the seller party, as the FIRST child, with the SEPA scheme", () => {
+    expect(xml).toContain(
+      '<cac:PartyIdentification><cbc:ID schemeID="SEPA">DE98ZZZ09999999999</cbc:ID></cac:PartyIdentification>',
+    );
+    const party = /<cac:AccountingSupplierParty>[\s\S]*?<\/cac:AccountingSupplierParty>/.exec(
+      xml,
+    )![0];
+    expect(party.indexOf("PartyIdentification")).toBeLessThan(party.indexOf("cac:PostalAddress"));
+  });
+});
+
+describe("the paper tells the payer what is about to be collected", () => {
+  const printed = (invoice: Invoice) =>
+    printedText(
+      defaultInvoiceTemplate(
+        invoice,
+        computeInvoice(invoice),
+        resolveLabels("de"),
+        makeFormatters("de", "EUR"),
+      ),
+    ).join("\n");
+
+  it("names the mandate, the creditor id and the debited account", () => {
+    const text = printed(base);
+    expect(text).toContain("SEPA-Lastschrift");
+    expect(text).toContain("MND-2026-0042");
+    expect(text).toContain("DE98ZZZ09999999999");
+    expect(text).toContain("DE02120300000000202051");
+  });
+
+  it("says nothing when the invoice is paid by transfer", () => {
+    const transfer: Invoice = { ...base, payment: { meansCode: "58", iban: "DE02" } };
+    expect(printed(transfer)).not.toContain("SEPA-Lastschrift");
+  });
+});
+
+describe("the pre-flight, including a rule that was wrong before", () => {
+  it("no longer demands a payee IBAN for a direct debit (59 is not a credit transfer)", () => {
+    // UNCL 4461: 58 = SEPA credit transfer, 59 = SEPA DIRECT DEBIT. 59 used to sit in the
+    // credit-transfer list, so this invoice was told to supply an IBAN it does not need.
+    expect(xrechnungProblems(base).join(" ")).not.toContain("BT-84");
+  });
+
+  it("still demands one for a real credit transfer", () => {
+    const transfer: Invoice = { ...base, payment: { meansCode: "58" } };
+    expect(xrechnungProblems(transfer).join(" ")).toContain("BT-84");
+  });
+
+  it("demands a mandate reference for a collection", () => {
+    const noMandate: Invoice = { ...base, payment: { meansCode: "59" } };
+    expect(xrechnungProblems(noMandate).join(" ")).toContain("BT-89");
+  });
+
+  it("does not ask for a mandate when nobody is collecting", () => {
+    const transfer: Invoice = { ...base, payment: { meansCode: "58", iban: "DE02" } };
+    expect(xrechnungProblems(transfer).join(" ")).not.toContain("BT-89");
+  });
+});
+
+describe("absent means untouched", () => {
+  it("adds nothing to either syntax", () => {
+    const plain: Invoice = { ...base, payment: { meansCode: "58", iban: "DE02" } };
+    const c = computeInvoice(plain);
+    expect(toCII(plain, c)).not.toContain("DirectDebitMandateID");
+    expect(toCII(plain, c)).not.toContain("CreditorReferenceID");
+    expect(toCII(plain, c)).not.toContain("PayerPartyDebtorFinancialAccount");
+    expect(toUBL(plain, c)).not.toContain("PaymentMandate");
+    expect(toUBL(plain, c)).not.toContain("PartyIdentification");
+  });
+});

--- a/packages/e-invoice/tests/preceding-invoice.test.ts
+++ b/packages/e-invoice/tests/preceding-invoice.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { Invoice } from "../src/invoice.ts";
+import { toCII } from "../src/cii.ts";
+import { toUBL } from "../src/ubl.ts";
+import { computeInvoice } from "../src/compute.ts";
+import { defaultInvoiceTemplate } from "../src/template.ts";
+import { resolveLabels, makeFormatters } from "../src/i18n.ts";
+import { printedText } from "./support/printed.ts";
+
+/**
+ * BG-3, the reference that makes a credit note traceable to what it corrects.
+ *
+ * Both syntaxes put it in a different place and CII needs a namespace we did not previously emit, so
+ * the position tests here are not pedantry: CII is sequence-bound, and a correct element in the wrong
+ * slot is an invalid file that the business-rule validator still passes.
+ */
+
+const base: Invoice = {
+  number: "GS-2026-004",
+  issueDate: "2026-09-09",
+  type: 381, // credit note - the case BG-3 exists for
+  currency: "EUR",
+  seller: {
+    name: "Muster GmbH",
+    vatId: "DE123456789",
+    address: { city: "Berlin", postCode: "10115", country: "DE" },
+  },
+  buyer: { name: "Kunde AG", address: { city: "München", postCode: "80331", country: "DE" } },
+  lines: [
+    {
+      name: "Rückvergütung",
+      quantity: 1,
+      unit: "C62",
+      netUnitPrice: 200,
+      vat: { category: "S", ratePercent: 19 },
+    },
+  ],
+};
+
+const withRefs = (refs: Invoice["precedingInvoices"]): Invoice => ({
+  ...base,
+  precedingInvoices: refs,
+});
+
+describe("CII", () => {
+  it("names the original invoice and its date", () => {
+    const invoice = withRefs([{ number: "RE-2026-0100", issueDate: "2026-08-01" }]);
+    const xml = toCII(invoice, computeInvoice(invoice));
+    expect(xml).toContain("<ram:IssuerAssignedID>RE-2026-0100</ram:IssuerAssignedID>");
+    expect(xml).toContain('<qdt:DateTimeString format="102">20260801</qdt:DateTimeString>');
+  });
+
+  it("uses the QUALIFIED namespace for the date, and declares it", () => {
+    const invoice = withRefs([{ number: "RE-1", issueDate: "2026-08-01" }]);
+    const xml = toCII(invoice, computeInvoice(invoice));
+    // udt would be the wrong type here - FormattedIssueDateTime is qdt:FormattedDateTimeType.
+    expect(xml).toContain('xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100"');
+    expect(xml).not.toMatch(/<ram:FormattedIssueDateTime><udt:/);
+  });
+
+  it("places it AFTER the monetary summation, which is where the XSD puts it", () => {
+    const invoice = withRefs([{ number: "RE-1" }]);
+    const xml = toCII(invoice, computeInvoice(invoice));
+    expect(xml.indexOf("SpecifiedTradeSettlementHeaderMonetarySummation")).toBeLessThan(
+      xml.indexOf("InvoiceReferencedDocument"),
+    );
+  });
+
+  it("omits the date element entirely when there is no date", () => {
+    const invoice = withRefs([{ number: "RE-1" }]);
+    const xml = toCII(invoice, computeInvoice(invoice));
+    expect(xml).toContain("<ram:IssuerAssignedID>RE-1</ram:IssuerAssignedID>");
+    expect(xml).not.toContain("FormattedIssueDateTime");
+  });
+});
+
+describe("UBL", () => {
+  it("wraps it as a billing reference with an ISO date", () => {
+    const invoice = withRefs([{ number: "RE-2026-0100", issueDate: "2026-08-01" }]);
+    const xml = toUBL(invoice, computeInvoice(invoice));
+    expect(xml).toContain("<cbc:ID>RE-2026-0100</cbc:ID>");
+    expect(xml).toContain("<cbc:IssueDate>2026-08-01</cbc:IssueDate>");
+    expect(xml).toMatch(/<cac:BillingReference><cac:InvoiceDocumentReference>/);
+  });
+
+  it("sits between the order and the contract reference, per the InvoiceType sequence", () => {
+    const invoice = {
+      ...withRefs([{ number: "RE-1" }]),
+      purchaseOrderRef: "PO-9",
+      contractRef: "C-9",
+    };
+    const xml = toUBL(invoice, computeInvoice(invoice));
+    expect(xml.indexOf("cac:OrderReference")).toBeLessThan(xml.indexOf("cac:BillingReference"));
+    expect(xml.indexOf("cac:BillingReference")).toBeLessThan(
+      xml.indexOf("cac:ContractDocumentReference"),
+    );
+  });
+});
+
+describe("more than one, because a correction may settle several", () => {
+  it("emits every reference in both syntaxes", () => {
+    const invoice = withRefs([
+      { number: "RE-1", issueDate: "2026-07-01" },
+      { number: "RE-2", issueDate: "2026-08-01" },
+    ]);
+    const computed = computeInvoice(invoice);
+    expect(toCII(invoice, computed).match(/InvoiceReferencedDocument>/g)).toHaveLength(4); // 2 open + 2 close
+    expect(toUBL(invoice, computed).match(/<cac:BillingReference>/g)).toHaveLength(2);
+  });
+});
+
+describe("the paper names it too", () => {
+  const printed = (invoice: Invoice) =>
+    printedText(
+      defaultInvoiceTemplate(
+        invoice,
+        computeInvoice(invoice),
+        resolveLabels("de"),
+        makeFormatters("de", "EUR"),
+      ),
+    ).join("\n");
+
+  it("shows the number and the date in the reference box", () => {
+    const text = printed(withRefs([{ number: "RE-2026-0100", issueDate: "2026-08-01" }]));
+    expect(text).toContain("Bezug auf Rechnung");
+    expect(text).toContain("RE-2026-0100");
+    expect(text).toContain("01.08.2026");
+  });
+
+  it("lists several on one line", () => {
+    const text = printed(withRefs([{ number: "RE-1" }, { number: "RE-2" }]));
+    expect(text).toMatch(/RE-1, RE-2/);
+  });
+
+  it("says nothing at all when there is no reference", () => {
+    expect(printed(base)).not.toContain("Bezug auf Rechnung");
+  });
+});
+
+describe("absent means untouched", () => {
+  it("adds no element to either syntax", () => {
+    const computed = computeInvoice(base);
+    expect(toCII(base, computed)).not.toContain("InvoiceReferencedDocument");
+    expect(toUBL(base, computed)).not.toContain("BillingReference");
+  });
+});

--- a/packages/e-invoice/tests/rounding.test.ts
+++ b/packages/e-invoice/tests/rounding.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { Invoice } from "../src/invoice.ts";
+import { toCII } from "../src/cii.ts";
+import { toUBL } from "../src/ubl.ts";
+import { computeInvoice } from "../src/compute.ts";
+import { defaultInvoiceTemplate } from "../src/template.ts";
+import { resolveLabels, makeFormatters } from "../src/i18n.ts";
+import { printedText } from "./support/printed.ts";
+
+/**
+ * BT-114, the deliberate cent. It moves the amount DUE, not the invoice total - and the CII schema
+ * puts the element before the grand total, which reads as though it moved that instead. Getting the
+ * direction wrong makes an invoice whose own arithmetic disagrees, so that is what these pin down.
+ */
+
+const base: Invoice = {
+  number: "RE-2026-500",
+  issueDate: "2026-09-09",
+  currency: "EUR",
+  seller: {
+    name: "Muster GmbH",
+    vatId: "DE123456789",
+    address: { city: "Berlin", postCode: "10115", country: "DE" },
+  },
+  buyer: { name: "Kunde AG", address: { city: "München", postCode: "80331", country: "DE" } },
+  lines: [
+    {
+      // 84.35 net -> 100.3765 gross, which rounds to 100.38 and is worth smoothing.
+      name: "Leistung",
+      quantity: 1,
+      unit: "C62",
+      netUnitPrice: 84.35,
+      vat: { category: "S", ratePercent: 19 },
+    },
+  ],
+};
+
+describe("what it moves, and what it leaves alone", () => {
+  it("moves the payable and nothing else", () => {
+    const plain = computeInvoice(base);
+    const rounded = computeInvoice({ ...base, roundingAmount: 0.02 });
+    expect(rounded.grandTotal).toBe(plain.grandTotal); // BT-112 untouched
+    expect(rounded.taxTotal).toBe(plain.taxTotal); // BT-110 untouched
+    expect(rounded.taxBasisTotal).toBe(plain.taxBasisTotal); // BT-109 untouched
+    expect(rounded.duePayable).toBe(round(plain.duePayable + 0.02));
+  });
+
+  it("rounds DOWN when the figure is negative", () => {
+    const c = computeInvoice({ ...base, roundingAmount: -0.03 });
+    expect(c.duePayable).toBe(round(c.grandTotal - 0.03));
+  });
+
+  it("stacks with an amount already paid", () => {
+    const c = computeInvoice({ ...base, paidAmount: 50, roundingAmount: 0.05 });
+    expect(c.duePayable).toBe(round(c.grandTotal - 50 + 0.05));
+  });
+
+  it("is 0 when nobody asked, and changes nothing", () => {
+    const c = computeInvoice(base);
+    expect(c.roundingAmount).toBe(0);
+    expect(c.duePayable).toBe(c.grandTotal);
+  });
+});
+
+describe("both syntaxes, each in its own slot", () => {
+  const invoice = { ...base, roundingAmount: 0.02 };
+  const computed = computeInvoice(invoice);
+
+  it("CII writes it between the tax total and the grand total", () => {
+    const xml = toCII(invoice, computed);
+    expect(xml).toContain("<ram:RoundingAmount>0.02</ram:RoundingAmount>");
+    expect(xml.indexOf("TaxTotalAmount")).toBeLessThan(xml.indexOf("RoundingAmount"));
+    expect(xml.indexOf("RoundingAmount")).toBeLessThan(xml.indexOf("GrandTotalAmount"));
+  });
+
+  it("UBL writes it between the prepaid amount and the payable", () => {
+    const withPaid = { ...invoice, paidAmount: 10 };
+    const xml = toUBL(withPaid, computeInvoice(withPaid));
+    expect(xml).toContain(
+      '<cbc:PayableRoundingAmount currencyID="EUR">0.02</cbc:PayableRoundingAmount>',
+    );
+    expect(xml.indexOf("PrepaidAmount")).toBeLessThan(xml.indexOf("PayableRoundingAmount"));
+    expect(xml.indexOf("PayableRoundingAmount")).toBeLessThan(xml.indexOf("PayableAmount"));
+  });
+
+  it("keeps a negative sign, which is the whole point of the field", () => {
+    const down = { ...base, roundingAmount: -0.03 };
+    const c = computeInvoice(down);
+    expect(toCII(down, c)).toContain("<ram:RoundingAmount>-0.03</ram:RoundingAmount>");
+    expect(toUBL(down, c)).toContain(">-0.03</cbc:PayableRoundingAmount>");
+  });
+
+  it("emits nothing at all when there is no rounding", () => {
+    const c = computeInvoice(base);
+    expect(toCII(base, c)).not.toContain("RoundingAmount");
+    expect(toUBL(base, c)).not.toContain("PayableRoundingAmount");
+  });
+});
+
+describe("the paper explains the difference", () => {
+  const printed = (invoice: Invoice) =>
+    printedText(
+      defaultInvoiceTemplate(
+        invoice,
+        computeInvoice(invoice),
+        resolveLabels("de"),
+        makeFormatters("de", "EUR"),
+      ),
+    ).join("\n");
+
+  it("shows the rounding with its sign, so the payable is not a mystery", () => {
+    const text = printed({ ...base, roundingAmount: 0.02 });
+    expect(text).toContain("Rundung");
+    expect(text).toMatch(/\+0,02/);
+  });
+
+  it("shows a downward rounding as a subtraction", () => {
+    expect(printed({ ...base, roundingAmount: -0.03 })).toMatch(/-0,03/);
+  });
+
+  it("prints no rounding line when there is none", () => {
+    expect(printed(base)).not.toContain("Rundung");
+  });
+});
+
+const round = (n: number) => Math.round(n * 100) / 100;

--- a/packages/e-invoice/tests/scalar-references.test.ts
+++ b/packages/e-invoice/tests/scalar-references.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from "vitest";
+import { Invoice } from "../src/invoice.ts";
+import { toCII } from "../src/cii.ts";
+import { toUBL } from "../src/ubl.ts";
+import { computeInvoice } from "../src/compute.ts";
+import { defaultInvoiceTemplate } from "../src/template.ts";
+import { resolveLabels, makeFormatters } from "../src/i18n.ts";
+import { printedText } from "./support/printed.ts";
+
+/**
+ * The fifteen scalars that only exist so someone can quote them back: project, tender, cost centre,
+ * party identifiers, order lines, country of origin.
+ *
+ * Individually they are one element each. Together they are the case where a generator quietly
+ * writes the right value into the wrong slot, so most of what is asserted here is WHERE things land -
+ * the two syntaxes disagree about that constantly, and only one of them is checked by a schema that
+ * cares about sequence.
+ */
+
+const full: Invoice = {
+  number: "RE-2026-600",
+  issueDate: "2026-09-09",
+  currency: "EUR",
+  buyerReference: "LEITWEG-1",
+  purchaseOrderRef: "PO-100",
+  salesOrderRef: "SO-200", // BT-14
+  contractRef: "C-300",
+  projectRef: "PRJ-400", // BT-11
+  tenderRef: "TENDER-500", // BT-17
+  objectRef: "METER-600", // BT-18
+  buyerAccountingRef: "KST-4711", // BT-19
+  notes: ["Bitte bei Rueckfragen die Projektnummer angeben."],
+  noteSubjectCode: "AAI", // BT-21
+  seller: {
+    name: "Muster GmbH",
+    identifier: "4012345000009", // BT-29
+    vatId: "DE123456789",
+    address: { city: "Berlin", postCode: "10115", country: "DE" },
+  },
+  buyer: {
+    name: "Kunde AG",
+    identifier: "4098765000004", // BT-46
+    address: { city: "München", postCode: "80331", country: "DE" },
+  },
+  delivery: { date: "2026-09-01", locationId: "LOC-77" }, // BT-71
+  payeeName: "Factor AG",
+  payeeIdentifier: "PAYEE-1", // BT-60
+  payeeLegalRegistrationId: "HRB 4711", // BT-61
+  lines: [
+    {
+      name: "Zaehler",
+      quantity: 1,
+      unit: "C62",
+      netUnitPrice: 100,
+      vat: { category: "S", ratePercent: 19 },
+      objectRef: "DEV-9", // BT-128
+      orderLineRef: "12", // BT-132
+      buyerAccountingRef: "KST-0815", // BT-133
+      originCountry: "CH", // BT-159
+    },
+  ],
+};
+
+const computed = computeInvoice(full);
+const cii = toCII(full, computed);
+const ubl = toUBL(full, computed);
+
+describe("CII", () => {
+  it("puts a party identifier FIRST, where TradePartyType declares ID", () => {
+    expect(cii).toContain("<ram:SellerTradeParty><ram:ID>4012345000009</ram:ID>");
+    expect(cii).toContain("<ram:BuyerTradeParty><ram:ID>4098765000004</ram:ID>");
+  });
+
+  it("separates the seller's order number from the buyer's", () => {
+    expect(cii).toContain(
+      "<ram:SellerOrderReferencedDocument><ram:IssuerAssignedID>SO-200</ram:IssuerAssignedID>",
+    );
+    expect(cii).toContain(
+      "<ram:BuyerOrderReferencedDocument><ram:IssuerAssignedID>PO-100</ram:IssuerAssignedID>",
+    );
+  });
+
+  it("tells the shared reference element apart by TypeCode", () => {
+    expect(cii).toContain(
+      "<ram:AdditionalReferencedDocument><ram:IssuerAssignedID>TENDER-500</ram:IssuerAssignedID><ram:TypeCode>50</ram:TypeCode>",
+    );
+    expect(cii).toContain(
+      "<ram:AdditionalReferencedDocument><ram:IssuerAssignedID>METER-600</ram:IssuerAssignedID><ram:TypeCode>130</ram:TypeCode>",
+    );
+  });
+
+  it("carries the note subject code beside the note", () => {
+    expect(cii).toMatch(/<ram:IncludedNote><ram:Content>[^<]*<\/ram:Content><ram:SubjectCode>AAI</);
+  });
+
+  it("puts the cost centre in the accounting account, at the end of the settlement", () => {
+    expect(cii).toContain(
+      "<ram:ReceivableSpecifiedTradeAccountingAccount><ram:ID>KST-4711</ram:ID>",
+    );
+    expect(cii.indexOf("DuePayableAmount")).toBeLessThan(cii.indexOf("KST-4711"));
+  });
+
+  it("carries the payee identifier and registration", () => {
+    expect(cii).toContain("<ram:PayeeTradeParty><ram:ID>PAYEE-1</ram:ID>");
+    expect(cii).toContain("<ram:SpecifiedLegalOrganization><ram:ID>HRB 4711</ram:ID>");
+  });
+
+  it("carries the delivery location, the order line, the object and the origin", () => {
+    expect(cii).toContain("<ram:ShipToTradeParty><ram:ID>LOC-77</ram:ID>");
+    expect(cii).toContain("<ram:BuyerOrderReferencedDocument><ram:LineID>12</ram:LineID>");
+    expect(cii).toContain("<ram:OriginTradeCountry><ram:ID>CH</ram:ID>");
+    expect(cii).toContain("<ram:ID>KST-0815</ram:ID>");
+  });
+});
+
+describe("UBL, where the same values land somewhere else entirely", () => {
+  it("keeps both order numbers in ONE OrderReference", () => {
+    expect(ubl).toContain(
+      "<cac:OrderReference><cbc:ID>PO-100</cbc:ID><cbc:SalesOrderID>SO-200</cbc:SalesOrderID></cac:OrderReference>",
+    );
+  });
+
+  it("uses three different elements for tender, object and project", () => {
+    expect(ubl).toContain(
+      "<cac:OriginatorDocumentReference><cbc:ID>TENDER-500</cbc:ID></cac:OriginatorDocumentReference>",
+    );
+    expect(ubl).toContain(
+      "<cac:AdditionalDocumentReference><cbc:ID>METER-600</cbc:ID><cbc:DocumentTypeCode>130</cbc:DocumentTypeCode>",
+    );
+    expect(ubl).toContain("<cac:ProjectReference><cbc:ID>PRJ-400</cbc:ID></cac:ProjectReference>");
+  });
+
+  it("has no element for the note subject and prefixes the note instead", () => {
+    // BT-21 exists in CII as an element. In UBL the binding writes it as #CODE# in front of BT-22.
+    expect(ubl).toMatch(/<cbc:Note>#AAI#Bitte bei/);
+  });
+
+  it("writes the cost centre BEFORE the buyer reference, per the InvoiceType sequence", () => {
+    expect(ubl).toContain("<cbc:AccountingCost>KST-4711</cbc:AccountingCost>");
+    expect(ubl.indexOf("cbc:AccountingCost")).toBeLessThan(ubl.indexOf("cbc:BuyerReference"));
+  });
+
+  it("puts the tender BEFORE the contract reference, likewise", () => {
+    expect(ubl.indexOf("OriginatorDocumentReference")).toBeLessThan(
+      ubl.indexOf("ContractDocumentReference"),
+    );
+  });
+
+  it("nests the delivery location id with its address", () => {
+    expect(ubl).toContain("<cac:DeliveryLocation><cbc:ID>LOC-77</cbc:ID>");
+  });
+
+  it("carries the payee identity as party identification and legal entity", () => {
+    expect(ubl).toContain(
+      "<cac:PayeeParty><cac:PartyIdentification><cbc:ID>PAYEE-1</cbc:ID></cac:PartyIdentification>",
+    );
+    expect(ubl).toContain("<cac:PartyLegalEntity><cbc:CompanyID>HRB 4711</cbc:CompanyID>");
+  });
+
+  it("carries the line references and the country of origin", () => {
+    expect(ubl).toContain("<cbc:AccountingCost>KST-0815</cbc:AccountingCost>");
+    expect(ubl).toContain("<cac:OrderLineReference><cbc:LineID>12</cbc:LineID>");
+    expect(ubl).toContain("<cac:DocumentReference><cbc:ID>DEV-9</cbc:ID>");
+    expect(ubl).toContain("<cac:OriginCountry><cbc:IdentificationCode>CH</cbc:IdentificationCode>");
+  });
+});
+
+describe("every one of them reaches the paper", () => {
+  const text = printedText(
+    defaultInvoiceTemplate(full, computed, resolveLabels("de"), makeFormatters("de", "EUR")),
+  ).join("\n");
+
+  it.each([
+    ["BT-14 sales order", "SO-200"],
+    ["BT-11 project", "PRJ-400"],
+    ["BT-17 tender", "TENDER-500"],
+    ["BT-18 object", "METER-600"],
+    ["BT-19 cost centre", "KST-4711"],
+    ["BT-29 seller id", "4012345000009"],
+    ["BT-46 buyer id", "4098765000004"],
+    ["BT-71 delivery location", "LOC-77"],
+    ["BT-60 payee id", "PAYEE-1"],
+    ["BT-61 payee registration", "HRB 4711"],
+    ["BT-128 line object", "DEV-9"],
+    ["BT-132 order line", "Bestellposition 12"],
+    ["BT-133 line cost centre", "KST-0815"],
+    ["BT-159 origin country", "Ursprungsland CH"],
+  ])("prints %s", (_name, value) => {
+    expect(text).toContain(value);
+  });
+});
+
+describe("absent means untouched", () => {
+  it("adds none of the elements when none of the fields is set", () => {
+    const bare: Invoice = {
+      number: "RE-1",
+      issueDate: "2026-09-09",
+      currency: "EUR",
+      seller: { name: "S", address: { country: "DE" } },
+      buyer: { name: "B", address: { country: "DE" } },
+      lines: [
+        {
+          name: "L",
+          quantity: 1,
+          unit: "C62",
+          netUnitPrice: 1,
+          vat: { category: "S", ratePercent: 19 },
+        },
+      ],
+    };
+    const c = computeInvoice(bare);
+    for (const tag of [
+      "SellerOrderReferencedDocument",
+      "SpecifiedProcuringProject",
+      "ReceivableSpecifiedTradeAccountingAccount",
+      "OriginTradeCountry",
+      "SubjectCode",
+    ]) {
+      expect(toCII(bare, c), tag).not.toContain(tag);
+    }
+    for (const tag of [
+      "SalesOrderID",
+      "ProjectReference",
+      "OriginatorDocumentReference",
+      "AccountingCost",
+      "OriginCountry",
+      "PartyIdentification",
+    ]) {
+      expect(toUBL(bare, c), tag).not.toContain(tag);
+    }
+  });
+});

--- a/packages/e-invoice/tests/skonto.test.ts
+++ b/packages/e-invoice/tests/skonto.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import { Invoice } from "../src/invoice.ts";
+import { toCII } from "../src/cii.ts";
+import { toUBL } from "../src/ubl.ts";
+import { computeInvoice } from "../src/compute.ts";
+import { resolveDiscounts, paymentTermsText } from "../src/skonto.ts";
+import { en16931Problems } from "../src/profile-check.ts";
+import { defaultInvoiceTemplate } from "../src/template.ts";
+import { resolveLabels, makeFormatters } from "../src/i18n.ts";
+import { printedText } from "./support/printed.ts";
+
+/**
+ * Skonto is the gap that could produce a WRONG invoice, so these tests are about more than the
+ * string format: that the discount never touches the totals, that both syntaxes say the same thing,
+ * that the paper shows what the XML says, and that the old workaround is now named as a mistake.
+ */
+
+const base: Invoice = {
+  number: "RE-2026-100",
+  issueDate: "2026-09-09",
+  currency: "EUR",
+  seller: {
+    name: "Muster GmbH",
+    vatId: "DE123456789",
+    address: { city: "Berlin", postCode: "10115", country: "DE" },
+  },
+  buyer: { name: "Kunde AG", address: { city: "München", postCode: "80331", country: "DE" } },
+  lines: [
+    {
+      name: "Wartung",
+      quantity: 1,
+      unit: "C62",
+      netUnitPrice: 1000,
+      vat: { category: "S", ratePercent: 19 },
+    },
+  ],
+  payment: { iban: "DE02120300000000202051", terms: "Zahlbar innerhalb 30 Tagen netto." },
+};
+
+const withSkonto = (...discounts: { days: number; percent: number; baseAmount?: number }[]) => ({
+  ...base,
+  payment: { ...base.payment, cashDiscounts: discounts },
+});
+
+describe("the numbers", () => {
+  it("defaults the base to the gross total, not the net", () => {
+    const invoice = withSkonto({ days: 14, percent: 2 });
+    const gross = computeInvoice(invoice).grandTotal; // 1000 + 19 % = 1190
+    const [d] = resolveDiscounts(invoice.payment!.cashDiscounts, invoice.issueDate, gross);
+    expect(d!.baseAmount).toBe(1190);
+    expect(d!.discountAmount).toBe(23.8);
+    expect(d!.discountedTotal).toBe(1166.2);
+  });
+
+  it("counts the deadline from the issue date", () => {
+    const [d] = resolveDiscounts([{ days: 14, percent: 2 }], "2026-09-09", 100);
+    expect(d!.deadline).toBe("2026-09-23");
+  });
+
+  it("crosses a month and a leap day without drifting", () => {
+    expect(resolveDiscounts([{ days: 30, percent: 1 }], "2026-12-20", 100)[0]!.deadline).toBe(
+      "2027-01-19",
+    );
+    expect(resolveDiscounts([{ days: 1, percent: 1 }], "2028-02-28", 100)[0]!.deadline).toBe(
+      "2028-02-29",
+    );
+  });
+
+  it("NEVER changes the invoice totals - that is the whole reason it is not an allowance", () => {
+    const plain = computeInvoice(base);
+    const skonto = computeInvoice(withSkonto({ days: 14, percent: 2 }));
+    expect(skonto.grandTotal).toBe(plain.grandTotal);
+    expect(skonto.duePayable).toBe(plain.duePayable);
+    expect(skonto.taxBasisTotal).toBe(plain.taxBasisTotal);
+  });
+});
+
+describe("the BT-20 payload", () => {
+  it("appends the structured line beneath the human terms", () => {
+    const text = paymentTermsText(
+      "Zahlbar in 30 Tagen.",
+      [{ days: 14, percent: 2 }],
+      "2026-09-09",
+      1190,
+    );
+    expect(text).toBe("Zahlbar in 30 Tagen.\n#SKONTO#TAGE=14#PROZENT=2.00#");
+  });
+
+  it("writes BASISBETRAG only when the user gave one", () => {
+    const text = paymentTermsText(
+      undefined,
+      [
+        { days: 14, percent: 2 },
+        { days: 30, percent: 1.5, baseAmount: 500 },
+      ],
+      "2026-09-09",
+      1190,
+    );
+    expect(text).toBe(
+      "#SKONTO#TAGE=14#PROZENT=2.00#\n#SKONTO#TAGE=30#PROZENT=1.50#BASISBETRAG=500.00#",
+    );
+  });
+
+  it("always writes two decimals, because a machine reads this", () => {
+    const text = paymentTermsText(undefined, [{ days: 7, percent: 3 }], "2026-09-09", 100);
+    expect(text).toContain("PROZENT=3.00#");
+  });
+
+  it("leaves the terms untouched when there is no discount, so old output stays byte-identical", () => {
+    expect(paymentTermsText("Nur Text.", undefined, "2026-09-09", 100)).toBe("Nur Text.");
+    expect(paymentTermsText("Nur Text.", [], "2026-09-09", 100)).toBe("Nur Text.");
+    expect(paymentTermsText(undefined, undefined, "2026-09-09", 100)).toBeUndefined();
+  });
+});
+
+describe("both syntaxes carry it, and say the same thing", () => {
+  const invoice = withSkonto({ days: 14, percent: 2 });
+  const computed = computeInvoice(invoice);
+
+  it("CII puts it in ram:Description", () => {
+    expect(toCII(invoice, computed)).toContain("#SKONTO#TAGE=14#PROZENT=2.00#");
+  });
+
+  it("UBL puts it in cbc:Note", () => {
+    expect(toUBL(invoice, computed)).toContain("#SKONTO#TAGE=14#PROZENT=2.00#");
+  });
+
+  it("and neither reports a lower payable amount", () => {
+    expect(toCII(invoice, computed)).toContain(
+      "<ram:DuePayableAmount>1190.00</ram:DuePayableAmount>",
+    );
+  });
+});
+
+describe("the paper says what the XML says", () => {
+  it("prints the percentage, the deadline and what it saves", () => {
+    const invoice = withSkonto({ days: 14, percent: 2 });
+    const text = printedText(
+      defaultInvoiceTemplate(
+        invoice,
+        computeInvoice(invoice),
+        resolveLabels("de"),
+        makeFormatters("de", "EUR"),
+      ),
+    ).join("\n");
+    expect(text).toContain("Skonto");
+    expect(text).toMatch(/23\.09\.2026/);
+    expect(text).toMatch(/1\.166,20/);
+  });
+});
+
+describe("the workaround is named as a mistake", () => {
+  it("refuses an allowance whose reason says Skonto", () => {
+    const problems = en16931Problems({
+      ...base,
+      allowancesCharges: [
+        {
+          isCharge: false,
+          amount: 23.8,
+          vat: { category: "S", ratePercent: 19 },
+          reason: "2% Skonto",
+        },
+      ],
+    });
+    expect(problems.join(" ")).toContain("cashDiscounts");
+  });
+
+  it("says nothing about a real, unconditional discount", () => {
+    const problems = en16931Problems({
+      ...base,
+      allowancesCharges: [
+        {
+          isCharge: false,
+          amount: 50,
+          vat: { category: "S", ratePercent: 19 },
+          reason: "Treuerabatt",
+        },
+      ],
+    });
+    expect(problems).toEqual([]);
+  });
+
+  it("rejects a discount that cannot exist", () => {
+    expect(en16931Problems(withSkonto({ days: 14, percent: 0 })).join(" ")).toContain("percent");
+    expect(en16931Problems(withSkonto({ days: -1, percent: 2 })).join(" ")).toContain("days");
+  });
+});

--- a/packages/e-invoice/tests/support/maximal.ts
+++ b/packages/e-invoice/tests/support/maximal.ts
@@ -148,6 +148,12 @@ export const maximalInvoice: Invoice = {
     accountName: "MARK-ACCOUNTNAME",
     bic: "MARK-BIC",
     terms: "MARK-TERMS",
+    // BG-19 - the three fields CII scatters over three blocks and UBL keeps in two.
+    directDebit: {
+      mandateReference: "MARK-MANDATE",
+      creditorId: "MARK-CREDITORID",
+      debitedIban: "MARK-DEBITEDIBAN",
+    },
     // Two tiers, and the second names its own base - so both shapes of the BT-20 line are covered.
     cashDiscounts: [
       { days: 14, percent: 2 },

--- a/packages/e-invoice/tests/support/maximal.ts
+++ b/packages/e-invoice/tests/support/maximal.ts
@@ -17,6 +17,10 @@ export const maximalInvoice: Invoice = {
   issueDate: "2026-08-25",
   type: 380,
   currency: "EUR",
+  // A seller who invoices in EUR but accounts VAT in CHF - the real shape of BT-6/BT-111, and
+  // the reason the CII schema allows TaxTotalAmount exactly twice.
+  taxCurrency: "CHF", // BT-6
+  taxTotalInTaxCurrency: 42.5, // BT-111
   dueDate: "2026-09-08",
   buyerReference: "MARK-BUYERREF",
   purchaseOrderRef: "MARK-ORDERREF",

--- a/packages/e-invoice/tests/support/maximal.ts
+++ b/packages/e-invoice/tests/support/maximal.ts
@@ -127,6 +127,11 @@ export const maximalInvoice: Invoice = {
     accountName: "MARK-ACCOUNTNAME",
     bic: "MARK-BIC",
     terms: "MARK-TERMS",
+    // Two tiers, and the second names its own base - so both shapes of the BT-20 line are covered.
+    cashDiscounts: [
+      { days: 14, percent: 2 },
+      { days: 30, percent: 1, baseAmount: 500 },
+    ],
   },
   paidAmount: 100,
 };

--- a/packages/e-invoice/tests/support/maximal.ts
+++ b/packages/e-invoice/tests/support/maximal.ts
@@ -88,7 +88,9 @@ export const maximalInvoice: Invoice = {
       allowancesCharges: [
         {
           isCharge: false,
-          amount: 5,
+          // Stated as a RATE, so the amount is derived (BT-137/138) - the other shape of the union.
+          baseAmount: 100,
+          percent: 5,
           vat: { category: "S", ratePercent: 19 },
           reason: "MARK-LINEALLOWANCE",
           reasonCode: "95", // BT-140
@@ -106,7 +108,8 @@ export const maximalInvoice: Invoice = {
   allowancesCharges: [
     {
       isCharge: false,
-      amount: 20,
+      baseAmount: 200,
+      percent: 10, // BT-93 / BT-94 - amount derived as 20.00, same figure as before
       vat: { category: "S", ratePercent: 19 },
       reason: "MARK-DOCALLOWANCE",
     },

--- a/packages/e-invoice/tests/support/maximal.ts
+++ b/packages/e-invoice/tests/support/maximal.ts
@@ -161,4 +161,5 @@ export const maximalInvoice: Invoice = {
     ],
   },
   paidAmount: 100,
+  roundingAmount: 0.03, // BT-114
 };

--- a/packages/e-invoice/tests/support/maximal.ts
+++ b/packages/e-invoice/tests/support/maximal.ts
@@ -21,6 +21,19 @@ export const maximalInvoice: Invoice = {
   buyerReference: "MARK-BUYERREF",
   purchaseOrderRef: "MARK-ORDERREF",
   contractRef: "MARK-CONTRACTREF",
+  // BG-24 - one with a real file, one with only a link, so both branches reach the XSD check.
+  supportingDocuments: [
+    {
+      reference: "MARK-DOCREF",
+      description: "MARK-DOCDESC",
+      file: {
+        content: new TextEncoder().encode("Stunden;8\n"),
+        mimeType: "text/csv",
+        filename: "MARK-DOCFILE.csv",
+      },
+    },
+    { reference: "MARK-DOCREF2", url: "https://example.invalid/MARK-DOCURL.pdf" },
+  ],
   // BG-3 - two of them, one with a date and one without, so both shapes reach the XSD check.
   precedingInvoices: [
     { number: "MARK-PRECEDING", issueDate: "2026-06-30" },

--- a/packages/e-invoice/tests/support/maximal.ts
+++ b/packages/e-invoice/tests/support/maximal.ts
@@ -20,6 +20,12 @@ export const maximalInvoice: Invoice = {
   dueDate: "2026-09-08",
   buyerReference: "MARK-BUYERREF",
   purchaseOrderRef: "MARK-ORDERREF",
+  salesOrderRef: "MARK-SALESORDER", // BT-14
+  projectRef: "MARK-PROJECT", // BT-11
+  tenderRef: "MARK-TENDER", // BT-17
+  objectRef: "MARK-OBJECT", // BT-18
+  buyerAccountingRef: "MARK-BUYERACCOUNT", // BT-19
+  noteSubjectCode: "AAI", // BT-21 - a real UNCL 4451 code, not a marker: it is validated
   contractRef: "MARK-CONTRACTREF",
   // BG-24 - one with a real file, one with only a link, so both branches reach the XSD check.
   supportingDocuments: [
@@ -42,6 +48,7 @@ export const maximalInvoice: Invoice = {
   notes: ["MARK-DOCNOTE"],
   seller: {
     name: "MARK-SELLERNAME",
+    identifier: "MARK-SELLERID", // BT-29
     tradingName: "MARK-SELLERTRADING",
     vatId: "MARK-SELLERVAT",
     taxNumber: "MARK-SELLERTAXNO",
@@ -61,6 +68,7 @@ export const maximalInvoice: Invoice = {
   },
   buyer: {
     name: "MARK-BUYERNAME",
+    identifier: "MARK-BUYERID", // BT-46
     tradingName: "MARK-BUYERTRADING",
     vatId: "MARK-BUYERVAT",
     legalRegistrationId: "MARK-BUYERREG",
@@ -78,6 +86,7 @@ export const maximalInvoice: Invoice = {
   },
   delivery: {
     date: "2026-08-20",
+    locationId: "MARK-DELIVERYLOC", // BT-71
     recipientName: "MARK-DELIVERYTO",
     address: {
       line1: "MARK-DELIVERYLINE1",
@@ -88,6 +97,8 @@ export const maximalInvoice: Invoice = {
   },
   period: { start: "2026-07-02", end: "2026-07-20" },
   payeeName: "MARK-PAYEE",
+  payeeIdentifier: "MARK-PAYEEID", // BT-60
+  payeeLegalRegistrationId: "MARK-PAYEEREG", // BT-61
   lines: [
     {
       id: "MARK-LINEID",
@@ -103,6 +114,10 @@ export const maximalInvoice: Invoice = {
       vat: { category: "S", ratePercent: 19 },
       period: { start: "2026-07-02", end: "2026-07-20" },
       note: "MARK-LINENOTE",
+      objectRef: "MARK-LINEOBJECT", // BT-128
+      orderLineRef: "MARK-ORDERLINE", // BT-132
+      buyerAccountingRef: "MARK-LINEACCOUNT", // BT-133
+      originCountry: "CH", // BT-159 - a country CODE, so no marker fits
       allowancesCharges: [
         {
           isCharge: false,

--- a/packages/e-invoice/tests/support/maximal.ts
+++ b/packages/e-invoice/tests/support/maximal.ts
@@ -21,6 +21,11 @@ export const maximalInvoice: Invoice = {
   buyerReference: "MARK-BUYERREF",
   purchaseOrderRef: "MARK-ORDERREF",
   contractRef: "MARK-CONTRACTREF",
+  // BG-3 - two of them, one with a date and one without, so both shapes reach the XSD check.
+  precedingInvoices: [
+    { number: "MARK-PRECEDING", issueDate: "2026-06-30" },
+    { number: "MARK-PRECEDING2" },
+  ],
   notes: ["MARK-DOCNOTE"],
   seller: {
     name: "MARK-SELLERNAME",

--- a/packages/e-invoice/tests/supporting-documents.test.ts
+++ b/packages/e-invoice/tests/supporting-documents.test.ts
@@ -144,6 +144,52 @@ describe("the file also goes into the PDF, not only the XML", () => {
   });
 });
 
+describe("a name collision is refused, because no validator catches it", () => {
+  const file = (filename: string) => ({
+    reference: filename,
+    file: { content: CSV, mimeType: "text/csv", filename },
+  });
+
+  it("refuses the name a reader uses to find the invoice XML", () => {
+    // Both files end up in one name tree. A consumer picks whichever it finds first, and veraPDF
+    // calls the result compliant - measured.
+    expect(() => pdfAttachments([file("factur-x.xml")])).toThrow(/factur-x\.xml/);
+  });
+
+  it("refuses the other reserved names too, whatever the case", () => {
+    for (const n of ["zugferd-invoice.xml", "XRechnung.xml", "order-x.xml"]) {
+      expect(() => pdfAttachments([file(n)]), n).toThrow(/invoice XML/);
+    }
+  });
+
+  it("refuses two attachments sharing a name", () => {
+    expect(() => pdfAttachments([file("t.csv"), file("t.csv")])).toThrow(/used twice/);
+  });
+
+  it("does NOT quietly rename - the name is written in the XML too", () => {
+    // Uniquifying the PDF key would leave the XML saying "t.csv" and the PDF saying "t (2).csv",
+    // which is the two-halves-disagree defect this package exists to prevent.
+    try {
+      pdfAttachments([file("t.csv"), file("t.csv")]);
+    } catch (e) {
+      expect((e as Error).message).toContain("cannot share a name");
+    }
+  });
+
+  it("allows names that merely look similar", () => {
+    expect(() => pdfAttachments([file("factur-x-copy.xml"), file("t.csv")])).not.toThrow();
+  });
+
+  it("names both in the pre-flight, before the render throws", () => {
+    const problems = en16931Problems({
+      ...base,
+      supportingDocuments: [file("factur-x.xml"), file("t.csv"), file("T.CSV")],
+    });
+    expect(problems.join(" ")).toContain("invoice XML");
+    expect(problems.join(" ")).toContain("used twice");
+  });
+});
+
 describe("the paper says an attachment exists", () => {
   const printed = (invoice: Invoice) =>
     printedText(

--- a/packages/e-invoice/tests/supporting-documents.test.ts
+++ b/packages/e-invoice/tests/supporting-documents.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+import { Invoice } from "../src/invoice.ts";
+import { toCII } from "../src/cii.ts";
+import { toUBL } from "../src/ubl.ts";
+import { computeInvoice } from "../src/compute.ts";
+import { toBase64, pdfAttachments } from "../src/attachment.ts";
+import { en16931Problems } from "../src/profile-check.ts";
+import { defaultInvoiceTemplate } from "../src/template.ts";
+import { resolveLabels, makeFormatters } from "../src/i18n.ts";
+import { printedText } from "./support/printed.ts";
+
+/**
+ * BG-24. A supporting document has to reach the recipient twice - base64 in the XML for a machine,
+ * an embedded file in the PDF for a person - and the paper has to SAY it is there, or nobody looks.
+ */
+
+const base: Invoice = {
+  number: "RE-2026-300",
+  issueDate: "2026-09-09",
+  currency: "EUR",
+  seller: {
+    name: "Muster GmbH",
+    vatId: "DE123456789",
+    address: { city: "Berlin", postCode: "10115", country: "DE" },
+  },
+  buyer: { name: "Kunde AG", address: { city: "München", postCode: "80331", country: "DE" } },
+  lines: [
+    {
+      name: "Support",
+      quantity: 8,
+      unit: "HUR",
+      netUnitPrice: 95,
+      vat: { category: "S", ratePercent: 19 },
+    },
+  ],
+};
+
+const CSV = new TextEncoder().encode("Datum;Stunden\n2026-09-01;8\n");
+
+const withDocs = (docs: Invoice["supportingDocuments"]): Invoice => ({
+  ...base,
+  supportingDocuments: docs,
+});
+
+describe("base64, written by hand because neither Buffer nor btoa is safe here", () => {
+  it("matches the reference encoding on bytes above 0x7f", () => {
+    const bytes = new Uint8Array([0x00, 0x7f, 0x80, 0xff, 0xfe]);
+    expect(toBase64(bytes)).toBe(Buffer.from(bytes).toString("base64"));
+  });
+
+  it("pads the way base64 pads", () => {
+    expect(toBase64(new TextEncoder().encode("a"))).toBe("YQ==");
+    expect(toBase64(new TextEncoder().encode("ab"))).toBe("YWI=");
+    expect(toBase64(new TextEncoder().encode("abc"))).toBe("YWJj");
+    expect(toBase64(new Uint8Array(0))).toBe("");
+  });
+
+  it("agrees with Buffer on a longer run, so length has no edge case left", () => {
+    const bytes = new Uint8Array(500).map((_, i) => (i * 37) % 256);
+    expect(toBase64(bytes)).toBe(Buffer.from(bytes).toString("base64"));
+  });
+});
+
+describe("the XML carries the file", () => {
+  const invoice = withDocs([
+    {
+      reference: "TIMESHEET-09",
+      description: "Stundennachweis September",
+      file: { content: CSV, mimeType: "text/csv", filename: "stunden.csv" },
+    },
+  ]);
+  const computed = computeInvoice(invoice);
+
+  it("CII writes the binary with the two required attributes", () => {
+    const xml = toCII(invoice, computed);
+    expect(xml).toContain(
+      `<ram:AttachmentBinaryObject mimeCode="text/csv" filename="stunden.csv">${toBase64(CSV)}</ram:AttachmentBinaryObject>`,
+    );
+    expect(xml).toContain("<ram:IssuerAssignedID>TIMESHEET-09</ram:IssuerAssignedID>");
+    expect(xml).toContain("<ram:TypeCode>916</ram:TypeCode>");
+  });
+
+  it("CII places it in the agreement, after the contract reference", () => {
+    const withRefs = { ...invoice, contractRef: "C-1" };
+    const xml = toCII(withRefs, computeInvoice(withRefs));
+    expect(xml.indexOf("ContractReferencedDocument")).toBeLessThan(
+      xml.indexOf("AdditionalReferencedDocument"),
+    );
+  });
+
+  it("UBL nests it one level deeper, inside cac:Attachment", () => {
+    const xml = toUBL(invoice, computed);
+    expect(xml).toMatch(
+      /<cac:AdditionalDocumentReference><cbc:ID>TIMESHEET-09<\/cbc:ID>.*?<cac:Attachment><cbc:EmbeddedDocumentBinaryObject/,
+    );
+  });
+
+  it("round-trips: what comes out of the XML is the file that went in", () => {
+    const xml = toCII(invoice, computed);
+    const b64 = /<ram:AttachmentBinaryObject[^>]*>([^<]+)</.exec(xml)![1]!;
+    expect(new Uint8Array(Buffer.from(b64, "base64"))).toEqual(CSV);
+  });
+});
+
+describe("a link instead of a file", () => {
+  const invoice = withDocs([{ reference: "LEISTUNG-09", url: "https://example.invalid/n.pdf" }]);
+  const computed = computeInvoice(invoice);
+
+  it("CII uses URIID and writes no binary", () => {
+    const xml = toCII(invoice, computed);
+    expect(xml).toContain("<ram:URIID>https://example.invalid/n.pdf</ram:URIID>");
+    expect(xml).not.toContain("AttachmentBinaryObject");
+  });
+
+  it("UBL wraps it as an external reference", () => {
+    expect(toUBL(invoice, computed)).toContain(
+      "<cac:ExternalReference><cbc:URI>https://example.invalid/n.pdf</cbc:URI></cac:ExternalReference>",
+    );
+  });
+});
+
+describe("the file also goes into the PDF, not only the XML", () => {
+  it("hands the renderer a Supplement attachment per file", () => {
+    const attachments = pdfAttachments([
+      {
+        reference: "A",
+        file: { content: CSV, mimeType: "text/csv", filename: "stunden.csv" },
+      },
+      { reference: "B", url: "https://example.invalid/x" },
+    ]);
+    expect(attachments).toHaveLength(1); // the link has no file to attach
+    expect(attachments[0]).toMatchObject({
+      name: "stunden.csv",
+      mimeType: "text/csv",
+      relationship: "Supplement",
+    });
+  });
+
+  it("calls it Supplement, never Data - only the invoice XML is the invoice", () => {
+    const [a] = pdfAttachments([
+      { reference: "A", file: { content: CSV, mimeType: "text/csv", filename: "x.csv" } },
+    ]);
+    expect(a!.relationship).not.toBe("Data");
+  });
+});
+
+describe("the paper says an attachment exists", () => {
+  const printed = (invoice: Invoice) =>
+    printedText(
+      defaultInvoiceTemplate(
+        invoice,
+        computeInvoice(invoice),
+        resolveLabels("de"),
+        makeFormatters("de", "EUR"),
+      ),
+    ).join("\n");
+
+  it("names the description, the reference and the file", () => {
+    const text = printed(
+      withDocs([
+        {
+          reference: "TIMESHEET-09",
+          description: "Stundennachweis September",
+          file: { content: CSV, mimeType: "text/csv", filename: "stunden.csv" },
+        },
+      ]),
+    );
+    expect(text).toContain("Anlagen");
+    expect(text).toContain("Stundennachweis September");
+    expect(text).toContain("stunden.csv");
+  });
+
+  it("shows the link when there is no file", () => {
+    const text = printed(withDocs([{ reference: "L", url: "https://example.invalid/n.pdf" }]));
+    expect(text).toContain("https://example.invalid/n.pdf");
+  });
+
+  it("stays silent with no attachments", () => {
+    expect(printed(base)).not.toContain("Anlagen");
+  });
+});
+
+describe("what the pre-flight refuses", () => {
+  it("a document that is only a name", () => {
+    const problems = en16931Problems(withDocs([{ reference: "X" }]));
+    expect(problems.join(" ")).toContain("neither a file nor a url");
+  });
+
+  it("a file without the attributes the schema requires", () => {
+    const problems = en16931Problems(
+      withDocs([{ reference: "X", file: { content: CSV, mimeType: "", filename: "" } }]),
+    );
+    expect(problems.join(" ")).toContain("filename");
+    expect(problems.join(" ")).toContain("mimeType");
+  });
+
+  it("says nothing about a complete one", () => {
+    expect(
+      en16931Problems(
+        withDocs([
+          { reference: "X", file: { content: CSV, mimeType: "text/csv", filename: "a.csv" } },
+        ]),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("absent means untouched", () => {
+  it("adds nothing to either syntax", () => {
+    const computed = computeInvoice(base);
+    expect(toCII(base, computed)).not.toContain("AdditionalReferencedDocument");
+    expect(toUBL(base, computed)).not.toContain("AdditionalDocumentReference");
+  });
+});

--- a/packages/e-invoice/tests/supporting-documents.test.ts
+++ b/packages/e-invoice/tests/supporting-documents.test.ts
@@ -168,12 +168,9 @@ describe("a name collision is refused, because no validator catches it", () => {
 
   it("does NOT quietly rename - the name is written in the XML too", () => {
     // Uniquifying the PDF key would leave the XML saying "t.csv" and the PDF saying "t (2).csv",
-    // which is the two-halves-disagree defect this package exists to prevent.
-    try {
-      pdfAttachments([file("t.csv"), file("t.csv")]);
-    } catch (e) {
-      expect((e as Error).message).toContain("cannot share a name");
-    }
+    // which is the two-halves-disagree defect this package exists to prevent. Asserted with toThrow,
+    // not a try/catch: a catch block that never runs is a test that passes for the wrong reason.
+    expect(() => pdfAttachments([file("t.csv"), file("t.csv")])).toThrow(/cannot share a name/);
   });
 
   it("allows names that merely look similar", () => {

--- a/packages/e-invoice/tests/tax-currency.test.ts
+++ b/packages/e-invoice/tests/tax-currency.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { Invoice } from "../src/invoice.ts";
+import { toCII } from "../src/cii.ts";
+import { toUBL } from "../src/ubl.ts";
+import { computeInvoice } from "../src/compute.ts";
+import { en16931Problems, xrechnungProblems } from "../src/profile-check.ts";
+import { defaultInvoiceTemplate } from "../src/template.ts";
+import { resolveLabels, makeFormatters } from "../src/i18n.ts";
+import { printedText } from "./support/printed.ts";
+
+/**
+ * BT-6 / BT-111 - the VAT total in the currency VAT is accounted in.
+ *
+ * This one was built ahead of the other edge cases for a reason that has nothing to do with how
+ * often it occurs: a foreign-currency invoice went out WITHOUT a Euro tax figure and without a word
+ * of warning. Same shape as Skonto entered as an allowance - the library accepted an input that
+ * produced a deficient document and said nothing. Most of what is tested here is the warning.
+ */
+
+const usd: Invoice = {
+  number: "RE-2026-700",
+  issueDate: "2026-09-09",
+  currency: "USD",
+  buyerReference: "LEITWEG-1",
+  seller: {
+    name: "Muster GmbH",
+    vatId: "DE123456789",
+    electronicAddress: "re@muster.invalid",
+    address: { city: "Berlin", postCode: "10115", country: "DE" },
+    contact: { name: "A", phone: "1", email: "a@muster.invalid" },
+  },
+  buyer: {
+    name: "Buyer Inc",
+    electronicAddress: "ap@buyer.invalid",
+    address: { city: "Boston", postCode: "02108", country: "US" },
+  },
+  delivery: { date: "2026-09-01" },
+  dueDate: "2026-10-09",
+  lines: [
+    {
+      name: "Consulting",
+      quantity: 1,
+      unit: "C62",
+      netUnitPrice: 1000,
+      vat: { category: "S", ratePercent: 19 },
+    },
+  ],
+  payment: { meansCode: "58", iban: "DE02120300000000202051" },
+};
+
+const withEuroVat: Invoice = { ...usd, taxCurrency: "EUR", taxTotalInTaxCurrency: 172.4 };
+
+describe("the silence that made this urgent", () => {
+  it("warns when a non-EUR invoice states no accounting currency", () => {
+    const problems = xrechnungProblems(usd);
+    expect(problems.join(" ")).toContain("USD");
+    expect(problems.join(" ")).toContain("BT-6");
+  });
+
+  it("stops warning once the Euro figure is there", () => {
+    expect(xrechnungProblems(withEuroVat).join(" ")).not.toContain("BT-6");
+  });
+
+  it("says nothing at all for a plain Euro invoice", () => {
+    const eur: Invoice = { ...usd, currency: "EUR" };
+    expect(xrechnungProblems(eur).join(" ")).not.toContain("BT-6");
+  });
+});
+
+describe("BR-53: a currency without its amount, and the reverse", () => {
+  it("refuses a currency with no figure in it", () => {
+    const problems = en16931Problems({ ...usd, taxCurrency: "EUR" });
+    expect(problems.join(" ")).toContain("BT-111");
+  });
+
+  it("refuses a figure with no currency", () => {
+    const problems = en16931Problems({ ...usd, taxTotalInTaxCurrency: 172.4 });
+    expect(problems.join(" ")).toContain("BT-6");
+  });
+
+  it("accepts the pair", () => {
+    expect(en16931Problems(withEuroVat)).toEqual([]);
+  });
+});
+
+describe("the same element twice, told apart by its currency", () => {
+  const computed = computeInvoice(withEuroVat);
+
+  it("CII writes two TaxTotalAmounts - which is why the schema caps it at two", () => {
+    const xml = toCII(withEuroVat, computed);
+    expect(xml).toContain('<ram:TaxTotalAmount currencyID="USD">190.00</ram:TaxTotalAmount>'); // BT-110
+    expect(xml).toContain('<ram:TaxTotalAmount currencyID="EUR">172.40</ram:TaxTotalAmount>'); // BT-111
+    expect(xml.match(/<ram:TaxTotalAmount/g)).toHaveLength(2);
+  });
+
+  it("CII writes the tax currency BEFORE the invoice currency", () => {
+    const xml = toCII(withEuroVat, computed);
+    expect(xml).toContain("<ram:TaxCurrencyCode>EUR</ram:TaxCurrencyCode>");
+    expect(xml.indexOf("TaxCurrencyCode")).toBeLessThan(xml.indexOf("InvoiceCurrencyCode"));
+  });
+
+  it("UBL adds a SECOND TaxTotal that carries no breakdown", () => {
+    const xml = toUBL(withEuroVat, computed);
+    expect(xml).toContain("<cbc:TaxCurrencyCode>EUR</cbc:TaxCurrencyCode>");
+    expect(xml).toContain(
+      '<cac:TaxTotal><cbc:TaxAmount currencyID="EUR">172.40</cbc:TaxAmount></cac:TaxTotal>',
+    );
+    expect(xml.match(/<cac:TaxTotal>/g)).toHaveLength(2);
+  });
+
+  it("adds neither when the fields are absent", () => {
+    const c = computeInvoice(usd);
+    expect(toCII(usd, c).match(/<ram:TaxTotalAmount/g)).toHaveLength(1);
+    expect(toCII(usd, c)).not.toContain("TaxCurrencyCode");
+    expect(toUBL(usd, c).match(/<cac:TaxTotal>/g)).toHaveLength(1);
+  });
+});
+
+describe("we never invent the exchange rate", () => {
+  it("takes the amount as given and does not derive it", () => {
+    // 190.00 USD of VAT at some rate is 172.40 EUR here. Which rate applies - supply date, invoice
+    // date, monthly average - is a tax question, so the number comes from the user, not from us.
+    const odd: Invoice = { ...usd, taxCurrency: "EUR", taxTotalInTaxCurrency: 1 };
+    expect(toCII(odd, computeInvoice(odd))).toContain(
+      '<ram:TaxTotalAmount currencyID="EUR">1.00</ram:TaxTotalAmount>',
+    );
+  });
+});
+
+describe("the paper carries it, because that is who the figure is for", () => {
+  it("prints the VAT total in the accounting currency", () => {
+    const text = printedText(
+      defaultInvoiceTemplate(
+        withEuroVat,
+        computeInvoice(withEuroVat),
+        resolveLabels("de"),
+        makeFormatters("de", "USD"),
+      ),
+    ).join("\n");
+    expect(text).toContain("USt in EUR");
+    // Formatted as MONEY in the other currency: "172,4" would read as a typo on a tax figure.
+    expect(text).toContain("172,40\u00a0€");
+  });
+});


### PR DESCRIPTION
## Summary

A lot of fields and options are now available on XRechnung and ZUGFeRD e.g.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added percentage-based allowances and charges, cash discounts, invoice rounding, secondary-currency tax totals, direct debit, and expanded invoice references.
  - Supporting documents now appear in printed invoices, CII/UBL exports, and PDF/A-3 attachments.
  - Added seller, buyer, delivery, line-item, payee, accounting, order, and preceding-invoice references.
  - Payment terms now support structured early-payment discount information.
  - German, English, and French labels and currency-aware amount formatting were expanded.

- **Bug Fixes**
  - Improved validation for inconsistent amounts, discounts, currencies, attachments, and direct-debit details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->