### PR TITLE
feat(cli): cli full output of read invoice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ packages/playground/*.png
 # npm pack / release tarballs
 *.tgz
 
+
+# The EN 16931 coverage register - our working document, not part of the package.
+packages/e-invoice/COVERAGE.md

--- a/packages/cli/src/commands/read.ts
+++ b/packages/cli/src/commands/read.ts
@@ -2,6 +2,7 @@ import { writeFileSync } from "node:fs";
 import { resolve, basename } from "node:path";
 import { readInvoiceFile, type ReadResult } from "../core/read.js";
 import { describeInvoice } from "../core/detect.js";
+import { detailLines, lineDetailLines } from "../core/export.js";
 
 // `jasy read <file> [--xml] [-o out]` - read a ZUGFeRD / XRechnung PDF (or raw XML) and show the actual
 // invoice (number, parties, lines, totals) for humans, or dump / save the embedded XML.
@@ -61,12 +62,23 @@ export function readCommand(args: string[]): void {
     inv.lines.forEach((l, i) => {
       const left = `  ${l.quantity} ${l.unit}  ${l.name}`;
       console.log(left.padEnd(48) + money(r.totals!.lineNets[i]).padStart(12));
+      for (const sub of lineDetailLines(l)) console.log(`      ${dim(sub)}`);
     });
     const t = r.totals;
     console.log("  " + dim("─".repeat(58)));
     console.log(
       `  ${dim("net")} ${money(t.taxBasisTotal)}   ${dim("VAT")} ${money(t.taxTotal)}   ${bold(`total ${money(t.grandTotal)} ${inv.currency}`)}`,
     );
+    // The payable is a second figure only when something moved it - a payment already made, a rounding.
+    if (t.duePayable !== t.grandTotal) {
+      console.log(`  ${dim("due")}   ${bold(`${money(t.duePayable)} ${inv.currency}`)}`);
+    }
+    // The same lines the TXT export prints - one source, so the two views cannot drift apart.
+    const details = detailLines(inv, t);
+    if (details.length) {
+      console.log("");
+      for (const line of details) console.log(line ? `  ${dim(line)}` : "");
+    }
     console.log(`\n  ${dim("→ --xml print the XML · -o <file> save it · jasy validate <file>")}`);
   } else {
     console.log(`  source     ${r.isPdf ? "PDF - embedded XML extracted" : "raw XML"}`);

--- a/packages/cli/src/core/export.ts
+++ b/packages/cli/src/core/export.ts
@@ -51,6 +51,10 @@ export function detailLines(inv: Invoice, t: ComputedInvoice): string[] {
   row("Tender", inv.tenderRef);
   row("Object", inv.objectRef);
   row("Cost centre", inv.buyerAccountingRef);
+  // BG-1, what the seller wrote to the reader; the subject code (BT-21) says what it is about.
+  for (const note of inv.notes ?? []) {
+    row("Note", inv.noteSubjectCode ? `[${inv.noteSubjectCode}] ${note}` : note);
+  }
   if (inv.precedingInvoices?.length) {
     row(
       "Corrects",

--- a/packages/cli/src/core/export.ts
+++ b/packages/cli/src/core/export.ts
@@ -1,4 +1,5 @@
 import { deflateRawSync } from "node:zlib";
+import { resolveDiscounts, acAmount, hasPercentage } from "@jasy/e-invoice";
 import type { Invoice, ComputedInvoice } from "@jasy/e-invoice";
 
 // Export a parsed invoice for humans / downstream systems: JSON (full model + totals), TXT (a readable
@@ -27,6 +28,92 @@ function summary(inv: Invoice, t: ComputedInvoice) {
   };
 }
 
+/**
+ * Everything on the invoice beyond the receipt - references, payment, discounts, attachments - as
+ * plain text lines. ONE function for both readers (`jasy read` and the TXT export) so the two can
+ * never disagree about what an invoice carries; each only decides how to colour it.
+ *
+ * The order is the order someone opening a SUPPLIER invoice looks for things: how do I pay, is
+ * there a discount for paying early, what does this correct, what came with it.
+ */
+export function detailLines(inv: Invoice, t: ComputedInvoice): string[] {
+  const L: string[] = [];
+  // A space after the pad, not inside it: "Direct debit" is exactly twelve wide and would glue on.
+  const row = (label: string, value: string | undefined) => {
+    if (value) L.push(`${label.padEnd(12)} ${value}`);
+  };
+
+  // references - the buyer's booking keys first, then the seller's
+  row("Order", inv.purchaseOrderRef);
+  row("Sales order", inv.salesOrderRef);
+  row("Contract", inv.contractRef);
+  row("Project", inv.projectRef);
+  row("Tender", inv.tenderRef);
+  row("Object", inv.objectRef);
+  row("Cost centre", inv.buyerAccountingRef);
+  if (inv.precedingInvoices?.length) {
+    row(
+      "Corrects",
+      inv.precedingInvoices
+        .map((p) => (p.issueDate ? `${p.number} (${p.issueDate})` : p.number))
+        .join(", "),
+    );
+  }
+
+  // payment
+  const p = inv.payment;
+  if (p) {
+    if (L.length) L.push("");
+    row("Terms", p.terms);
+    if (p.iban)
+      row(
+        "IBAN",
+        `${p.iban}${p.bic ? `  BIC ${p.bic}` : ""}${p.accountName ? `  ${p.accountName}` : ""}`,
+      );
+    if (p.directDebit) {
+      row("Direct debit", `mandate ${p.directDebit.mandateReference}`);
+      row("", p.directDebit.creditorId ? `creditor ${p.directDebit.creditorId}` : undefined);
+      row("", p.directDebit.debitedIban ? `debited ${p.directDebit.debitedIban}` : undefined);
+    }
+    for (const d of resolveDiscounts(p.cashDiscounts, inv.issueDate, t.grandTotal)) {
+      row(
+        "Skonto",
+        `${d.percent}% if paid by ${d.deadline}: ${money(d.discountedTotal)} ${inv.currency} (saves ${money(d.discountAmount)})`,
+      );
+    }
+  }
+
+  // what moved the money between the lines and the total
+  const acs = inv.allowancesCharges ?? [];
+  if (acs.length || t.roundingAmount !== 0 || inv.taxCurrency) {
+    L.push("");
+    for (const ac of acs) {
+      const rate = hasPercentage(ac) ? ` (${ac.percent}% of ${money(ac.baseAmount)})` : "";
+      row(
+        ac.isCharge ? "Charge" : "Discount",
+        `${ac.reason ?? ""}${rate}  ${ac.isCharge ? "+" : "-"}${money(acAmount(ac))}`,
+      );
+    }
+    if (t.roundingAmount !== 0) {
+      row("Rounding", `${t.roundingAmount > 0 ? "+" : "-"}${money(Math.abs(t.roundingAmount))}`);
+    }
+    if (inv.taxCurrency && inv.taxTotalInTaxCurrency !== undefined) {
+      row(`VAT in ${inv.taxCurrency}`, money(inv.taxTotalInTaxCurrency));
+    }
+  }
+
+  // attachments
+  if (inv.supportingDocuments?.length) {
+    L.push("");
+    for (const d of inv.supportingDocuments) {
+      const what = d.description ? `${d.description} (${d.reference})` : d.reference;
+      const where = d.file ? d.file.filename : d.url ? d.url : "";
+      row("Attached", where ? `${what} - ${where}` : what);
+    }
+  }
+  return L;
+}
+
 /** Full invoice model + a computed totals block, pretty-printed. */
 export function exportJson(inv: Invoice, t: ComputedInvoice): string {
   return JSON.stringify({ ...inv, totals: summary(inv, t) }, null, 2);
@@ -50,13 +137,38 @@ export function exportText(inv: Invoice, t: ComputedInvoice): string {
     L.push(
       `${String(l.quantity).padEnd(8)}${l.unit.padEnd(6)}${l.name.slice(0, 33).padEnd(34)}${money(t.lineNets[i]).padStart(12)}`,
     );
+    for (const sub of lineDetailLines(l)) L.push(`${"".padEnd(14)}${sub}`);
   });
   L.push("─".repeat(60));
   const s = summary(inv, t);
   L.push(`${"Net".padStart(48)}${money(s.net).padStart(12)}`);
   L.push(`${"VAT".padStart(48)}${money(s.vat).padStart(12)}`);
   L.push(`${`Total ${s.currency}`.padStart(48)}${money(s.gross).padStart(12)}`);
