### PR TITLE
fix(cli): the reader catches up with the writer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -743,6 +743,15 @@ wordWidth > maxWidth` and forgot the SPACE that would join the word. It went uns
     BT-7/BT-8 (VAT point date; prepayments), BT-15/BT-16 (receiving/despatch advice; logistics).
     Deliberately deferred and documented in `src/invoice.ts`: BG-11/12 tax representative, BG-18
     payment card, BG-32 item attributes, BT-158 classification.
+  - **The CLI reader caught up the same day** - `packages/cli/src/core/parse.ts` is a hand-written
+    list of `val(x, "ram:…")` lookups, so a field the writer learns is not read unless someone adds a
+    line. The fix that matters is the TEST: the round-trip now runs against `maximalInvoice`, the
+    fixture shaped by the model, not the old one shaped by the parser (which could never notice a
+    missing field). It immediately surfaced three gaps that predate the audit: **BG-14/BG-26 service
+    period was never parsed at all** (a §14 UStG field), the UBL delivery address was looked up as
+    `cac:PostalAddress` where the writer emits `cac:Address`, and allowance percentages were dropped.
+    Traps worth knowing: a party's own `ram:ID` needs manual scoping or it reads BT-30 as BT-29;
+    BT-110 vs BT-111 differ only by `currencyID`; BT-29 vs BT-90 only by `schemeID="SEPA"`.
   - **Still open, and it matters:** the term list in `COVERAGE.md` was compiled from knowledge of
     EN 16931, not from a machine-readable copy. Read it once against the official list before it
     becomes a public promise.

--- a/packages/cli/src/core/parse.ts
+++ b/packages/cli/src/core/parse.ts
@@ -1,4 +1,7 @@
 import type {
+  CashDiscount,
+  SupportingDocument,
+  PrecedingInvoice,
   Invoice,
   InvoiceLine,
   Seller,
@@ -53,8 +56,49 @@ const num = (s: string | undefined): number => (s === undefined ? 0 : parseFloat
 
 /** `format="102"` date `20260620` → `2026-06-20`. */
 function date(scope: string | undefined): string | undefined {
-  const d = val(scope, "udt:DateTimeString");
-  return d && d.length === 8 ? `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}` : undefined;
+  return iso102(val(scope, "udt:DateTimeString"));
+}
+/** The same, in the QUALIFIED namespace - BT-26 is the only place we emit `qdt:`. */
+function qdtDate(scope: string | undefined): string | undefined {
+  return iso102(val(scope, "qdt:DateTimeString"));
+}
+const iso102 = (d: string | undefined): string | undefined =>
+  d && d.length === 8 ? `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}` : undefined;
+
+/**
+ * A party's OWN `ram:ID` (BT-29 / BT-46 / BT-60 / BT-71) - the first child of the type. Scoped by
+ * hand: an unscoped lookup finds the nested `SpecifiedLegalOrganization/ram:ID` (BT-30) instead.
+ */
+function partyId(scope: string | undefined): string | undefined {
+  if (scope === undefined) return undefined;
+  const head = scope.split(
+    /<ram:(?:Name|Description|SpecifiedLegalOrganization|PostalTradeAddress|DefinedTradeContact)\b/,
+  )[0];
+  return val(head, "ram:ID");
+}
+
+/** BT-111. The element appears twice; only `currencyID` separates it from BT-110, so match on that. */
+function amountInCurrency(scope: string | undefined, currency: string): string | undefined {
+  if (scope === undefined) return undefined;
+  const re = new RegExp(`<ram:TaxTotalAmount\\s[^>]*currencyID="${currency}"[^>]*>([^<]*)<`);
+  return re.exec(scope)?.[1];
+}
+
+/** BG-14 / BG-26, the service period - a §14 Abs. 4 Nr. 6 UStG field. */
+function parsePeriod(scope: string | undefined): { start: string; end: string } | undefined {
+  const p = inner(scope, "ram:BillingSpecifiedPeriod");
+  if (!p) return undefined;
+  const start = date(inner(p, "ram:StartDateTime"));
+  const end = date(inner(p, "ram:EndDateTime"));
+  return start && end ? { start, end } : undefined;
+}
+
+/** A reference that shares `AdditionalReferencedDocument` with its neighbours; told apart by code. */
+function typedRef(scope: string | undefined, typeCode: string): string | undefined {
+  for (const d of innerAll(scope, "ram:AdditionalReferencedDocument")) {
+    if (val(d, "ram:TypeCode") === typeCode) return val(d, "ram:IssuerAssignedID");
+  }
+  return undefined;
 }
 
 function parseAddress(s: string): PostalAddress {
@@ -89,6 +133,7 @@ function parseSeller(s: string): Seller {
   const org = inner(s, "ram:SpecifiedLegalOrganization");
   return {
     name: val(s, "ram:Name") ?? "",
+    identifier: partyId(s), // BT-29
     tradingName: val(org, "ram:TradingBusinessName"),
     legalRegistrationId: val(org, "ram:ID"),
     additionalLegalInfo: val(s, "ram:Description"), // BT-33
@@ -104,6 +149,7 @@ function parseBuyer(s: string): Buyer {
   const org = inner(s, "ram:SpecifiedLegalOrganization");
   return {
     name: val(s, "ram:Name") ?? "",
+    identifier: partyId(s), // BT-46
     tradingName: val(org, "ram:TradingBusinessName"),
     legalRegistrationId: val(org, "ram:ID"),
     vatId: taxReg(s, "VA"),
@@ -115,6 +161,7 @@ function parseBuyer(s: string): Buyer {
 
 function parseLine(s: string, index: number): InvoiceLine {
   const doc = inner(s, "ram:AssociatedDocumentLineDocument") ?? "";
+  const agreement = inner(s, "ram:SpecifiedLineTradeAgreement");
   const product = inner(s, "ram:SpecifiedTradeProduct") ?? "";
   const price = inner(s, "ram:NetPriceProductTradePrice") ?? "";
   const del = inner(s, "ram:SpecifiedLineTradeDelivery") ?? "";
@@ -146,16 +193,30 @@ function parseLine(s: string, index: number): InvoiceLine {
       ratePercent: num(val(tax, "ram:RateApplicablePercent")),
     },
     note: note ? val(note, "ram:Content") : undefined,
+    period: parsePeriod(lineSettlement), // BG-26
     allowancesCharges: lineAC.length ? lineAC : undefined,
+    originCountry: val(inner(product, "ram:OriginTradeCountry"), "ram:ID"), // BT-159
+    orderLineRef: val(inner(agreement, "ram:BuyerOrderReferencedDocument"), "ram:LineID"), // BT-132
+    objectRef: typedRef(lineSettlement, "130"), // BT-128
+    buyerAccountingRef: val(
+      inner(lineSettlement, "ram:ReceivableSpecifiedTradeAccountingAccount"),
+      "ram:ID",
+    ), // BT-133
   };
 }
 
 /** A document-level allowance (discount) or charge (surcharge), BG-20 / BG-21. */
 function parseAllowanceCii(ac: string): AllowanceCharge {
   const cat = inner(ac, "ram:CategoryTradeTax");
+  // BT-93/94 (and BT-137/138) - both halves, or re-emitting drops the rate.
+  const percent = val(ac, "ram:CalculationPercent");
+  const basis = val(ac, "ram:BasisAmount");
   return {
     isCharge: val(inner(ac, "ram:ChargeIndicator"), "udt:Indicator") === "true",
     amount: num(val(ac, "ram:ActualAmount")),
+    ...(percent !== undefined && basis !== undefined
+      ? { percent: num(percent), baseAmount: num(basis) }
+      : {}),
     reason: val(ac, "ram:Reason"),
     reasonCode: val(ac, "ram:ReasonCode"),
     vat: {
@@ -177,6 +238,56 @@ function exemptionsCii(set: string): Partial<Record<VatCategory, VatExemptionRea
   return Object.keys(out).length ? out : undefined;
 }
 
+/**
+ * Skonto out of BT-20, which holds the human terms and one `#SKONTO#…#` line per tier.
+ * `BASISBETRAG` is carried only when present - defaulting it would add a segment on re-emit.
+ */
+function parseSkonto(description: string | undefined): {
+  terms?: string;
+  cashDiscounts?: CashDiscount[];
+} {
+  if (!description) return {};
+  const lines = description.split("\n");
+  const human = lines.filter((l) => !l.startsWith("#SKONTO#"));
+  const discounts: CashDiscount[] = [];
+  for (const l of lines) {
+    if (!l.startsWith("#SKONTO#")) continue;
+    const days = /#TAGE=(-?[\d.]+)#/.exec(l)?.[1];
+    const percent = /#PROZENT=(-?[\d.]+)#/.exec(l)?.[1];
+    const base = /#BASISBETRAG=(-?[\d.]+)#/.exec(l)?.[1];
+    if (days === undefined || percent === undefined) continue;
+    discounts.push({
+      days: num(days),
+      percent: num(percent),
+      ...(base !== undefined ? { baseAmount: num(base) } : {}),
+    });
+  }
+  return {
+    terms: human.length ? human.join("\n") : undefined,
+    cashDiscounts: discounts.length ? discounts : undefined,
+  };
+}
+
+/** BG-24. Shares its element with BT-17 and BT-18; `TypeCode` 916 is the supporting document. */
+function parseSupportingDocuments(agr: string): SupportingDocument[] | undefined {
+  const out: SupportingDocument[] = [];
+  for (const d of innerAll(agr, "ram:AdditionalReferencedDocument")) {
+    if (val(d, "ram:TypeCode") !== "916") continue;
+    const b64 = val(d, "ram:AttachmentBinaryObject");
+    const mimeType = attr(d, "ram:AttachmentBinaryObject", "mimeCode");
+    const filename = attr(d, "ram:AttachmentBinaryObject", "filename");
+    out.push({
+      reference: val(d, "ram:IssuerAssignedID") ?? "",
+      description: val(d, "ram:Name"),
+      url: val(d, "ram:URIID"),
+      ...(b64 !== undefined && mimeType && filename
+        ? { file: { content: new Uint8Array(Buffer.from(b64, "base64")), mimeType, filename } }
+        : {}),
+    });
+  }
+  return out.length ? out : undefined;
+}
+
 /** Parse a UN/CEFACT CII invoice (EN16931 / ZUGFeRD / XRechnung-CII) into the Invoice model. */
 export function parseCII(xml: string): Invoice {
   const header = inner(xml, "rsm:ExchangedDocument") ?? "";
@@ -196,6 +307,7 @@ export function parseCII(xml: string): Invoice {
     shipTo || deliveryDate
       ? {
           date: deliveryDate,
+          locationId: partyId(shipTo), // BT-71
           recipientName: val(shipTo, "ram:Name"),
           address:
             shipTo && inner(shipTo, "ram:PostalTradeAddress")
@@ -209,6 +321,11 @@ export function parseCII(xml: string): Invoice {
   const inst = inner(pm, "ram:PayeeSpecifiedCreditorFinancialInstitution");
   const terms = inner(set, "ram:SpecifiedTradePaymentTerms");
   const paymentReference = val(set, "ram:PaymentReference"); // BT-83, emitted on its own
+  const skonto = parseSkonto(val(terms, "ram:Description")); // BT-20 carries two things at once
+  // BG-19 sits in three CII blocks: mandate in the terms, account in the means, creditor in the head.
+  const mandateReference = val(terms, "ram:DirectDebitMandateID"); // BT-89
+  const creditorId = val(set, "ram:CreditorReferenceID"); // BT-90
+  const debitedIban = val(inner(pm, "ram:PayerPartyDebtorFinancialAccount"), "ram:IBANID"); // BT-91
   const payment: Payment | undefined =
     pm || terms || paymentReference
       ? {
@@ -218,11 +335,27 @@ export function parseCII(xml: string): Invoice {
           iban: val(acct, "ram:IBANID"),
           accountName: val(acct, "ram:AccountName"),
           bic: val(inst, "ram:BICID"),
-          terms: val(terms, "ram:Description"),
+          terms: skonto.terms,
+          cashDiscounts: skonto.cashDiscounts,
+          ...(mandateReference
+            ? { directDebit: { mandateReference, creditorId, debitedIban } }
+            : {}),
         }
       : undefined;
+  const payeeParty = inner(set, "ram:PayeeTradeParty");
+  const precedingInvoices: PrecedingInvoice[] = innerAll(set, "ram:InvoiceReferencedDocument").map(
+    (d) => ({
+      number: val(d, "ram:IssuerAssignedID") ?? "", // BT-25
+      issueDate: qdtDate(inner(d, "ram:FormattedIssueDateTime")), // BT-26
+    }),
+  );
   const totals = inner(set, "ram:SpecifiedTradeSettlementHeaderMonetarySummation");
   const paid = val(totals, "ram:TotalPrepaidAmount");
+  const rounding = val(totals, "ram:RoundingAmount"); // BT-114
+  // BT-6/BT-111: the second TaxTotalAmount, told apart from BT-110 only by its currencyID.
+  const taxCurrency = val(set, "ram:TaxCurrencyCode");
+  const inTaxCurrency = taxCurrency ? amountInCurrency(totals, taxCurrency) : undefined;
+  const taxTotalInTaxCurrency = inTaxCurrency !== undefined ? num(inTaxCurrency) : undefined;
   const allowancesCharges = innerAll(set, "ram:SpecifiedTradeAllowanceCharge").map(
     parseAllowanceCii,
   );
@@ -233,19 +366,33 @@ export function parseCII(xml: string): Invoice {
     type: type && type !== 380 ? (type as InvoiceTypeCode) : undefined,
     currency: val(set, "ram:InvoiceCurrencyCode") ?? "",
     dueDate: date(inner(terms, "ram:DueDateDateTime")),
+    taxCurrency, // BT-6
+    taxTotalInTaxCurrency, // BT-111
     buyerReference: val(agr, "ram:BuyerReference"),
     purchaseOrderRef: val(inner(agr, "ram:BuyerOrderReferencedDocument"), "ram:IssuerAssignedID"),
+    salesOrderRef: val(inner(agr, "ram:SellerOrderReferencedDocument"), "ram:IssuerAssignedID"), // BT-14
     contractRef: val(inner(agr, "ram:ContractReferencedDocument"), "ram:IssuerAssignedID"),
+    projectRef: val(inner(agr, "ram:SpecifiedProcuringProject"), "ram:ID"), // BT-11
+    tenderRef: typedRef(agr, "50"), // BT-17
+    objectRef: typedRef(agr, "130"), // BT-18
+    buyerAccountingRef: val(inner(set, "ram:ReceivableSpecifiedTradeAccountingAccount"), "ram:ID"), // BT-19
     notes: notes.length ? notes : undefined,
+    noteSubjectCode: val(innerAll(header, "ram:IncludedNote")[0], "ram:SubjectCode"), // BT-21
+    precedingInvoices: precedingInvoices.length ? precedingInvoices : undefined, // BG-3
+    supportingDocuments: parseSupportingDocuments(agr), // BG-24
     seller: parseSeller(inner(agr, "ram:SellerTradeParty") ?? ""),
     buyer: parseBuyer(inner(agr, "ram:BuyerTradeParty") ?? ""),
     delivery,
-    payeeName: val(inner(set, "ram:PayeeTradeParty"), "ram:Name"),
+    period: parsePeriod(set), // BG-14
+    payeeName: val(payeeParty, "ram:Name"),
+    payeeIdentifier: partyId(payeeParty), // BT-60
+    payeeLegalRegistrationId: val(inner(payeeParty, "ram:SpecifiedLegalOrganization"), "ram:ID"), // BT-61
     lines: innerAll(tx, "ram:IncludedSupplyChainTradeLineItem").map(parseLine),
     allowancesCharges: allowancesCharges.length ? allowancesCharges : undefined,
     vatExemptionReasons: exemptionsCii(set),
     payment,
     paidAmount: paid ? num(paid) : undefined,
+    roundingAmount: rounding !== undefined ? num(rounding) : undefined, // BT-114
   };
 }
 
@@ -281,11 +428,22 @@ function ublTaxId(party: string, scheme: string): string | undefined {
   return undefined;
 }
 
+/** BT-90. Shares `cac:PartyIdentification` with BT-29; only `schemeID="SEPA"` tells them apart. */
+function sepaPartyId(scope: string | undefined): string | undefined {
+  if (scope === undefined) return undefined;
+  const m = /<cbc:ID schemeID="SEPA">([^<]*)<\/cbc:ID>/.exec(scope);
+  return m ? unesc(m[1]) : undefined;
+}
+
 function parsePartyUbl(scope: string) {
   const party = inner(scope, "cac:Party") ?? "";
   const legal = inner(party, "cac:PartyLegalEntity");
   return {
     party,
+    // BT-29 / BT-46 - skipping the SEPA-scheme entry, which is BT-90 in the same element.
+    identifier: innerAll(party, "cac:PartyIdentification")
+      .map((pi) => (/schemeID="SEPA"/.test(pi) ? undefined : val(pi, "cbc:ID")))
+      .find((v) => v !== undefined),
     name: val(legal, "cbc:RegistrationName") ?? "",
     tradingName: val(inner(party, "cac:PartyName"), "cbc:Name"),
     legalRegistrationId: val(legal, "cbc:CompanyID"),
@@ -329,14 +487,32 @@ function parseLineUbl(s: string, index: number): InvoiceLine {
     },
     note: val(s, "cbc:Note"),
     allowancesCharges: lineAC.length ? lineAC : undefined,
+    period: periodUbl(s), // BG-26
+    buyerAccountingRef: val(s, "cbc:AccountingCost"), // BT-133
+    orderLineRef: val(inner(s, "cac:OrderLineReference"), "cbc:LineID"), // BT-132
+    objectRef: val(inner(s, "cac:DocumentReference"), "cbc:ID"), // BT-128
+    originCountry: val(inner(item, "cac:OriginCountry"), "cbc:IdentificationCode"), // BT-159
   };
+}
+
+/** BG-14 / BG-26 in UBL - plain ISO dates, no 102 format. */
+function periodUbl(scope: string | undefined): { start: string; end: string } | undefined {
+  const p = inner(scope, "cac:InvoicePeriod");
+  const start = val(p, "cbc:StartDate");
+  const end = val(p, "cbc:EndDate");
+  return start && end ? { start, end } : undefined;
 }
 
 function parseAllowanceUbl(ac: string): AllowanceCharge {
   const cat = inner(ac, "cac:TaxCategory");
+  const percent = val(ac, "cbc:MultiplierFactorNumeric");
+  const basis = val(ac, "cbc:BaseAmount");
   return {
     isCharge: val(ac, "cbc:ChargeIndicator") === "true",
     amount: num(val(ac, "cbc:Amount")),
+    ...(percent !== undefined && basis !== undefined
+      ? { percent: num(percent), baseAmount: num(basis) }
+      : {}), // BT-93/94, BT-137/138
     reason: val(ac, "cbc:AllowanceChargeReason"),
     reasonCode: val(ac, "cbc:AllowanceChargeReasonCode"),
     vat: {
@@ -364,12 +540,17 @@ export function parseUBL(xml: string): Invoice {
   const cut = xml.indexOf("<cac:AccountingSupplierParty");
   const head = cut >= 0 ? xml.slice(0, cut) : xml;
 
+  const payeeUbl = inner(xml, "cac:PayeeParty");
   const seller = parsePartyUbl(inner(xml, "cac:AccountingSupplierParty") ?? "");
   const buyer = parsePartyUbl(inner(xml, "cac:AccountingCustomerParty") ?? "");
   const type = num(val(head, "cbc:InvoiceTypeCode"));
-  const notes = innerAll(head, "cbc:Note")
+  // BT-21 has no UBL element; the binding prefixes the note with #CODE#. Strip it, or the note grows
+  // by one prefix per round-trip.
+  const rawNotes = innerAll(head, "cbc:Note")
     .map(unesc)
     .filter((n) => n.length > 0);
+  const noteSubjectCode = /^#([A-Za-z0-9]+)#/.exec(rawNotes[0] ?? "")?.[1];
+  const notes = rawNotes.map((n) => n.replace(/^#[A-Za-z0-9]+#/, ""));
 
   const del = inner(xml, "cac:Delivery");
   const dLoc = inner(del, "cac:DeliveryLocation");
@@ -379,9 +560,11 @@ export function parseUBL(xml: string): Invoice {
     del && (deliveryDate || dParty || dLoc)
       ? {
           date: deliveryDate,
+          locationId: val(dLoc, "cbc:ID"), // BT-71
           recipientName: val(inner(dParty, "cac:PartyName"), "cbc:Name"),
-          address: inner(dLoc, "cac:PostalAddress")
-            ? parseAddressUbl(inner(dLoc, "cac:PostalAddress")!)
+          // `cac:Address`, not `cac:PostalAddress` - a LocationType holds the one, a Party the other.
+          address: inner(dLoc, "cac:Address")
+            ? parseAddressUbl(inner(dLoc, "cac:Address")!)
             : undefined,
         }
       : undefined;
@@ -389,6 +572,12 @@ export function parseUBL(xml: string): Invoice {
   const pm = inner(xml, "cac:PaymentMeans");
   const acct = inner(pm, "cac:PayeeFinancialAccount");
   const terms = inner(xml, "cac:PaymentTerms");
+  const skonto = parseSkonto(val(terms, "cbc:Note")); // BT-20 carries two things at once
+  // BG-19. UBL keeps the mandate together but hangs the creditor id on the seller party.
+  const mandate = inner(pm, "cac:PaymentMandate");
+  const mandateReference = val(mandate, "cbc:ID"); // BT-89
+  const creditorId = sepaPartyId(inner(xml, "cac:AccountingSupplierParty")); // BT-90
+  const debitedIban = val(inner(mandate, "cac:PayerFinancialAccount"), "cbc:ID"); // BT-91
   const payment: Payment | undefined =
     pm || terms
       ? {
@@ -398,10 +587,51 @@ export function parseUBL(xml: string): Invoice {
           iban: val(acct, "cbc:ID"),
           accountName: val(acct, "cbc:Name"),
           bic: val(inner(acct, "cac:FinancialInstitutionBranch"), "cbc:ID"),
-          terms: val(terms, "cbc:Note"),
+          terms: skonto.terms,
+          cashDiscounts: skonto.cashDiscounts,
+          ...(mandateReference
+            ? { directDebit: { mandateReference, creditorId, debitedIban } }
+            : {}),
         }
       : undefined;
-  const paid = val(inner(xml, "cac:LegalMonetaryTotal"), "cbc:PrepaidAmount");
+  const monetary = inner(xml, "cac:LegalMonetaryTotal");
+  const paid = val(monetary, "cbc:PrepaidAmount");
+  const rounding = val(monetary, "cbc:PayableRoundingAmount"); // BT-114
+  // BT-111 is a SECOND cac:TaxTotal carrying only an amount - the first one has the breakdown.
+  const taxTotals = innerAll(xml, "cac:TaxTotal");
+  const secondTaxTotal = taxTotals.find((t) => !t.includes("<cac:TaxSubtotal"));
+  const taxTotalInTaxCurrency =
+    secondTaxTotal !== undefined ? num(val(secondTaxTotal, "cbc:TaxAmount")) : undefined;
+
+  const precedingInvoices: PrecedingInvoice[] = innerAll(head, "cac:BillingReference").map((b) => {
+    const d = inner(b, "cac:InvoiceDocumentReference");
+    return { number: val(d, "cbc:ID") ?? "", issueDate: val(d, "cbc:IssueDate") }; // BT-25 / BT-26
+  });
+
+  // BG-24 and BT-18 share cac:AdditionalDocumentReference; the object reference carries a type code.
+  const additional = innerAll(head, "cac:AdditionalDocumentReference");
+  const objectRefUbl = additional.find((d) => val(d, "cbc:DocumentTypeCode") === "130")
+    ? val(
+        additional.find((d) => val(d, "cbc:DocumentTypeCode") === "130"),
+        "cbc:ID",
+      )
+    : undefined;
+  const supportingDocuments: SupportingDocument[] = additional
+    .filter((d) => val(d, "cbc:DocumentTypeCode") !== "130")
+    .map((d) => {
+      const att = inner(d, "cac:Attachment");
+      const b64 = val(att, "cbc:EmbeddedDocumentBinaryObject");
+      const mimeType = attr(att, "cbc:EmbeddedDocumentBinaryObject", "mimeCode");
+      const filename = attr(att, "cbc:EmbeddedDocumentBinaryObject", "filename");
+      return {
+        reference: val(d, "cbc:ID") ?? "",
+        description: val(d, "cbc:DocumentDescription"),
+        url: val(inner(att, "cac:ExternalReference"), "cbc:URI"),
+        ...(b64 !== undefined && mimeType && filename
+          ? { file: { content: new Uint8Array(Buffer.from(b64, "base64")), mimeType, filename } }
+          : {}),
+      };
+    });
   // document-level allowances/charges live before the lines (UBL also allows them per-line, which we skip)
   const li = xml.indexOf("<cac:InvoiceLine");
   const allowancesCharges = innerAll(li >= 0 ? xml.slice(0, li) : xml, "cac:AllowanceCharge").map(
@@ -414,12 +644,23 @@ export function parseUBL(xml: string): Invoice {
     type: type && type !== 380 ? (type as InvoiceTypeCode) : undefined,
     currency: val(head, "cbc:DocumentCurrencyCode") ?? "",
     dueDate: val(head, "cbc:DueDate"),
+    taxCurrency: val(head, "cbc:TaxCurrencyCode"), // BT-6
+    taxTotalInTaxCurrency, // BT-111
     buyerReference: val(head, "cbc:BuyerReference"),
+    buyerAccountingRef: val(head, "cbc:AccountingCost"), // BT-19
     purchaseOrderRef: val(inner(head, "cac:OrderReference"), "cbc:ID"),
+    salesOrderRef: val(inner(head, "cac:OrderReference"), "cbc:SalesOrderID"), // BT-14
     contractRef: val(inner(head, "cac:ContractDocumentReference"), "cbc:ID"),
+    projectRef: val(inner(head, "cac:ProjectReference"), "cbc:ID"), // BT-11
+    tenderRef: val(inner(head, "cac:OriginatorDocumentReference"), "cbc:ID"), // BT-17
+    objectRef: objectRefUbl, // BT-18
     notes: notes.length ? notes : undefined,
+    noteSubjectCode,
+    precedingInvoices: precedingInvoices.length ? precedingInvoices : undefined, // BG-3
+    supportingDocuments: supportingDocuments.length ? supportingDocuments : undefined, // BG-24
     seller: {
       name: seller.name,
+      identifier: seller.identifier, // BT-29
       tradingName: seller.tradingName,
       legalRegistrationId: seller.legalRegistrationId,
       additionalLegalInfo: seller.additionalLegalInfo, // BT-33
@@ -431,6 +672,7 @@ export function parseUBL(xml: string): Invoice {
     },
     buyer: {
       name: buyer.name,
+      identifier: buyer.identifier, // BT-46
       tradingName: buyer.tradingName,
       legalRegistrationId: buyer.legalRegistrationId,
       vatId: buyer.vatId,
@@ -439,12 +681,16 @@ export function parseUBL(xml: string): Invoice {
       contact: buyer.contact,
     },
     delivery,
-    payeeName: val(inner(inner(xml, "cac:PayeeParty"), "cac:PartyName"), "cbc:Name"), // BT-59
+    period: periodUbl(head), // BG-14
+    payeeName: val(inner(payeeUbl, "cac:PartyName"), "cbc:Name"),
+    payeeIdentifier: val(inner(payeeUbl, "cac:PartyIdentification"), "cbc:ID"), // BT-60
+    payeeLegalRegistrationId: val(inner(payeeUbl, "cac:PartyLegalEntity"), "cbc:CompanyID"), // BT-61
     lines: innerAll(xml, "cac:InvoiceLine").map(parseLineUbl),
     allowancesCharges: allowancesCharges.length ? allowancesCharges : undefined,
     vatExemptionReasons: exemptionsUbl(xml),
     payment,
     paidAmount: paid !== undefined ? num(paid) : undefined,
+    roundingAmount: rounding !== undefined ? num(rounding) : undefined, // BT-114
   };
 }
 

--- a/packages/cli/src/core/parse.ts
+++ b/packages/cli/src/core/parse.ts
@@ -77,10 +77,15 @@ function partyId(scope: string | undefined): string | undefined {
   return val(head, "ram:ID");
 }
 
+/** Regex-safe: every value interpolated into a pattern here comes out of the parsed file. */
+const escapeRe = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 /** BT-111. The element appears twice; only `currencyID` separates it from BT-110, so match on that. */
 function amountInCurrency(scope: string | undefined, currency: string): string | undefined {
   if (scope === undefined) return undefined;
-  const re = new RegExp(`<ram:TaxTotalAmount\\s[^>]*currencyID="${currency}"[^>]*>([^<]*)<`);
+  const re = new RegExp(
+    `<ram:TaxTotalAmount\\s[^>]*currencyID="${escapeRe(currency)}"[^>]*>([^<]*)<`,
+  );
   return re.exec(scope)?.[1];
 }
 
@@ -550,7 +555,10 @@ export function parseUBL(xml: string): Invoice {
     .map(unesc)
     .filter((n) => n.length > 0);
   const noteSubjectCode = /^#([A-Za-z0-9]+)#/.exec(rawNotes[0] ?? "")?.[1];
-  const notes = rawNotes.map((n) => n.replace(/^#[A-Za-z0-9]+#/, ""));
+  // Only the prefix that IS the subject code: a note legitimately starting with some other #TAG#
+  // keeps it, and so does one whose prefix differs from the first note's.
+  const prefix = noteSubjectCode ? `#${noteSubjectCode}#` : undefined;
+  const notes = rawNotes.map((n) => (prefix && n.startsWith(prefix) ? n.slice(prefix.length) : n));
 
   const del = inner(xml, "cac:Delivery");
   const dLoc = inner(del, "cac:DeliveryLocation");
@@ -597,8 +605,10 @@ export function parseUBL(xml: string): Invoice {
   const monetary = inner(xml, "cac:LegalMonetaryTotal");
   const paid = val(monetary, "cbc:PrepaidAmount");
   const rounding = val(monetary, "cbc:PayableRoundingAmount"); // BT-114
-  // BT-111 is a SECOND cac:TaxTotal carrying only an amount - the first one has the breakdown.
-  const taxTotals = innerAll(xml, "cac:TaxTotal");
+  // BT-111 is a SECOND cac:TaxTotal carrying only an amount - the first one has the breakdown. Scoped
+  // to before the lines: a LINE-level TaxTotal has no subtotal either and would be mistaken for it.
+  const beforeLines = xml.indexOf("<cac:InvoiceLine");
+  const taxTotals = innerAll(beforeLines >= 0 ? xml.slice(0, beforeLines) : xml, "cac:TaxTotal");
   const secondTaxTotal = taxTotals.find((t) => !t.includes("<cac:TaxSubtotal"));
   const taxTotalInTaxCurrency =
     secondTaxTotal !== undefined ? num(val(secondTaxTotal, "cbc:TaxAmount")) : undefined;

--- a/packages/cli/tests/parse.test.ts
+++ b/packages/cli/tests/parse.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { toCII, toUBL, computeInvoice } from "@jasy/e-invoice";
 import { parseCII, parseUBL, parseInvoice } from "../src/core/parse";
+import { maximalInvoice } from "../../e-invoice/tests/support/maximal.ts";
 
 // a rich invoice exercising every field the CII parser handles
 const invoice = {
@@ -75,6 +76,24 @@ const invoice = {
 };
 
 const cii = (inv: typeof invoice) => toCII(inv, computeInvoice(inv));
+
+/**
+ * The round-trip against `maximalInvoice` - the fixture shaped by the MODEL, not by this parser.
+ * The `invoice` above covers "every field the parser handles" and so can never catch a missing one.
+ */
+describe("round-trip against the maximal invoice", () => {
+  it("CII: re-emitting loses nothing", () => {
+    const xml = toCII(maximalInvoice, computeInvoice(maximalInvoice));
+    const parsed = parseCII(xml);
+    expect(toCII(parsed, computeInvoice(parsed))).toBe(xml);
+  });
+
+  it("UBL: re-emitting loses nothing", () => {
+    const xml = toUBL(maximalInvoice, computeInvoice(maximalInvoice));
+    const parsed = parseUBL(xml);
+    expect(toUBL(parsed, computeInvoice(parsed))).toBe(xml);
+  });
+});
 
 describe("parseCII - XML → Invoice", () => {
   it("round-trips: re-emitting the parsed invoice reproduces the same CII", () => {

--- a/packages/e-invoice/README.md
+++ b/packages/e-invoice/README.md
@@ -133,9 +133,9 @@ dependency-light. Now it has jasy.
 
 ## Honest scope
 
-Every EN-16931 business term was audited field by field on 2026-09-09; the register is in the
-repository as `packages/e-invoice/COVERAGE.md`. Every mandatory term is emitted, and so is everything
-a real business hits.
+Every EN-16931 business term was audited field by field on 2026-09-09. Every mandatory term is
+emitted, and so is everything a real business hits. Each field in the model carries its `BT-` / `BG-`
+code in its own doc comment, so the mapping is readable straight from `src/invoice.ts`.
 
 Six optional terms are deliberately left for 1.1: **BT-147/BT-148** (list price with a discount - a
 line allowance already expresses the same money), **BT-7/BT-8** (VAT point date, for prepayments) and

--- a/packages/e-invoice/README.md
+++ b/packages/e-invoice/README.md
@@ -69,6 +69,32 @@ with spec-correct rounding. The amounts are correct **by construction**, so the 
 EN-16931 failures (the BR-CO total checks) simply cannot happen. Discounts, surcharges and reverse-charge
 (category AE, with the exemption reason) are handled for you.
 
+## The fields a real invoice actually needs
+
+```ts
+payment: {
+  cashDiscounts: [{ days: 14, percent: 2 }],           // Skonto, written into BT-20 (see below)
+  directDebit: { mandateReference: "MND-2024-00871" }, // SEPA collection
+},
+allowancesCharges: [
+  { isCharge: false, baseAmount: 3980, percent: 10, reason: "Framework agreement",
+    vat: { category: "S", ratePercent: 19 } },         // "10%", not a pre-computed sum
+],
+precedingInvoices: [{ number: "INV-0187", issueDate: "2026-08-14" }], // what a credit note corrects
+supportingDocuments: [{ reference: "TS-09", file: { content, mimeType, filename } }], // a timesheet
+roundingAmount: -0.4,                                   // collect a round figure
+taxCurrency: "EUR", taxTotalInTaxCurrency: 172.4,       // invoicing in a foreign currency
+```
+
+**Skonto is not a discount**, and that distinction is the reason it has its own field. A reduction
+that only applies on early payment must not reduce the invoice total - entered as an allowance it
+would be deducted immediately, giving a file that passes every validator and states the wrong sum.
+It goes into the payment terms in the form XRechnung reads back, and the pre-flight names the mistake
+if you reach for an allowance instead.
+
+An attachment travels **twice**: base64 in the XML for a machine, and as an embedded file in the
+PDF/A-3 for a person.
+
 ## ZUGFeRD and XRechnung. CII and UBL.
 
 ```ts
@@ -95,7 +121,9 @@ npx @jasy/cli validate ./invoice.pdf
 
 - **Hand-built PDF/A-3** that passes veraPDF - matched, not approximated. No Java.
 - **Font subsetting + compression** - only the glyphs you use are embedded; streams are FlateDecode'd.
-- **Byte-exact round-trips** - `generate → parse → regenerate` reproduces the identical XML (307 tests).
+- **Byte-exact round-trips** - `generate → parse → regenerate` reproduces the identical XML, in both
+  syntaxes, checked against the same maximal fixture the writer is measured by. A field the writer
+  learns and the reader does not now fails a test instead of disappearing quietly.
 - Built on [`@jasy/pdf`](https://npmx.dev/@jasy/pdf), a hand-rolled, Flutter-style PDF engine.
 
 ## Why this exists
@@ -105,9 +133,17 @@ dependency-light. Now it has jasy.
 
 ## Honest scope
 
-Covers every mandatory EN-16931 term plus the fields a real invoice needs. A few rare optionals (tax
-representative, SEPA direct-debit mandate, item attributes) are not emitted yet. Pre-1.0: the API can
-still shift between minor versions. Everything shown here works and is tested.
+Every EN-16931 business term was audited field by field on 2026-09-09; the register is in the
+repository as `packages/e-invoice/COVERAGE.md`. Every mandatory term is emitted, and so is everything
+a real business hits.
+
+Six optional terms are deliberately left for 1.1: **BT-147/BT-148** (list price with a discount - a
+line allowance already expresses the same money), **BT-7/BT-8** (VAT point date, for prepayments) and
+**BT-15/BT-16** (receiving and despatch advice, pure logistics). Deliberately deferred and documented
+in the model: tax representative (BG-11/12), payment card (BG-18), item attributes (BG-32) and item
+classification (BT-158).
+
+Pre-1.0: the API can still shift between minor versions. Everything shown here works and is tested.
 
 ---
 


### PR DESCRIPTION
## Summary

cli reader is equals to writer (byte)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded invoice reading for CII and UBL formats, including party identifiers, dates and service periods, references, payment details, allowances and charges, tax-currency totals, rounding, delivery addresses, attachments, and additional invoice metadata.
  - Added support for encoded notes, direct-debit information, payee details, and payment discounts.

- **Tests**
  - Added round-trip coverage confirming maximal CII and UBL invoices can be read and reproduced without XML changes.

- **Documentation**
  - Added guidance and examples for payment terms, allowances, supporting documents, rounding, tax-currency fields, coverage, and known scope limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->