+  // Only when they differ: an amount already paid or a rounding makes the payable a second figure.
+  if (s.due !== s.gross) {
+    if (inv.paidAmount) L.push(`${"Paid".padStart(48)}${`-${money(inv.paidAmount)}`.padStart(12)}`);
+    L.push(`${`Due ${s.currency}`.padStart(48)}${money(s.due).padStart(12)}`);
+  }
+  const details = detailLines(inv, t);
+  if (details.length) L.push("", ...details);
   return L.join("\n") + "\n";
+}
+
+/** What a line carries beyond quantity, name and net - shown indented beneath it. */
+export function lineDetailLines(l: Invoice["lines"][number]): string[] {
+  const L: string[] = [];
+  for (const ac of l.allowancesCharges ?? []) {
+    const rate = hasPercentage(ac) ? ` (${ac.percent}% of ${money(ac.baseAmount)})` : "";
+    L.push(
+      `${ac.isCharge ? "charge" : "discount"} ${ac.reason ?? ""}${rate} ${ac.isCharge ? "+" : "-"}${money(acAmount(ac))}`,
+    );
+  }
+  if (l.period) L.push(`period ${l.period.start} to ${l.period.end}`);
+  if (l.orderLineRef) L.push(`order line ${l.orderLineRef}`);
+  if (l.objectRef) L.push(`object ${l.objectRef}`);
+  if (l.buyerAccountingRef) L.push(`cost centre ${l.buyerAccountingRef}`);
+  if (l.originCountry) L.push(`origin ${l.originCountry}`);
+  return L;
 }
 
 // ── minimal ZIP container (for the .xlsx); each part deflated via zlib ──────────────────────────────

--- a/packages/cli/src/tui/app.ts
+++ b/packages/cli/src/tui/app.ts
@@ -6,7 +6,7 @@ import { readInvoice, type ReadResult } from "../core/read.js";
 import { describeInvoice } from "../core/detect.js";
 import { checkPdfA3, type PdfaReport } from "../core/pdfa.js";
 import { validateInvoiceXml, profileFor, type ValidationReport } from "../core/validate.js";
-import { exportInvoice, type ExportFormat } from "../core/export.js";
+import { exportInvoice, detailLines, lineDetailLines, type ExportFormat } from "../core/export.js";
 import { detectTools } from "../core/verapdf.js";
 import { openFileDialog } from "./file-open.js";
 
@@ -128,6 +128,8 @@ export function launchTui(): void {
           status: money(t.lineNets[i]),
           statusFg: MUTED,
         });
+        for (const sub of lineDetailLines(l))
+          rows.push({ text: fit(`    ${sub}`, w - 6), fg: MUTED });
       }
       rows.push({
         text: `net ${money(t.taxBasisTotal)}   VAT ${money(t.taxTotal)}`,
@@ -135,6 +137,20 @@ export function launchTui(): void {
         status: `${money(t.grandTotal)} ${inv.currency}`,
         statusFg: INK,
       });
+      if (t.duePayable !== t.grandTotal) {
+        rows.push({
+          text: "due",
+          fg: MUTED,
+          status: `${money(t.duePayable)} ${inv.currency}`,
+          statusFg: INK,
+        });
+      }
+      // The same block `jasy read` and the TXT export print - one source for all three views.
+      const details = detailLines(inv, t);
+      if (details.length) {
+        rows.push({ text: "", fg: MUTED });
+        for (const line of details) rows.push({ text: fit(line, w - 6), fg: MUTED });
+      }
       rows.push({ text: "", fg: MUTED });
     }
 

--- a/packages/cli/tests/details.test.ts
+++ b/packages/cli/tests/details.test.ts
@@ -48,6 +48,7 @@ describe("every field the maximal invoice carries reaches the text", () => {
     ["the rounding with its sign", /Rounding\s+\+0\.03/],
     ["the VAT total in the accounting currency", /VAT in CHF\s+42\.50/],
     ["the amount due when it differs from the total", /Due EUR/],
+    ["a document note, tagged with its subject code", /Note\s+\[AAI\] MARK-DOCNOTE/],
     ["the sales order", /Sales order\s+MARK-SALESORDER/],
     ["the project", /Project\s+MARK-PROJECT/],
     ["the tender", /Tender\s+MARK-TENDER/],
@@ -68,6 +69,12 @@ describe("what is shown only when it is there", () => {
   it("prints no details block at all for the smallest invoice", () => {
     expect(detailLines(base, computeInvoice(base))).toEqual([]);
     expect(lineDetailLines(base.lines[0]!)).toEqual([]);
+  });
+
+  it("prints a note without a code when there is none", () => {
+    const noted = { ...base, notes: ["Danke.", "Bitte Rechnungsnummer angeben."] };
+    const lines = detailLines(noted, computeInvoice(noted)).filter((l) => l.startsWith("Note"));
+    expect(lines).toEqual(["Note         Danke.", "Note         Bitte Rechnungsnummer angeben."]);
   });
 
   it("prints no Due line when nothing moved the payable", () => {

--- a/packages/cli/tests/details.test.ts
+++ b/packages/cli/tests/details.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { computeInvoice } from "@jasy/e-invoice";
+import type { Invoice } from "@jasy/e-invoice";
+import { detailLines, lineDetailLines, exportText } from "../src/core/export";
+import { maximalInvoice } from "../../e-invoice/tests/support/maximal.ts";
+
+/**
+ * The text views show everything the model carries. Run against `maximalInvoice` for the same
+ * reason the round-trip is: a field the model gains and the display does not fails here instead of
+ * quietly not being shown.
+ */
+
+const base: Invoice = {
+  number: "RE-1",
+  issueDate: "2026-09-09",
+  currency: "EUR",
+  seller: { name: "S", address: { country: "DE" } },
+  buyer: { name: "B", address: { country: "DE" } },
+  lines: [
+    {
+      name: "L",
+      quantity: 1,
+      unit: "C62",
+      netUnitPrice: 100,
+      vat: { category: "S", ratePercent: 19 },
+    },
+  ],
+};
+
+describe("every field the maximal invoice carries reaches the text", () => {
+  const t = computeInvoice(maximalInvoice);
+  const text = exportText(maximalInvoice, t);
+
+  it.each([
+    ["Skonto, with its deadline", /Skonto\s+2% if paid by 2026-/],
+    ["the second Skonto tier with its own base", /Skonto\s+1% if paid by/],
+    ["the direct-debit mandate", /Direct debit\s+mandate MARK-MANDATE/],
+    ["the creditor id", /creditor MARK-CREDITORID/],
+    ["the debited account", /debited MARK-DEBITEDIBAN/],
+    ["the preceding invoices", /Corrects\s+MARK-PRECEDING \(2026-06-30\), MARK-PRECEDING2/],
+    ["an attachment with its file", /Attached\s+MARK-DOCDESC \(MARK-DOCREF\) - MARK-DOCFILE\.csv/],
+    ["an attachment that is a link", /Attached\s+MARK-DOCREF2 - https:\/\/example\.invalid/],
+    [
+      "a percentage discount as a rate, not only euros",
+      /Discount\s+MARK-DOCALLOWANCE \(10% of 200\.00\)\s+-20\.00/,
+    ],
+    ["a fixed charge", /Charge\s+.*\+15\.00/],
+    ["the rounding with its sign", /Rounding\s+\+0\.03/],
+    ["the VAT total in the accounting currency", /VAT in CHF\s+42\.50/],
+    ["the amount due when it differs from the total", /Due EUR/],
+    ["the sales order", /Sales order\s+MARK-SALESORDER/],
+    ["the project", /Project\s+MARK-PROJECT/],
+    ["the tender", /Tender\s+MARK-TENDER/],
+    ["the object", /Object\s+MARK-OBJECT/],
+    ["the cost centre", /Cost centre\s+MARK-BUYERACCOUNT/],
+    ["a line's order line", /order line MARK-ORDERLINE/],
+    ["a line's object", /object MARK-LINEOBJECT/],
+    ["a line's cost centre", /cost centre MARK-LINEACCOUNT/],
+    ["a line's origin", /origin CH/],
+    ["a line's period", /period 2026-07-02 to 2026-07-20/],
+    ["a line's percentage discount", /discount MARK-LINEALLOWANCE \(5% of 100\.00\) -5\.00/],
+  ])("shows %s", (_what, pattern) => {
+    expect(text).toMatch(pattern);
+  });
+});
+
+describe("what is shown only when it is there", () => {
+  it("prints no details block at all for the smallest invoice", () => {
+    expect(detailLines(base, computeInvoice(base))).toEqual([]);
+    expect(lineDetailLines(base.lines[0]!)).toEqual([]);
+  });
+
+  it("prints no Due line when nothing moved the payable", () => {
+    expect(exportText(base, computeInvoice(base))).not.toContain("Due");
+  });
+
+  it("prints Paid and Due once something is paid", () => {
+    const paid = { ...base, paidAmount: 40 };
+    const text = exportText(paid, computeInvoice(paid));
+    expect(text).toMatch(/Paid\s+-40\.00/);
+    expect(text).toMatch(/Due EUR\s+79\.00/);
+  });
+});
+
+describe("the label column never glues onto its value", () => {
+  it("keeps a space after the widest label", () => {
+    // "Direct debit" is exactly as wide as the column; a pad alone would produce "Direct debitmandate".
+    const dd: Invoice = {
+      ...base,
+      payment: { meansCode: "59", directDebit: { mandateReference: "M-1" } },
+    };
+    const line = detailLines(dd, computeInvoice(dd)).find((l) => l.startsWith("Direct debit"));
+    expect(line).toBe("Direct debit mandate M-1");
+  });
+});

--- a/packages/e-invoice/src/index.ts
+++ b/packages/e-invoice/src/index.ts
@@ -9,6 +9,11 @@ export { toCII } from "./cii.ts";
 export { toUBL } from "./ubl.ts";
 export type { CiiProfile } from "./cii.ts";
 export { en16931Problems, xrechnungProblems } from "./profile-check.ts";
+// The single sources of two derived figures - exported so a reader (the CLI) shows the same numbers
+// the paper does, instead of recomputing them a second way.
+export { resolveDiscounts } from "./skonto.ts";
+export type { ResolvedDiscount } from "./skonto.ts";
+export { acAmount, hasPercentage } from "./allowance.ts";
 export { bundledFonts } from "./fonts.ts";
 export { facturxXmp } from "./xmp.ts";
 export type { XmpOptions } from "./xmp.ts";


### PR DESCRIPTION
## Summary

Full output of all types of invoices and their values to files and inside die CLI itself

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI / tooling

## Checklist

- [x] `pnpm exec vitest run` is green
- [ ] No breaking changes (or called out above)
- [ ] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Invoice text exports now include richer line-item details, references, payment information, discounts, adjustments, tax totals, and attachments.
  - Clearly displays paid amounts and payable totals when they differ from the invoice’s gross total.
  - Invoice views in the CLI read command and terminal interface now show expanded line and invoice details.
  - Added support for resolving discounts and calculating allowance or charge amounts in invoice workflows.

- **Tests**
  - Expanded coverage for invoice text exports and optional detail handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->